### PR TITLE
Rename `classpath` -> `build-tools`

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,17 +19,17 @@ def jdbcModules = [
         'postgresql'
 ]
 
-include 'test-resources-core'
-include 'test-resources-embedded'
-include 'test-resources-client'
 include 'test-resources-bom'
+include 'test-resources-build-tools'
+include 'test-resources-core'
+include 'test-resources-client'
+include 'test-resources-embedded'
 include 'test-resources-hivemq'
 include 'test-resources-kafka'
 include 'test-resources-mongodb'
 include 'test-resources-neo4j'
 include 'test-resources-testcontainers'
 include 'test-resources-server'
-include 'test-resources-classpath'
 
 jdbcModules.each {
     String projectName = "test-resources-jdbc-$it"

--- a/test-resources-build-tools/build.gradle
+++ b/test-resources-build-tools/build.gradle
@@ -22,7 +22,7 @@ classpath.
 
 def writeVersion = tasks.register("writeVersionClass", WriteVersion) {
     outputDirectory.set(layout.buildDirectory.dir("version-info"))
-    getPackage().set("io.micronaut.testresources.classpath")
+    getPackage().set("io.micronaut.testresources.buildtools")
     version.set(project.version as String)
 }
 

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/MavenDependency.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/MavenDependency.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.testresources.classpath;
+package io.micronaut.testresources.buildtools;
 
 /**
  * Represents a Maven dependency using its group, artifact

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.testresources.classpath;
+package io.micronaut.testresources.buildtools;
 
 import java.util.Arrays;
 import java.util.List;

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.testresources.classpath
+package io.micronaut.testresources.buildtools
 
 import spock.lang.Specification
 


### PR DESCRIPTION
This will make it simpler if we add more common stuff to this module
later.