### PR TITLE
Add support for R2DBC

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,12 +38,18 @@ testcontainers-mysql = { module = "org.testcontainers:mysql", version = "" }
 testcontainers-neo4j = { module = "org.testcontainers:neo4j", version = "" }
 testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version = "" }
 testcontainers-postgres = { module = "org.testcontainers:postgresql", version = "" }
+testcontainers-r2dbc = { module = "org.testcontainers:r2dbc", version = "" }
 
 mariadb = { module = "org.mariadb.jdbc:mariadb-java-client", version = "" }
 mongodb = { module = "org.mongodb:mongodb-driver-sync", version = "" }
 mysql = { module = "mysql:mysql-connector-java", version = "" }
 oracle-xe = { module = "com.oracle.database.jdbc:ojdbc8", version = "" }
 postgres = { module = "org.postgresql:postgresql", version = "" }
+
+reactive-mariadb = { module = "org.mariadb:r2dbc-mariadb", version = "" }
+reactive-mysql = { module = "dev.miku:r2dbc-mysql", version = "" }
+reactive-oracle-xe = { module = "com.oracle.database.r2dbc:oracle-r2dbc", version = "" }
+reactive-postgres = { module = "org.postgresql:r2dbc-postgresql", version = "" }
 
 #
 # Managed dependencies appear in the BOM

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,13 @@ def jdbcModules = [
         'oracle-xe',
         'postgresql'
 ]
+def r2dbcModules = [
+        'core',
+        'mariadb',
+        'mysql',
+        'oracle-xe',
+        'postgresql'
+]
 
 include 'test-resources-bom'
 include 'test-resources-build-tools'
@@ -35,6 +42,11 @@ jdbcModules.each {
     String projectName = "test-resources-jdbc-$it"
     include projectName
     project(":test-resources-jdbc-$it").projectDir = file("test-resources-jdbc/$projectName")
+}
+r2dbcModules.each {
+    String projectName = "test-resources-r2dbc-$it"
+    include projectName
+    project(":test-resources-r2dbc-$it").projectDir = file("test-resources-r2dbc/$projectName")
 }
 
 micronautBuild {

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -43,11 +43,14 @@ public final class TestResourcesClasspath {
 
     private static final String MICRONAUT_NEO4J = "micronaut-neo4j";
     private static final String MICRONAUT_DATA_MONGODB = "micronaut-data-mongodb";
+    private static final String MICRONAUT_DATA_R2DBC = "micronaut-data-r2dbc";
     private static final String MYSQL_CONNECTOR_JAVA = "mysql-connector-java";
-
+    private static final String REACTIVE_MYSQL_DRIVER = "dev.miku:r2dbc-mysql";
     private static final String MYSQL_MYSQL_CONNECTOR_JAVA = "mysql:mysql-connector-java";
-    private static final String POSTGRESQL = "org.postgresql:postgresql";
+    private static final String POSTGRESQL_DRIVER = "org.postgresql:postgresql";
+    private static final String REACTIVE_POSTGRESQL_DRIVER = "org.postgresql:r2dbc-postgresql";
     private static final String MARIADB_JAVA_CLIENT = "org.mariadb.jdbc:mariadb-java-client";
+    private static final String REACTIVE_MARIADB_DRIVER = "org.mariadb:r2dbc-mariadb";
     private static final String MONGODB_DRIVER_ASYNC = "org.mongodb:mongodb-driver-async";
     private static final String MONGODB_DRIVER_SYNC = "org.mongodb:mongodb-driver-sync";
     private static final String MONGODB_DRIVER_REACTIVESTREAMS = "org.mongodb:mongodb-driver-reactivestreams";
@@ -63,15 +66,20 @@ public final class TestResourcesClasspath {
         ORACLE_DRIVER_10,
         ORACLE_DRIVER_11
     );
+    private static final String REACTIVE_ORACLE_DRIVER = "com.oracle.database.r2dbc:oracle-r2dbc";
 
     private static final String KAFKA_MODULE = "kafka";
     private static final String HIVEMQ_MODULE = "hivemq";
     private static final String MONGODB_MODULE = "mongodb";
     private static final String MYSQL_MODULE = "jdbc-mysql";
+    private static final String REACTIVE_MYSQL_MODULE = "r2dbc-mysql";
     private static final String NEO4J_MODULE = "neo4j";
     private static final String ORACLE_XE_MODULE = "jdbc-oracle-xe";
+    private static final String REACTIVE_ORACLE_XE_MODULE = "r2dbc-oracle-xe";
     private static final String POSTGRESQL_MODULE = "jdbc-postgresql";
+    private static final String REACTIVE_POSTGRESQL_MODULE = "r2dbc-postgresql";
     private static final String MARIADB_MODULE = "jdbc-mariadb";
+    private static final String REACTIVE_MARIADB_MODULE = "r2dbc-mariadb";
 
     private TestResourcesClasspath() {
 
@@ -114,16 +122,24 @@ public final class TestResourcesClasspath {
             m.onArtifact(MICRONAUT_DATA_MONGODB, MONGODB_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_NEO4J), deps -> true, NEO4J_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(artifactEquals(MYSQL_CONNECTOR_JAVA)), MYSQL_MODULE);
-            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(POSTGRESQL)), POSTGRESQL_MODULE);
+            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(POSTGRESQL_DRIVER)), POSTGRESQL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(MARIADB_JAVA_CLIENT)), MARIADB_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(d -> ORACLE_DRIVERS.contains(d.getModule())), ORACLE_XE_MODULE);
+            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_MYSQL_DRIVER)), REACTIVE_MYSQL_MODULE);
+            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_MARIADB_DRIVER)), REACTIVE_MARIADB_MODULE);
+            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_POSTGRESQL_DRIVER)), REACTIVE_POSTGRESQL_MODULE);
+            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_ORACLE_DRIVER)), REACTIVE_ORACLE_XE_MODULE);
             m.passthroughModules(MYSQL_MYSQL_CONNECTOR_JAVA,
-                POSTGRESQL,
+                POSTGRESQL_DRIVER,
                 MARIADB_JAVA_CLIENT,
                 MONGODB_DRIVER_ASYNC,
                 MONGODB_DRIVER_SYNC,
                 MONGODB_DRIVER_REACTIVESTREAMS,
-                ORACLE_DRIVER_5, ORACLE_DRIVER_6, ORACLE_DRIVER_8, ORACLE_DRIVER_10, ORACLE_DRIVER_11
+                ORACLE_DRIVER_5, ORACLE_DRIVER_6, ORACLE_DRIVER_8, ORACLE_DRIVER_10, ORACLE_DRIVER_11,
+                REACTIVE_MYSQL_DRIVER,
+                REACTIVE_MARIADB_DRIVER,
+                REACTIVE_POSTGRESQL_DRIVER,
+                REACTIVE_ORACLE_DRIVER
             );
         });
     }

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -34,7 +34,7 @@ class TestResourcesClasspathTest extends Specification {
         'neo4j-bolt' | 'neo4j'
     }
 
-    def "passes through JDBC driver #driver"() {
+    def "passes through driver #driver"() {
         when:
         infer("org:foo:1.0", "$driver:1.0")
 
@@ -55,6 +55,10 @@ class TestResourcesClasspathTest extends Specification {
                 'com.oracle.database.jdbc:ojdbc8',
                 'com.oracle.database.jdbc:ojdbc10',
                 'com.oracle.database.jdbc:ojdbc11',
+                'dev.miku:r2dbc-mysql',
+                'org.mariadb:r2dbc-mariadb',
+                'org.postgresql:r2dbc-postgresql',
+                'com.oracle.database.r2dbc:oracle-r2dbc'
         ]
     }
 
@@ -98,6 +102,26 @@ class TestResourcesClasspathTest extends Specification {
                 "org.mongodb:mongodb-driver-reactivestreams"
         ]
 
+    }
+
+    def "infers Micronaut Data R2DBC #driver"() {
+        when:
+        infer 'io.micronaut.data:micronaut-data-r2dbc:1.0', "$driver:1.0"
+
+        then:
+        inferredClasspathEquals(
+                'io.micronaut.testresources:micronaut-test-resources-server:1.0.34',
+                'io.micronaut.testresources:micronaut-test-resources-testcontainers:1.0.34',
+                "io.micronaut.testresources:micronaut-test-resources-r2dbc-$module:1.0.34",
+                "$driver:1.0"
+        )
+
+        where:
+        driver                                   | module
+        'dev.miku:r2dbc-mysql'                   | 'mysql'
+        'org.mariadb:r2dbc-mariadb'              | 'mariadb'
+        'org.postgresql:r2dbc-postgresql'        | 'postgresql'
+        'com.oracle.database.r2dbc:oracle-r2dbc' | 'oracle-xe'
     }
 
     private void inferredClasspathEquals(String... dependencies) {

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/Scope.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/Scope.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.testresources.core;
 
+import java.util.Map;
+
 /**
  * A scope represents the lifecycle of a test resource.
  * The root scope is handled by the test resources provider,
@@ -41,6 +43,19 @@ public final class Scope {
     private Scope(Scope parent, String id) {
         this.id = id;
         this.parent = parent;
+    }
+
+    /**
+     * Returns the scope id if found in the supplied properties.
+     * @param properties the properties where to look for the scope
+     * @return the scope
+     */
+    public static Scope from(Map<String, Object> properties) {
+        Object scopeId = properties.getOrDefault(PROPERTY_KEY, null);
+        if (scopeId == null) {
+            return ROOT;
+        }
+        return of(String.valueOf(scopeId));
     }
 
     /**

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -33,7 +33,6 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
     public static final String MONGODB_SERVER_URI = "mongodb.uri";
     public static final String DEFAULT_IMAGE = "mongo";
 
-
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
         return Collections.singletonList(MONGODB_SERVER_URI);

--- a/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides core support for R2DBC test resources.
+"""
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+    api(libs.testcontainers.r2dbc)
+
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -48,8 +48,8 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractR2DBCTestResourceProvider.class);
 
     private static final String DATASOURCES = "datasources";
-    private static final String R2DBC_DATASOURCES = "r2dbc.datasources";
     private static final String R2DBC_PREFIX = "r2dbc.";
+    private static final String R2DBC_DATASOURCES = R2DBC_PREFIX + DATASOURCES;
     private static final String URL = "url";
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
@@ -167,10 +167,13 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         String property = propertyName.substring(propertyName.lastIndexOf(".") + 1);
         switch (property) {
             case URL:
-                // r2dbc:mysql://localhost:3306/db
-                String url = "r2dbc:" + options.getValue(ConnectionFactoryOptions.DRIVER) +
-                    "://" + options.getValue(ConnectionFactoryOptions.HOST) + ":" + options.getValue(ConnectionFactoryOptions.PORT) +
-                    "/" + options.getValue(ConnectionFactoryOptions.DATABASE);
+                String url = String.format(
+                    "r2dbc:%s://%s:%s/%s",
+                    options.getValue(ConnectionFactoryOptions.DRIVER),
+                    options.getValue(ConnectionFactoryOptions.HOST),
+                    options.getValue(ConnectionFactoryOptions.PORT),
+                    options.getValue(ConnectionFactoryOptions.DATABASE)
+                );
                 LOGGER.debug("Resolved property: {} with value: {}", propertyName, url);
                 return url;
             case USERNAME:

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.core;
+
+import io.micronaut.testresources.core.Scope;
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import io.micronaut.testresources.testcontainers.TestContainers;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Base class for R2DBC test resources. Unlike JDBC test resources, this
+ * resolver is capable of reusing an existing JDBC test resources and
+ * expose it via R2DBC: this can be useful for Flyway database migrations
+ * which work over JDBC for example. For this to work, a datasource of
+ * the same name must exist, in which case it would be resolved first.
+ *
+ * If no such datasource exists, then a new container will be created.
+ *
+ * @param <T> the container type
+ */
+public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContainer<? extends T>> extends AbstractTestContainersProvider<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractR2DBCTestResourceProvider.class);
+
+    private static final String DATASOURCES = "datasources";
+    private static final String R2DBC_DATASOURCES = "r2dbc.datasources";
+    private static final String R2DBC_PREFIX = "r2dbc.";
+    private static final String URL = "url";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final List<String> RESOLVABLE_KEYS = Arrays.asList(
+        URL,
+        USERNAME,
+        PASSWORD
+    );
+
+    private static final String DIALECT = "dialect";
+    private static final String DRIVER = "driverClassName";
+    private static final String TYPE = "db-type";
+    private static final List<String> REQUIRED_PROPERTIES = Arrays.asList(
+        DIALECT,
+        DRIVER,
+        TYPE
+    );
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Arrays.asList(R2DBC_DATASOURCES, DATASOURCES);
+    }
+
+    @Override
+    public List<String> getRequiredProperties(String expression) {
+        if (expression.startsWith(R2DBC_DATASOURCES)) {
+            // If we resolve r2dbc.datasources.default.url, we will
+            // try to find a regular datasource with the same name
+            // and reuse it if it exists.
+            String regularDatasource = removeR2dbPrefixFrom(expression);
+            String datasourceName = datasourceNameFrom(regularDatasource);
+            List<String> requiredProperties = Stream.concat(
+                Stream.of(regularDatasource),
+                REQUIRED_PROPERTIES.stream().map(k -> r2dbDatasourceExpressionOf(datasourceName, k))
+            ).collect(Collectors.toList());
+
+            LOGGER.debug("Required properties: {}", requiredProperties);
+            return requiredProperties;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        Collection<String> r2dbcDatasources = propertyEntries.getOrDefault(R2DBC_DATASOURCES, Collections.emptyList());
+        Collection<String> datasources = propertyEntries.getOrDefault(DATASOURCES, Collections.emptyList());
+        List<String> properties = Stream.concat(r2dbcDatasources.stream(), datasources.stream())
+            .flatMap(name -> RESOLVABLE_KEYS.stream().map(key -> R2DBC_DATASOURCES + "." + name + "." + key))
+            .distinct()
+            .collect(Collectors.toList());
+        LOGGER.debug("Resolvable properties: {}", properties);
+        return properties;
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+        if (!propertyName.startsWith(R2DBC_PREFIX)) {
+            return false;
+        }
+        String baseDatasourceExpression = removeR2dbPrefixFrom(propertyName);
+        String datasource = datasourceNameFrom(baseDatasourceExpression);
+        String type = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, TYPE)));
+        if (type != null && type.equalsIgnoreCase(getSimpleName())) {
+            return true;
+        }
+        String driver = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, DRIVER)));
+        if (driver != null && driver.toLowerCase(Locale.US).contains(getSimpleName())) {
+            return true;
+        }
+        String dialect = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, DIALECT)));
+        if (dialect != null && dialect.equalsIgnoreCase(getSimpleName())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties) {
+        String name = removeR2dbPrefixFrom(propertyName);
+        if (properties.containsKey(name)) {
+            return resolveUsingExistingContainer(propertyName, properties, name);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected final Optional<String> resolveProperty(String expression, T container) {
+        Optional<ConnectionFactoryOptions> options = extractOptions(container);
+        if (options.isPresent()) {
+            String propertyName = expression.substring(expression.lastIndexOf(".") + 1);
+            return Optional.ofNullable(resolveFromConnectionOptions(propertyName, options.get()));
+        }
+        return Optional.empty();
+    }
+
+    private static String removeR2dbPrefixFrom(String propertyName) {
+        return propertyName.substring(R2DBC_PREFIX.length());
+    }
+
+    private Optional<String> resolveUsingExistingContainer(String propertyName, Map<String, Object> properties, String name) {
+        // Look for a container with JDBC
+        LOGGER.debug("Resolving property: {} with properties {}", propertyName, properties);
+        List<GenericContainer<?>> containers = TestContainers.findByRequestedProperty(Scope.from(properties), name);
+        LOGGER.debug("Found containers providing {} : {}", name, containers);
+        if (containers.size() > 1) {
+            LOGGER.warn("More than one container provides {}. Will use the first one.", name);
+        }
+        return containers.stream()
+            .findFirst()
+            .flatMap(this::extractOptions)
+            .map(options -> resolveFromConnectionOptions(propertyName, options));
+    }
+
+    private String resolveFromConnectionOptions(String propertyName, ConnectionFactoryOptions options) {
+        String property = propertyName.substring(propertyName.lastIndexOf(".") + 1);
+        switch (property) {
+            case URL:
+                // r2dbc:mysql://localhost:3306/db
+                String url = "r2dbc:" + options.getValue(ConnectionFactoryOptions.DRIVER) +
+                    "://" + options.getValue(ConnectionFactoryOptions.HOST) + ":" + options.getValue(ConnectionFactoryOptions.PORT) +
+                    "/" + options.getValue(ConnectionFactoryOptions.DATABASE);
+                LOGGER.debug("Resolved property: {} with value: {}", propertyName, url);
+                return url;
+            case USERNAME:
+                return String.valueOf(options.getValue(ConnectionFactoryOptions.USER));
+            case PASSWORD:
+                return String.valueOf(options.getValue(ConnectionFactoryOptions.PASSWORD));
+            default:
+        }
+        return null;
+    }
+
+    protected abstract Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container);
+
+    protected static String datasourceNameFrom(String expression) {
+        String remainder = expression.substring(1 + expression.indexOf('.'));
+        return remainder.substring(0, remainder.indexOf("."));
+    }
+
+    protected static String r2dbDatasourceExpressionOf(String datasource, String property) {
+        return R2DBC_DATASOURCES + "." + datasource + "." + property;
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides core support for R2DBC MariaDB test resources.
+"""
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+    api(project(':test-resources-r2dbc-core'))
+
+    implementation(libs.testcontainers.mariadb)
+    runtimeOnly(project(":test-resources-jdbc-mariadb"))
+
+    testImplementation(mn.micronaut.data.processor)
+    testImplementation(mn.micronaut.data.r2dbc)
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+
+    testRuntimeOnly(libs.reactive.mariadb)
+    testRuntimeOnly(libs.mariadb)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.mariadb;
+
+import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.MariaDBR2DBCDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider for reactive MariaDB.
+ */
+public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceProvider<MariaDBContainer<?>> {
+
+    @Override
+    protected String getSimpleName() {
+        return "mariadb";
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return "mariadb";
+    }
+
+    @Override
+    protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
+        if (container instanceof MariaDBContainer) {
+            return Optional.of(MariaDBR2DBCDatabaseContainer.getOptions((MariaDBContainer<?>) container));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+        return new MariaDBContainer<>(imageName);
+    }
+
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.mariadb.R2DBCMariaDBTestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.mariadb
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.MYSQL)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/StandaloneStartMariaDBSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/StandaloneStartMariaDBSQLTest.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.r2dbc.mariadb
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["standalone"] )
+class StandaloneStartMariaDBSQLTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive MariaDB container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "mariadb"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/WithJdbcStartMariaDBSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/WithJdbcStartMariaDBSQLTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.r2dbc.mariadb
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["jdbc"] )
+class WithJdbcStartMariaDBSQLTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive MariaDB container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "mariadb"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-jdbc.yml
@@ -1,0 +1,11 @@
+datasources:
+  default:
+    driverClassName: org.mariadb.jdbc.Driver
+    schema-generate: CREATE_DROP
+    dialect: MYSQL
+r2dbc:
+  datasources:
+    default:
+      db-type: mariadb
+      schema-generate: CREATE_DROP
+      dialect: MYSQL

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-standalone.yml
@@ -1,0 +1,6 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      db-type: mariadb
+      dialect: MYSQL

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides core support for R2DBC test resources.
+"""
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+    api(project(':test-resources-r2dbc-core'))
+
+    implementation(libs.testcontainers.mysql)
+    runtimeOnly(project(":test-resources-jdbc-mysql"))
+
+    testImplementation(mn.micronaut.data.processor)
+    testImplementation(mn.micronaut.data.r2dbc)
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+
+    testRuntimeOnly(libs.reactive.mysql)
+    testRuntimeOnly(libs.mysql)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.mysql;
+
+import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.MySQLR2DBCDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider for reactive MySQL.
+ */
+public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<MySQLContainer<?>> {
+
+    @Override
+    protected String getSimpleName() {
+        return "mysql";
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return "mysql";
+    }
+
+    @Override
+    protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
+        if (container instanceof MySQLContainer) {
+            return Optional.of(MySQLR2DBCDatabaseContainer.getOptions((MySQLContainer<?>) container));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+        return new MySQLContainer<>(imageName);
+    }
+
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.mysql.R2DBCMySQLTestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.mysql
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.MYSQL)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/StandaloneStartMySQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/StandaloneStartMySQLTest.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.r2dbc.mysql
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["standalone"] )
+class StandaloneStartMySQLTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive MySQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "mysql"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/WithJdbcStartMySQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/WithJdbcStartMySQLTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.r2dbc.mysql
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["jdbc"] )
+class WithJdbcStartMySQLTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive MySQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "mysql"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+datasources:
+  default:
+    driverClassName: com.mysql.cj.jdbc.Driver
+    schema-generate: CREATE_DROP
+    dialect: MYSQL
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: MYSQL

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/application-standalone.yml
@@ -1,0 +1,5 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: MYSQL

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides core support for R2DBC test resources.
+"""
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+    api(project(':test-resources-r2dbc-core'))
+
+    implementation(libs.testcontainers.oracle.xe)
+    runtimeOnly(project(":test-resources-jdbc-oracle-xe"))
+
+    testImplementation(mn.micronaut.data.processor)
+    testImplementation(mn.micronaut.data.r2dbc)
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+
+    testRuntimeOnly(libs.reactive.oracle.xe)
+    testRuntimeOnly(libs.oracle.xe)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.oracle;
+
+import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider which will spawn an Oracle XE reactive test container.
+ */
+public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResourceProvider<OracleContainer> {
+
+    private static final String R2DBC_ORACLE_DRIVER = "oracle";
+
+    @Override
+    protected String getSimpleName() {
+        return R2DBC_ORACLE_DRIVER;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return "gvenzl/oracle-xe";
+    }
+
+    @Override
+    protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
+        if (container instanceof OracleContainer) {
+            OracleContainer oracle = (OracleContainer) container;
+            ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.USER, oracle.getUsername())
+                .option(ConnectionFactoryOptions.PASSWORD, oracle.getPassword())
+                .option(ConnectionFactoryOptions.HOST, oracle.getHost())
+                .option(ConnectionFactoryOptions.PORT, oracle.getOraclePort())
+                .option(ConnectionFactoryOptions.DATABASE, oracle.getDatabaseName())
+                .option(ConnectionFactoryOptions.DRIVER, R2DBC_ORACLE_DRIVER)
+                .build();
+            return Optional.of(options);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected OracleContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+        return new OracleContainer(imageName);
+    }
+
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.oracle.R2DBCOracleXETestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.ORACLE)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/StandaloneStartOracleTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/StandaloneStartOracleTest.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+import spock.lang.Ignore
+
+@MicronautTest(environments = ["standalone"] )
+@Ignore("R2dbcSchemaGenerator doesn't support Oracle")
+class StandaloneStartOracleTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/WithJdbcStartOracleTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/WithJdbcStartOracleTest.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+import spock.lang.Ignore
+
+@MicronautTest(environments = ["jdbc"] )
+@Ignore("R2dbcSchemaGenerator doesn't support Oracle")
+class WithJdbcStartOracleTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+datasources:
+  default:
+    driverClassName: oracle.jdbc.OracleDriver
+    schema-generate: CREATE_DROP
+    dialect: ORACLE
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: ORACLE

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-standalone.yml
@@ -1,0 +1,5 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: ORACLE

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides core support for R2DBC test resources.
+"""
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+    api(project(':test-resources-r2dbc-core'))
+
+    implementation(libs.testcontainers.postgres)
+    runtimeOnly(project(":test-resources-jdbc-postgresql"))
+
+    testImplementation(mn.micronaut.data.processor)
+    testImplementation(mn.micronaut.data.r2dbc)
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+
+    testRuntimeOnly(libs.reactive.postgres)
+    testRuntimeOnly(libs.postgres)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.postgres;
+
+import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider for reactive PostgreSQL.
+ */
+public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<PostgreSQLContainer<?>> {
+
+    @Override
+    protected String getSimpleName() {
+        return "postgres";
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return "postgres";
+    }
+
+    @Override
+    protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
+        if (container instanceof PostgreSQLContainer) {
+            return Optional.of(PostgreSQLR2DBCDatabaseContainer.getOptions((PostgreSQLContainer<?>) container));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+        return new PostgreSQLContainer<>(imageName);
+    }
+
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.postgres.R2DBCPostgreSQLTestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.postgres
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.POSTGRES)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/StandaloneStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/StandaloneStartPostgreSQLTest.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.r2dbc.postgres
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["standalone"] )
+class StandaloneStartPostgreSQLTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive PostgreSQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/WithJdbcStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/WithJdbcStartPostgreSQLTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.r2dbc.postgres
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["jdbc"] )
+class WithJdbcStartPostgreSQLTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive PostgreSQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+datasources:
+  default:
+    driverClassName: org.postgresql.Driver
+    schema-generate: CREATE_DROP
+    dialect: POSTGRES
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: POSTGRES

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/application-standalone.yml
@@ -1,0 +1,5 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: POSTGRES

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
@@ -108,7 +108,7 @@ public class GenericTestContainerProvider implements TestResourcesResolver {
             .findFirst()
             .map(md -> {
                 DockerImageName imageName = DockerImageName.parse(md.getImageName());
-                return new MappedContainer(md, TestContainers.getOrCreate(GenericTestContainerProvider.class,
+                return new MappedContainer(md, TestContainers.getOrCreate(propertyName, GenericTestContainerProvider.class,
                     md.getId(),
                     properties,
                     () -> {


### PR DESCRIPTION
The R2DBC support is a bit special in the sense that it can work
in standalone mode, in which case it will first spawn a JDBC container
_then_ bridge it to R2DBC, or it can re-use an existing JDBC container.

This is useful in case a project uses Flyway, for example, which will
operate in JDBC mode, not R2DBC.

For this to happen, the code had to be refactored so that we can determine
what containers "resolved what property". For example, we needed a way
to figure out that a MySQL container was associated to the resolution
of the `datasources.default.url` property, so that if we try to resolve
`r2dbc.datasources.default.url`, then we can first search for a container
which supplied `datasources.default.url`. Note that this assumes that
the R2DBC and JDBC datasources are "mirrored", in the sense that they use
the same names. If not, strange things may happen.