### PR TITLE
Introduce `KnownModules`

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/internal/WriteModuleList.java
+++ b/buildSrc/src/main/groovy/io/micronaut/internal/WriteModuleList.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.internal;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+@CacheableTask
+public abstract class WriteModuleList extends DefaultTask {
+    @Input
+    abstract MapProperty<String, List<String>> getModules();
+
+    @Input
+    abstract MapProperty<String, String> getModuleDescriptions();
+
+    @Input
+    abstract Property<String> getPackage();
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void writeVersion() throws IOException {
+        File outputFile = getOutputDirectory().file(getPackage().map(pkg -> pkg.replace('.', '/') + "/KnownModules.java")).get().getAsFile();
+        Path parentPath = outputFile.getParentFile().toPath();
+        if (Files.isDirectory(parentPath) || Files.createDirectories(parentPath) != null) {
+            try (PrintWriter prn = new PrintWriter(new FileWriter(outputFile))) {
+                prn.println("package " + getPackage().get() + ";\n");
+                prn.println();
+                prn.println("/**");
+                prn.println(" * Micronaut Test Resources modules.");
+                prn.println(" */");
+                prn.println("public interface KnownModules {");
+                Map<String, String> moduleDescriptions = getModuleDescriptions().get();
+                getModules().get().entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> {
+                        String key = e.getKey();
+                        List<String> moduleList = e.getValue();
+                        String description = moduleDescriptions.get(key);
+                        if (description != null) {
+                            prn.println("    // " + description);
+                        }
+                        moduleList.forEach(module -> {
+                            String constant = module
+                                .replace("test-resources-", "")
+                                .replace('-', '_')
+                                .toUpperCase();
+                            prn.println("    String " + constant + " = \"" + module + "\";");
+                        });
+                        prn.println();
+                    });
+                prn.println("}");
+            }
+        }
+    }
+}

--- a/test-resources-build-tools/build.gradle
+++ b/test-resources-build-tools/build.gradle
@@ -1,4 +1,5 @@
 import io.micronaut.internal.WriteVersion
+import io.micronaut.internal.WriteModuleList
 
 plugins {
     id 'io.micronaut.build.internal.test-resources-module'
@@ -25,8 +26,30 @@ def writeVersion = tasks.register("writeVersionClass", WriteVersion) {
     getPackage().set("io.micronaut.testresources.buildtools")
     version.set(project.version as String)
 }
+def writeModuleList = tasks.register("writeModuleList", WriteModuleList) {
+    outputDirectory.set(layout.buildDirectory.dir("module-list"))
+    getPackage().set("io.micronaut.testresources.buildtools")
+    def thisProject = project
+    modules = rootProject.allprojects.findAll { it != thisProject && it != rootProject }
+            .collect { it.name - 'test-resources-' }
+            .groupBy {
+                if (it.startsWith('jdbc')) {
+                    'jdbc'
+                } else if (it.startsWith('r2dbc')) {
+                    'r2dbc'
+                } else if (it in ['core', 'bom', 'embedded', 'client', 'testcontainers']) {
+                    'core'
+                } else {
+                    'modules'
+                }
+            }
+    moduleDescriptions.put('core', 'Core modules')
+    moduleDescriptions.put('jdbc', 'JDBC modules')
+    moduleDescriptions.put('r2dbc', 'R2DBC modules')
+    moduleDescriptions.put('modules', 'Extra modules')
+}
 
-sourceSets.main.java.srcDir(writeVersion)
+sourceSets.main.java.srcDirs(writeVersion, writeModuleList)
 
 dependencies {
     testImplementation(mn.spock)

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -29,13 +29,13 @@ import java.util.stream.Stream;
  * case we need to put on the test resources classpath the Micronaut
  * test resources modules for JDBC and the MySQL driver.
  */
-public final class TestResourcesClasspath {
+public final class TestResourcesClasspath implements KnownModules {
     private static final String TEST_RESOURCES_GROUP = "io.micronaut.testresources";
     private static final String TEST_RESOURCES_ARTIFACT_PREFIX = "micronaut-test-resources-";
 
     private static final List<String> CORE_SUPPORT = Arrays.asList(
-        "server",
-        "testcontainers"
+        SERVER,
+        TESTCONTAINERS
     );
     private static final String MICRONAUT_DATA_PREFIX = "micronaut-data-";
     private static final String MICRONAUT_KAFKA = "micronaut-kafka";


### PR DESCRIPTION
This interface contains the list of known modules from the project,
so that build tools don't have to maintain their own list.

That interface will be extended by the Gradle DSL directly, so that
users can have completion on module names.