### PR TITLE
Add support for copying files to containers

### DIFF
--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -69,6 +69,26 @@ test-resources:
         - "path/to/local/readwrite-file.conf": /path/to/container/readwrite-file.conf
 ----
 
+It is also possible to copy files from the host to the container:
+
+.application.yml
+[source,yaml,subs="verbatim"]
+----
+test-resources:
+  containers:
+    mycontainer:
+      image-name: my/container
+      hostnames:
+        - my.service.host
+      exposed-ports:
+        - my.service.port: 1883
+      copy-to-container:
+        - path/to/local/readonly-file.conf: /path/to/container/file.conf
+        - classpath:/file/on/classpath.conf: /path/to/container/other.conf
+----
+
+In case you want to copy a file found on classpath, the source path must be prefixed with `classpath:`.
+
 The following properties are also supported:
 
 - `command`: Set the command that should be run in the container

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaCustomConfigTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaCustomConfigTest.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.testresources.kafka
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+
+@MicronautTest(environments = "custom")
+class KafkaCustomConfigTest extends AbstractKafkaSpec {
+
+    @Inject
+    ApplicationContext applicationContext
+
+    def "automatically starts a Kafka container"() {
+        when:
+        def client = applicationContext.getBean(AnalyticsClient)
+        def result = client.updateAnalytics("oh yeah!")
+
+        then:
+        result.block() == "oh yeah!"
+    }
+
+}

--- a/test-resources-kafka/src/test/resources/application-custom.yml
+++ b/test-resources-kafka/src/test/resources/application-custom.yml
@@ -1,0 +1,19 @@
+test-resources:
+  containers:
+    kafka:
+      env:
+        - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT"
+        - KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+        - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+        - KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      copy-to-container:
+        - classpath:/example/kafka_server_jaas.conf: /etc/kafka/kafka_server_jaas.conf
+
+# For the producer
+kafka:
+  security:
+    protocol: SASL_PLAINTEXT
+  sasl:
+    mechanism: PLAIN
+    jaas:
+      config: org.apache.kafka.common.security.plain.PlainLoginModule required username='alice' password='alice-secret';

--- a/test-resources-kafka/src/test/resources/example/kafka_server_jaas.conf
+++ b/test-resources-kafka/src/test/resources/example/kafka_server_jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_alice="alice-secret";
+};
+Client {};

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
@@ -15,7 +15,10 @@
  */
 package io.micronaut.testresources.testcontainers;
 
+import org.testcontainers.utility.MountableFile;
+
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -33,6 +36,7 @@ final class TestContainerMetadata {
     private final Map<String, String> env;
     private final Map<String, String> labels;
     private final Duration startupTimeout;
+    private final List<CopyFileToContainer> fileCopies;
 
     TestContainerMetadata(String id,
                           String imageName,
@@ -44,7 +48,8 @@ final class TestContainerMetadata {
                           String workingDirectory,
                           Map<String, String> env,
                           Map<String, String> labels,
-                          Duration startupTimeout) {
+                          Duration startupTimeout,
+                          List<CopyFileToContainer> fileCopies) {
         this.id = id;
         this.imageName = imageName;
         this.exposedPorts = exposedPorts;
@@ -56,6 +61,7 @@ final class TestContainerMetadata {
         this.env = env;
         this.labels = labels;
         this.startupTimeout = startupTimeout;
+        this.fileCopies = fileCopies;
     }
 
     public String getId() {
@@ -100,5 +106,27 @@ final class TestContainerMetadata {
 
     public Map<String, String> getLabels() {
         return labels;
+    }
+
+    public List<CopyFileToContainer> getFileCopies() {
+        return fileCopies;
+    }
+
+    public static final class CopyFileToContainer {
+        private final MountableFile file;
+        private final String destination;
+
+        public CopyFileToContainer(MountableFile file, String destination) {
+            this.file = file;
+            this.destination = destination;
+        }
+
+        public MountableFile getFile() {
+            return file;
+        }
+
+        public String getDestination() {
+            return destination;
+        }
     }
 }

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -208,6 +208,26 @@ class TestContainerMetadataSupportTest extends Specification {
         "3h"     | Duration.ofHours(3)
     }
 
+    def "reads copy file to container"() {
+        def config = """
+                containers:
+                    foo:
+                        copy-to-container:
+                            - classpath:/some/file.txt: /some/container/file.txt
+                            - /host/path: /container/path
+"""
+        when:
+        def md = metadataFrom(config, "foo")
+
+        then:
+        md.present
+        md.get().with {
+            def copies = it.fileCopies
+            assert copies.size() == 2
+            assert copies.findAll { it.destination == "/some/container/file.txt" }.size() == 1
+            assert copies.findAll { it.destination == "/container/path" }.size() == 1
+        }
+    }
 
     private static Optional<TestContainerMetadata> metadataFrom(String yaml, String key) {
         def asMap = convert(yaml)

--- a/test-resources-testcontainers/src/test/resources/some/file.txt
+++ b/test-resources-testcontainers/src/test/resources/some/file.txt
@@ -1,0 +1,1 @@
+Used in copy to container test


### PR DESCRIPTION
This commit adds support for copying files to container. As a
proof-of-concept, it adds a test to the Kafka module which uses
both environment variables and a custom SASL configuration,
which requires copying files to the container before it starts.