### PR TITLE
Refactor build

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+dependencies {
+    api(project(':test-resources-jdbc-core'))
+
+    testCompileOnly(mn.micronaut.data.processor)
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+    testRuntimeOnly(mn.micronaut.jdbc.hikari)
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+dependencies {
+    api(project(':test-resources-r2dbc-core'))
+    testImplementation(mn.micronaut.data.r2dbc)
+    testImplementation(mn.micronaut.data.processor)
+    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+dependencies {
+    api(project(':test-resources-core'))
+    api(project(':test-resources-testcontainers'))
+
+    testImplementation(project(":test-resources-embedded"))
+    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+}

--- a/test-resources-hivemq/build.gradle
+++ b/test-resources-hivemq/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,12 +7,8 @@ Provides support for launching a HiveMQ test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     implementation(libs.testcontainers.hivemq)
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.reactor)
     testImplementation(mn.micronaut.mqttv5)
 }

--- a/test-resources-jdbc/test-resources-jdbc-core/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-core/build.gradle
@@ -1,16 +1,13 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
     id 'java-test-fixtures'
 }
 
 description = """
-Provides support for launching a MySQL test container.
+Provides core support for JDBC test containers.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    implementation(platform(libs.boms.testcontainers))
     implementation(libs.testcontainers.jdbc)
 
     testFixturesApi(platform(mn.micronaut.bom))

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.jdbc-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a MariaDB test container.
 """
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
     implementation(libs.testcontainers.mariadb)
 
-    testCompileOnly(mn.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
     testRuntimeOnly(libs.mariadb)
-    testRuntimeOnly(mn.micronaut.jdbc.hikari)
 }

--- a/test-resources-jdbc/test-resources-jdbc-mssql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.jdbc-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a MS SQL test container.
 """
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
     implementation(libs.testcontainers.mssql)
 
-    testCompileOnly(mn.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
     testRuntimeOnly(libs.mssql)
-    testRuntimeOnly(mn.micronaut.jdbc.hikari)
 }

--- a/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.jdbc-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a MySQL test container.
 """
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
     implementation(libs.testcontainers.mysql)
 
-    testCompileOnly(mn.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
     testRuntimeOnly(libs.mysql)
-    testRuntimeOnly(mn.micronaut.jdbc.hikari)
 }

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/build.gradle
@@ -1,17 +1,13 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.jdbc-module'
 }
 
 description = """
-Provides support for launching a PostgreSQL test container.
+Provides support for launching a Oracle XE test container.
 """
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
     implementation(libs.testcontainers.oracle.xe)
 
-    testCompileOnly(mn.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
     testRuntimeOnly(libs.oracle.xe)
-    testRuntimeOnly(mn.micronaut.jdbc.hikari)
 }

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.jdbc-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a PostgreSQL test container.
 """
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
     implementation(libs.testcontainers.postgres)
 
-    testCompileOnly(mn.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
     testRuntimeOnly(libs.postgres)
-    testRuntimeOnly(mn.micronaut.jdbc.hikari)
 }

--- a/test-resources-kafka/build.gradle
+++ b/test-resources-kafka/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,12 +7,8 @@ Provides support for launching a Kafka test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     implementation(libs.testcontainers.kafka)
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.reactor)
     testImplementation(mn.micronaut.kafka)
 }

--- a/test-resources-mongodb/build.gradle
+++ b/test-resources-mongodb/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,13 +7,9 @@ Provides support for launching a MongoDB test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     implementation(libs.testcontainers.mongodb)
 
     testCompileOnly(mn.micronaut.data.document.processor)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.data.mongodb)
     testImplementation(libs.mongodb)
 }

--- a/test-resources-neo4j/build.gradle
+++ b/test-resources-neo4j/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a MongoDB test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     implementation(libs.testcontainers.neo4j)
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.neo4j)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,10 +7,5 @@ Provides core support for R2DBC test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     api(libs.testcontainers.r2dbc)
-
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
@@ -1,24 +1,14 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.r2dbc-module'
 }
 
 description = """
-Provides core support for R2DBC MariaDB test resources.
+Provides support for R2DBC MariaDB test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    api(project(':test-resources-r2dbc-core'))
-
     implementation(libs.testcontainers.mariadb)
     runtimeOnly(project(":test-resources-jdbc-mariadb"))
-
-    testImplementation(mn.micronaut.data.processor)
-    testImplementation(mn.micronaut.data.r2dbc)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
 
     testRuntimeOnly(libs.reactive.mariadb)
     testRuntimeOnly(libs.mariadb)

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
@@ -1,24 +1,14 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.r2dbc-module'
 }
 
 description = """
-Provides core support for R2DBC test resources.
+Provides support for MS SQL Server R2DBC test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    api(project(':test-resources-r2dbc-core'))
-
     implementation(libs.testcontainers.mssql)
     runtimeOnly(project(":test-resources-jdbc-mssql"))
-
-    testImplementation(mn.micronaut.data.processor)
-    testImplementation(mn.micronaut.data.r2dbc)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
 
     testRuntimeOnly(libs.reactive.mssql)
     testRuntimeOnly(libs.mssql)

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
@@ -1,24 +1,14 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.r2dbc-module'
 }
 
 description = """
-Provides core support for R2DBC test resources.
+Provides support for MySQL R2DBC test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    api(project(':test-resources-r2dbc-core'))
-
     implementation(libs.testcontainers.mysql)
     runtimeOnly(project(":test-resources-jdbc-mysql"))
-
-    testImplementation(mn.micronaut.data.processor)
-    testImplementation(mn.micronaut.data.r2dbc)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
 
     testRuntimeOnly(libs.reactive.mysql)
     testRuntimeOnly(libs.mysql)

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
@@ -1,24 +1,14 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.r2dbc-module'
 }
 
 description = """
-Provides core support for R2DBC test resources.
+Provides support for Oracle XE R2DBC test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    api(project(':test-resources-r2dbc-core'))
-
     implementation(libs.testcontainers.oracle.xe)
     runtimeOnly(project(":test-resources-jdbc-oracle-xe"))
-
-    testImplementation(mn.micronaut.data.processor)
-    testImplementation(mn.micronaut.data.r2dbc)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
 
     testRuntimeOnly(libs.reactive.oracle.xe)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
@@ -1,24 +1,14 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.r2dbc-module'
 }
 
 description = """
-Provides core support for R2DBC test resources.
+Provides support for PostgreSQL R2DBC test resources.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
-    api(project(':test-resources-r2dbc-core'))
-
     implementation(libs.testcontainers.postgres)
     runtimeOnly(project(":test-resources-jdbc-postgresql"))
-
-    testImplementation(mn.micronaut.data.processor)
-    testImplementation(mn.micronaut.data.r2dbc)
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
 
     testRuntimeOnly(libs.reactive.postgres)
     testRuntimeOnly(libs.postgres)

--- a/test-resources-rabbitmq/build.gradle
+++ b/test-resources-rabbitmq/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.testcontainers-module'
 }
 
 description = """
@@ -7,11 +7,7 @@ Provides support for launching a RabbitMQ test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
     implementation(libs.testcontainers.rabbitmq)
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.rabbitmq)
 }


### PR DESCRIPTION
Introduce convention plugins to remove some configuration duplication.
All test containers modules now have their own plugin. Similarly,
the JDBC and R2DBC modules share a lot of configuration, so they have
their own plugins now.