### PR TITLE
Pass test resources configuration to create method

### DIFF
--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -53,7 +53,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     }
 
     @Override
-    protected ElasticsearchContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected ElasticsearchContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         if ("latest".equals(imageName.getVersionPart())) {
             // ElasticSearch does't provide a latest tag, so we use a hardcoded version
             imageName = imageName.withTag(DEFAULT_TAG);
@@ -74,7 +74,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return ELASTICSEARCH_HOSTS.equals(propertyName);
     }
 }

--- a/test-resources-hashicorp-vault/build.gradle
+++ b/test-resources-hashicorp-vault/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 
     testImplementation(testFixtures(project(":test-resources-testcontainers")))
     testImplementation(mn.micronaut.discovery)
+    testImplementation(mn.micronaut.security.oauth2)
 }

--- a/test-resources-hashicorp-vault/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-hashicorp-vault/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,1 +1,1 @@
-io.micronaut.testresources.mongodb.VaultTestResourceProvider
+io.micronaut.testresources.hashicorp.vault.VaultTestResourceProvider

--- a/test-resources-hashicorp-vault/src/test/groovy/io/micronaut/testresources/hashicorp/vault/VaultStartedTest.groovy
+++ b/test-resources-hashicorp-vault/src/test/groovy/io/micronaut/testresources/hashicorp/vault/VaultStartedTest.groovy
@@ -1,14 +1,20 @@
-package io.micronaut.testresources.mongodb
+package io.micronaut.testresources.hashicorp.vault
+
 
 import io.micronaut.context.annotation.Value
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+import jakarta.inject.Inject
 
 @MicronautTest
 class VaultStartedTest extends AbstractTestContainersSpec {
 
     @Value('${vault.client.uri}')
     String uri
+
+    @Inject
+    OauthClientConfiguration oauthClientConfiguration
 
     @Override
     String getScopeName() {
@@ -18,5 +24,11 @@ class VaultStartedTest extends AbstractTestContainersSpec {
     def "automatically starts a Vault container"() {
         expect:
         listContainers().collectMany { it.ports as List }.any { uri == "http://localhost:$it.publicPort" }
+    }
+
+    def "secretsAreUsedForConfiguration"() {
+        expect:
+        oauthClientConfiguration.clientId == 'XXX'
+        oauthClientConfiguration.clientSecret == 'YYY'
     }
 }

--- a/test-resources-hashicorp-vault/src/test/groovy/io/micronaut/testresources/hashicorp/vault/VaultStartedTest.groovy
+++ b/test-resources-hashicorp-vault/src/test/groovy/io/micronaut/testresources/hashicorp/vault/VaultStartedTest.groovy
@@ -6,6 +6,7 @@ import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
 import jakarta.inject.Inject
+import jakarta.inject.Named
 
 @MicronautTest
 class VaultStartedTest extends AbstractTestContainersSpec {
@@ -14,6 +15,7 @@ class VaultStartedTest extends AbstractTestContainersSpec {
     String uri
 
     @Inject
+    @Named("test")
     OauthClientConfiguration oauthClientConfiguration
 
     @Override
@@ -28,7 +30,7 @@ class VaultStartedTest extends AbstractTestContainersSpec {
 
     def "secretsAreUsedForConfiguration"() {
         expect:
-        oauthClientConfiguration.clientId == 'XXX'
-        oauthClientConfiguration.clientSecret == 'YYY'
+        oauthClientConfiguration.clientId == 'hello'
+        oauthClientConfiguration.clientSecret == 'world'
     }
 }

--- a/test-resources-hashicorp-vault/src/test/resources/application-test.yml
+++ b/test-resources-hashicorp-vault/src/test/resources/application-test.yml
@@ -5,10 +5,3 @@ micronaut:
         default:
           client-id: ${OAUTH_CLIENT_ID:XXX}
           client-secret: ${OAUTH_CLIENT_SECRET:YYY}
-test-resources:
-  containers:
-    hashicorp-vault:
-      path: 'secret/my-path'
-      secrets:
-        - "key1=value1"
-        - "key2=value2"

--- a/test-resources-hashicorp-vault/src/test/resources/application-test.yml
+++ b/test-resources-hashicorp-vault/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+micronaut:
+  security:
+    oauth2:
+      clients:
+        default:
+          client-id: ${OAUTH_CLIENT_ID:XXX}
+          client-secret: ${OAUTH_CLIENT_SECRET:YYY}
+test-resources:
+  containers:
+    hashicorp-vault:
+      path: 'secret/my-path'
+      secrets:
+        - "key1=value1"
+        - "key2=value2"

--- a/test-resources-hashicorp-vault/src/test/resources/bootstrap.yml
+++ b/test-resources-hashicorp-vault/src/test/resources/bootstrap.yml
@@ -1,4 +1,6 @@
 micronaut:
+  application:
+    name: vault-test
   config-client:
     enabled: true
 vault:
@@ -6,3 +8,10 @@ vault:
     config:
       enabled: true
     kv-version: "V2"
+test-resources:
+  containers:
+    hashicorp-vault:
+      path: 'secret/vault-test'
+      secrets:
+        - "micronaut.security.oauth2.clients.test.client-id=hello"
+        - "micronaut.security.oauth2.clients.test.client-secret=world"

--- a/test-resources-hashicorp-vault/src/test/resources/bootstrap.yml
+++ b/test-resources-hashicorp-vault/src/test/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+micronaut:
+  config-client:
+    enabled: true
+vault:
+  client:
+    config:
+      enabled: true
+    kv-version: "V2"

--- a/test-resources-hivemq/src/main/java/io/micronaut/testresources/hivemq/HiveMQTestResourceProvider.java
+++ b/test-resources-hivemq/src/main/java/io/micronaut/testresources/hivemq/HiveMQTestResourceProvider.java
@@ -49,7 +49,7 @@ public class HiveMQTestResourceProvider extends AbstractTestContainersProvider<H
     }
 
     @Override
-    protected HiveMQContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected HiveMQContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new HiveMQContainer(imageName);
     }
 
@@ -59,7 +59,7 @@ public class HiveMQTestResourceProvider extends AbstractTestContainersProvider<H
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return MQTT_CLIENT_SERVER_URI.equals(propertyName);
     }
 }

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -72,16 +72,16 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         if (!propertyName.startsWith(PREFIX)) {
             return false;
         }
         String datasource = datasourceNameFrom(propertyName);
-        String type = String.valueOf(properties.get(datasourceExpressionOf(datasource, TYPE)));
+        String type = String.valueOf(requestedProperties.get(datasourceExpressionOf(datasource, TYPE)));
         if (type != null && type.equalsIgnoreCase(getSimpleName())) {
             return true;
         }
-        String dialect = String.valueOf(properties.get(datasourceExpressionOf(datasource, DIALECT)));
+        String dialect = String.valueOf(requestedProperties.get(datasourceExpressionOf(datasource, DIALECT)));
         if (dialect != null && dialect.equalsIgnoreCase(getSimpleName())) {
             return true;
         }

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
@@ -37,7 +37,7 @@ public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvide
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MariaDBContainer<>(imageName);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -37,7 +37,7 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MSSQLServerContainer<>(imageName);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -37,7 +37,7 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
-    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MySQLContainer<>(imageName);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
@@ -37,7 +37,7 @@ public class OracleXETestResourceProvider extends AbstractJdbcTestResourceProvid
     }
 
     @Override
-    protected OracleContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected OracleContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new OracleContainer(imageName);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
@@ -37,7 +37,7 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new PostgreSQLContainer<>(imageName);
     }
 

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -49,7 +49,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     }
 
     @Override
-    protected KafkaContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected KafkaContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new KafkaContainer(imageName);
     }
 
@@ -59,7 +59,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return KAFKA_BOOTSTRAP_SERVERS.equals(propertyName);
     }
 }

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -49,7 +49,7 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
     }
 
     @Override
-    protected MongoDBContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MongoDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MongoDBContainer(imageName);
     }
 
@@ -59,7 +59,7 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return MONGODB_SERVER_URI.equals(propertyName);
     }
 }

--- a/test-resources-neo4j/src/main/java/io/micronaut/testresources/neo4j/Neo4jTestResourceProvider.java
+++ b/test-resources-neo4j/src/main/java/io/micronaut/testresources/neo4j/Neo4jTestResourceProvider.java
@@ -59,7 +59,7 @@ public class Neo4jTestResourceProvider extends AbstractTestContainersProvider<Ne
     }
 
     @Override
-    protected Neo4jContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected Neo4jContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         Neo4jContainer<?> container = new Neo4jContainer<>(imageName);
         container.withoutAuthentication();
         return container;
@@ -74,7 +74,7 @@ public class Neo4jTestResourceProvider extends AbstractTestContainersProvider<Ne
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return SUPPORTED_PROPERTIES.contains(propertyName);
     }
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -105,21 +105,21 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         if (!propertyName.startsWith(R2DBC_PREFIX)) {
             return false;
         }
         String baseDatasourceExpression = removeR2dbPrefixFrom(propertyName);
         String datasource = datasourceNameFrom(baseDatasourceExpression);
-        String type = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, TYPE)));
+        String type = String.valueOf(requestedProperties.get(r2dbDatasourceExpressionOf(datasource, TYPE)));
         if (type != null && type.equalsIgnoreCase(getSimpleName())) {
             return true;
         }
-        String driver = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, DRIVER)));
+        String driver = String.valueOf(requestedProperties.get(r2dbDatasourceExpressionOf(datasource, DRIVER)));
         if (driver != null && driver.toLowerCase(Locale.US).contains(getSimpleName())) {
             return true;
         }
-        String dialect = String.valueOf(properties.get(r2dbDatasourceExpressionOf(datasource, DIALECT)));
+        String dialect = String.valueOf(requestedProperties.get(r2dbDatasourceExpressionOf(datasource, DIALECT)));
         if (dialect != null && dialect.equalsIgnoreCase(getSimpleName())) {
             return true;
         }
@@ -127,7 +127,7 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
     }
 
     @Override
-    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties) {
+    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
         String name = removeR2dbPrefixFrom(propertyName);
         if (properties.containsKey(name)) {
             return resolveUsingExistingContainer(propertyName, properties, name);

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
@@ -49,7 +49,7 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MariaDBContainer<>(imageName);
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
@@ -50,7 +50,7 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MSSQLServerContainer<>(imageName);
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
@@ -49,7 +49,7 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
     }
 
     @Override
-    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new MySQLContainer<>(imageName);
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
@@ -59,7 +59,7 @@ public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResource
     }
 
     @Override
-    protected OracleContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected OracleContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new OracleContainer(imageName);
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -49,7 +49,7 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new PostgreSQLContainer<>(imageName);
     }
 

--- a/test-resources-rabbitmq/src/main/java/io/micronaut/testresources/rabbitmq/RabbitMQTestResourceProvider.java
+++ b/test-resources-rabbitmq/src/main/java/io/micronaut/testresources/rabbitmq/RabbitMQTestResourceProvider.java
@@ -63,7 +63,7 @@ public class RabbitMQTestResourceProvider extends AbstractTestContainersProvider
     }
 
     @Override
-    protected RabbitMQContainer createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected RabbitMQContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return new RabbitMQContainer(imageName);
     }
 
@@ -82,7 +82,7 @@ public class RabbitMQTestResourceProvider extends AbstractTestContainersProvider
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return SUPPORTED_KEYSET.contains(propertyName);
     }
 }

--- a/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisTestResourceProvider.java
+++ b/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisTestResourceProvider.java
@@ -61,7 +61,7 @@ public class RedisTestResourceProvider extends AbstractTestContainersProvider<Ge
     }
 
     @Override
-    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> properties) {
+    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         GenericContainer<?> container = new GenericContainer<>(imageName);
         container.withExposedPorts(REDIS_PORT);
         return container;
@@ -76,7 +76,7 @@ public class RedisTestResourceProvider extends AbstractTestContainersProvider<Ge
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return SUPPORTED_PROPERTIES.contains(propertyName);
     }
 }

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -54,10 +54,11 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
      * Creates the test container.
      *
      * @param imageName the docker image name
-     * @param properties the resolved properties
+     * @param requestedProperties the resolved properties
+     * @param testResourcesConfiguration the test resources configuration
      * @return a container
      */
-    protected abstract T createContainer(DockerImageName imageName, Map<String, Object> properties);
+    protected abstract T createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration);
 
     /**
      * Determines if this resolver can resolve the requested property.
@@ -66,10 +67,11 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
      * example.
      *
      * @param propertyName the property to resolve
-     * @param properties the resolved properties
+     * @param requestedProperties the resolved properties
+     * @param testResourcesConfiguration the test resources configuration
      * @return if this resolver should answer
      */
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> properties) {
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
         return true;
     }
 
@@ -77,18 +79,20 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
      * Lets a resolver provide a value for the requested property without triggering the
      * creation of a test container. This can be used in case a resolver wants to check
      * existing containers first.
+     *
      * @param propertyName the name of the property to resolve
      * @param properties the properties used to resolve
+     * @param testResourcesConfiguration the test resources configuration
      * @return a resolved property
      */
-    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties) {
+    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
         return Optional.empty();
     }
 
     @Override
     public final Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
-        if (shouldAnswer(propertyName, properties)) {
-            Optional<String> firstPass = resolveWithoutContainer(propertyName, properties);
+        if (shouldAnswer(propertyName, properties, testResourcesConfiguration)) {
+            Optional<String> firstPass = resolveWithoutContainer(propertyName, properties, testResourcesConfiguration);
             if (firstPass.isPresent()) {
                 return firstPass;
             }
@@ -107,7 +111,7 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
                             imageName = imageName.withTag(md.getImageTag().get());
                         }
                     }
-                    T container = createContainer(imageName, properties);
+                    T container = createContainer(imageName, properties, testResourcesConfiguration);
                     metadata.ifPresent(md -> TestContainerMetadataSupport.applyMetadata(md, container));
                     return container;
                 }));

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
@@ -1,0 +1,20 @@
+package io.micronaut.testresources.testcontainers
+
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Specification
+
+class AbstractTestContainersProviderTest extends Specification {
+    def "test resources configuration is passed to the shouldAnswer and createContainer method"() {
+        def provider = Mock(AbstractTestContainersProvider) {
+            getDefaultImageName() >> 'my-image'
+        }
+
+        when:
+        provider.resolve('foo', [request: 'value'], ['test-resources.foo': 'config'])
+
+        then:
+        1 * provider.createContainer(_, [request: 'value'], ['test-resources.foo': 'config']) >> Stub(GenericContainer)
+        1 * provider.resolveWithoutContainer('foo', [request: 'value'], ['test-resources.foo': 'config']) >> Optional.empty()
+        1 * provider.shouldAnswer('foo', [request: 'value'], ['test-resources.foo': 'config']) >> true
+    }
+}


### PR DESCRIPTION
This commit fixes an inconsistency in the API: for generic test container
providers, the `create` method was only getting the explicit list of
requested properties, but not the test resources configuration map.

This forced implementors which need additional test resources configuration
to explicitly require those properties when they are actually already
available directly.