### PR TITLE
Add support for custom networks

### DIFF
--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -118,3 +118,32 @@ test-resources:
 ----
 
 Please refer to the <<configurationreference#io.micronaut.testresources.testcontainers.TestContainersConfiguration,configuration properties reference>> for details.
+
+== Advanced networking
+
+By default, each container is spawned in its own network.
+It is possible to let containers communicate with each other by declaring the network they belong to:
+
+[source,yaml]
+----
+test-resources:
+  containers:
+    producer:
+      image-name: alpine:3.14
+      command:
+        - /bin/sh
+        - "-c"
+        - "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done"
+      network: custom
+      network-aliases: bob
+      hostnames: producer.host
+    consumer:
+      image-name: alpine:3.14
+      command: top
+      network: custom
+      network-aliases: alice
+      hostnames: consumer.host
+----
+
+The `network` key is used to declare the network containers use.
+The `network-aliases` can be used to assign host names to the containers.

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
@@ -32,7 +32,7 @@ final class TestContainerMetadata {
 
     private final Map<String, String> rwFsBinds;
     private final Map<String, String> roFsBinds;
-    private final String command;
+    private final List<String> command;
     private final String workingDirectory;
     private final Map<String, String> env;
     private final Map<String, String> labels;
@@ -41,6 +41,8 @@ final class TestContainerMetadata {
     private final Long memory;
     private final Long swapMemory;
     private final Long sharedMemory;
+    private final String network;
+    private final Set<String> networkAliases;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     TestContainerMetadata(String id,
@@ -50,7 +52,7 @@ final class TestContainerMetadata {
                           Set<String> hostNames,
                           Map<String, String> rwFsBinds,
                           Map<String, String> roFsBinds,
-                          String command,
+                          List<String> command,
                           String workingDirectory,
                           Map<String, String> env,
                           Map<String, String> labels,
@@ -58,7 +60,7 @@ final class TestContainerMetadata {
                           List<CopyFileToContainer> fileCopies,
                           Long memory,
                           Long swapMemory,
-                          Long sharedMemory) {
+                          Long sharedMemory, String network, Set<String> networkAliases) {
         this.id = id;
         this.imageName = imageName;
         this.imageTag = imageTag;
@@ -75,6 +77,8 @@ final class TestContainerMetadata {
         this.memory = memory;
         this.swapMemory = swapMemory;
         this.sharedMemory = sharedMemory;
+        this.network = network;
+        this.networkAliases = networkAliases;
     }
 
     public String getId() {
@@ -105,8 +109,8 @@ final class TestContainerMetadata {
         return roFsBinds;
     }
 
-    public Optional<String> getCommand() {
-        return Optional.ofNullable(command);
+    public List<String> getCommand() {
+        return command;
     }
 
     public Optional<String> getWorkingDirectory() {
@@ -139,6 +143,14 @@ final class TestContainerMetadata {
 
     public Optional<Long> getSharedMemory() {
         return Optional.ofNullable(sharedMemory);
+    }
+
+    public Optional<String> getNetwork() {
+        return Optional.ofNullable(network);
+    }
+
+    public Set<String> getNetworkAliases() {
+        return networkAliases;
     }
 
     public static final class CopyFileToContainer {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
@@ -35,7 +35,7 @@ final class TestContainersConfiguration {
     private Map<String, Integer> exposedPorts;
     private Map<String, String> roFsBind;
     private Map<String, String> rwFsBind;
-    private String command;
+    private List<String> command;
     private String workingDirectory;
     private Map<String, String> env;
     private Map<String, String> labels;
@@ -44,6 +44,8 @@ final class TestContainersConfiguration {
     private String memory;
     private String swapMemory;
     private String sharedMemory;
+    private String network;
+    private List<String> networkAliases;
 
     /**
      * Returns the name of the docker image to use for the test resources container.
@@ -160,7 +162,7 @@ final class TestContainersConfiguration {
      * The container command.
      * @return the command
      */
-    public String getCommand() {
+    public List<String> getCommand() {
         return command;
     }
 
@@ -168,7 +170,7 @@ final class TestContainersConfiguration {
      * The container command, for example: "./gradlew run".
      * @param command the container command
      */
-    public void setCommand(String command) {
+    public void setCommand(List<String> command) {
         this.command = command;
     }
 
@@ -309,5 +311,39 @@ final class TestContainersConfiguration {
      */
     public void setSharedMemory(String sharedMemory) {
         this.sharedMemory = sharedMemory;
+    }
+
+    /**
+     * The network this container will belong to.
+     * @return the network.
+     */
+    public String getNetwork() {
+        return network;
+    }
+
+    /**
+     * The network this container will belong to.
+     * @param network the name of a network
+     */
+    public void setNetwork(String network) {
+        this.network = network;
+    }
+
+    /**
+     * The list of names this container will use in
+     * a custom network.
+     * @return the list of names
+     */
+    public List<String> getNetworkAliases() {
+        return networkAliases;
+    }
+
+    /**
+     * The list of names this container will use in
+     * a custom network.
+     * @param networkAliases the list of names
+     */
+    public void setNetworkAliases(List<String> networkAliases) {
+        this.networkAliases = networkAliases;
     }
 }

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
@@ -7,6 +7,7 @@ class AbstractTestContainersProviderTest extends Specification {
     def "test resources configuration is passed to the shouldAnswer and createContainer method"() {
         def provider = Mock(AbstractTestContainersProvider) {
             getDefaultImageName() >> 'my-image'
+            getSimpleName() >> 'test'
         }
 
         when:

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/CustomNetworkTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/CustomNetworkTest.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.testresources.testcontainers
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.core.Scope
+import spock.lang.Specification
+
+@MicronautTest
+class CustomNetworkTest extends Specification {
+    @Value("\${producer.host}")
+    String producerHostname
+
+    @Value("\${consumer.host}")
+    String consumerHostname
+
+    def "test containers on same network can talk to each other"() {
+        when:
+        // Please note that a user wouldn't be able to communicate
+        // directly to the container, it's internal API of the process
+        // which spawns the test containers, which happens to be the
+        // test process here
+        def networks = TestContainers.networks
+        def stdout = TestContainers.listAll()
+            .get(Scope.ROOT)
+            .find {
+                it.networkAliases.contains('alice')
+            }
+            ?.execInContainer("wget", "-O", "-", "http://bob:8080")
+            ?.stdout
+
+        then:
+        networks.size() == 1
+        networks['custom'].close()
+        "yay" == stdout
+    }
+}

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -123,7 +123,7 @@ class TestContainerMetadataSupportTest extends Specification {
         then:
         md.present
         md.get().with {
-            assert it.command.get() == "./gradlew run"
+            assert it.command == ["./gradlew run"]
         }
     }
 
@@ -300,6 +300,37 @@ class TestContainerMetadataSupportTest extends Specification {
         '2g'    | 2147483648L
         '2.5G'  | 2684354560L
     }
+
+    def "reads networks"() {
+        def config = """
+                containers:
+                    foo:
+                        network: first
+                        network-aliases: main
+                    bar:
+                        network: second
+                        network-aliases:
+                            - tarzan
+                            - jane
+        """
+
+        when:
+        def md1 = metadataFrom(config, "foo")
+        def md2 = metadataFrom(config, "bar")
+
+        then:
+        md1.present
+        md1.get().with {
+            assert it.network.get() == 'first'
+            assert it.networkAliases == ['main'] as Set
+        }
+        md2.present
+        md2.get().with {
+            assert it.network.get() == 'second'
+            assert it.networkAliases == ['tarzan', 'jane'] as Set
+        }
+    }
+
 
     private static Optional<TestContainerMetadata> metadataFrom(String yaml, String key) {
         def asMap = convert(yaml)

--- a/test-resources-testcontainers/src/test/resources/application-test.yml
+++ b/test-resources-testcontainers/src/test/resources/application-test.yml
@@ -6,3 +6,18 @@ test-resources:
         - smtp.host
       exposed-ports:
         - smtp.port: 25
+    producer:
+      image-name: alpine:3.14
+      command:
+        - /bin/sh
+        - "-c"
+        - "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done"
+      network: custom
+      network-aliases: bob
+      hostnames: producer.host
+    consumer:
+      image-name: alpine:3.14
+      command: top
+      network: custom
+      network-aliases: alice
+      hostnames: consumer.host


### PR DESCRIPTION
This commit adds support for declaring custom networks.
This makes it possible to have containers which directly
communicate with each other.

Fixes #31