### PR TITLE
Implement classpath volume mapping

### DIFF
--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
@@ -230,8 +230,8 @@ final class TestContainerMetadataSupport {
         if (!exposedPorts.isEmpty()) {
             container.withExposedPorts(exposedPorts.toArray(new Integer[0]));
         }
-        md.getRwFsBinds().forEach(container::withFileSystemBind);
-        md.getRoFsBinds().forEach((hostPath, containerPath) -> container.withFileSystemBind(hostPath, containerPath, BindMode.READ_ONLY));
+        md.getRwFsBinds().forEach((hostPath, containerPath) -> applyFsBind(container, hostPath, containerPath, BindMode.READ_WRITE));
+        md.getRoFsBinds().forEach((hostPath, containerPath) -> applyFsBind(container, hostPath, containerPath, BindMode.READ_ONLY));
         if (!md.getCommand().isEmpty()) {
             container.withCommand(md.getCommand().toArray(new String[0]));
         }
@@ -247,5 +247,13 @@ final class TestContainerMetadataSupport {
             container.withNetworkAliases(md.getNetworkAliases().toArray(new String[0]));
         }
         return container;
+    }
+
+    static void applyFsBind(GenericContainer<?> container, String hostPath, String containerPath, BindMode bindMode) {
+        if (hostPath.startsWith(CLASSPATH_PREFIX)) {
+            container.withClasspathResourceMapping(hostPath.substring(CLASSPATH_PREFIX.length()), containerPath, bindMode);
+        } else {
+            container.withFileSystemBind(hostPath, containerPath, bindMode);
+        }
     }
 }

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
@@ -132,7 +132,8 @@ final class TestContainersConfiguration {
 
     /**
      * A map where the key is a path in the host filesystem and the value is
-     * a path in the container filesystem.
+     * a path in the container filesystem. If the host path starts with "classpath:"
+     * then the path refers to an entry on classpath.
      * The path will be mounted read-only.
      * @param roFwBind the map of read-only fs bindings.
      */
@@ -150,7 +151,8 @@ final class TestContainersConfiguration {
 
     /**
      * A map where the key is a path in the host filesystem and the value is
-     * a path in the container filesystem.
+     * a path in the container filesystem. If the host path starts with "classpath:"
+     * then the path refers to an entry on classpath.
      * The path will be mounted read-write.
      * @param rwFsBind the map of read-write fs bindings.
      */

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -94,9 +94,11 @@ class TestContainerMetadataSupportTest extends Specification {
                     foo:
                         ro-fs-bind:
                           - /some/path: /some/container/path
+                          - classpath:/some/file.txt: /some/container/file.txt
                         rw-fs-bind:
                           - /some/other/path: /some/other/container/path
                           - "../relative": /absolute/path
+                          - classpath:/some/other-file.txt: /some/container/other-file.txt
         """
 
         when:
@@ -105,8 +107,8 @@ class TestContainerMetadataSupportTest extends Specification {
         then:
         md.present
         md.get().with {
-            assert it.roFsBinds == ['/some/path': '/some/container/path']
-            assert it.rwFsBinds == ['/some/other/path': '/some/other/container/path', '../relative': '/absolute/path']
+            assert it.roFsBinds == ['/some/path': '/some/container/path', 'classpath:/some/file.txt': '/some/container/file.txt']
+            assert it.rwFsBinds == ['/some/other/path': '/some/other/container/path', '../relative': '/absolute/path', 'classpath:/some/other-file.txt': '/some/container/other-file.txt']
         }
     }
 

--- a/test-resources-testcontainers/src/test/resources/some/other-file.txt
+++ b/test-resources-testcontainers/src/test/resources/some/other-file.txt
@@ -1,0 +1,1 @@
+for classpath volume mapping


### PR DESCRIPTION
This commit introduces the ability to mount classpath files in a container,
or mount classpath directories as volumes in a container.

Fixes #32