### PR TITLE
Tweak logging for Micronaut Test Resources server

### DIFF
--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/Application.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/Application.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
+import java.time.Duration;
 import java.util.Arrays;
 
 /**
@@ -36,6 +37,7 @@ public class Application {
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
 
     public static void main(String[] args) {
+        long sd = System.nanoTime();
         ApplicationContext context = Micronaut.run(Application.class, args);
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
@@ -51,6 +53,8 @@ public class Application {
                     throw new RuntimeException(e);
                 }
             });
+        long dur = System.nanoTime() - sd;
+        LOGGER.info("A Micronaut Test Resources server is listening on port {}, started in {}ms", context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
     }
 
     /**

--- a/test-resources-server/src/main/resources/logback.xml
+++ b/test-resources-server/src/main/resources/logback.xml
@@ -12,13 +12,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-   <logger name="io.micronaut.core.optim.StaticOptimizations" level="debug" additivity="false">
-        <appender-ref ref="STDOUT"/>
-    </logger>
-    <logger name="io.micronaut.aot" level="debug" additivity="false">
-        <appender-ref ref="STDOUT"/>
-    </logger>
-    <logger name="io.micronaut.core.io.service.SoftServiceLoader" level="debug" additivity="false">
+   <logger name="io.micronaut.runtime.Micronaut" level="warn" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 </configuration>


### PR DESCRIPTION
This commit tweaks the logging of the Micronaut Test Resources server,
to reduce confusion when a build starts: instead of seeing two traditional
Micronaut Application messages, the test resources server will not output
its own message, making it clearer that it's not the user application.