### PR TITLE
Update Kafka image to 7.0.4

### DIFF
--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class KafkaTestResourceProvider extends AbstractTestContainersProvider<KafkaContainer> {
 
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
-    public static final String DEFAULT_IMAGE = "confluentinc/cp-kafka:6.2.1";
+    public static final String DEFAULT_IMAGE = "confluentinc/cp-kafka:7.0.4";
 
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {


### PR DESCRIPTION
As of v 7.0.4, Confluent are generating ARM versions for their Kafka image 🎉 

https://github.com/confluentinc/kafka-images/blame/5ba80298dcd8d4707555036917ee805b82ed6b87/Jenkinsfile#L20

This change moves from `6.2.1` to `7.0.4` (which seems to be the first one to support it).

On an M1 mac, the startup time is 3s with 7.0.4 and 26s with 6.2.1