### PR TITLE
Add support for resolving R2DBC pool

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ reactive-mariadb = { module = "org.mariadb:r2dbc-mariadb", version = "" }
 reactive-mssql = { module = "io.r2dbc:r2dbc-mssql", version = "" }
 reactive-mysql = { module = "dev.miku:r2dbc-mysql", version = "" }
 reactive-oracle-xe = { module = "com.oracle.database.r2dbc:oracle-r2dbc", version = "" }
+reactive-pool = { module = "io.r2dbc:r2dbc-pool", version = "" }
 reactive-postgres = { module = "org.postgresql:r2dbc-postgresql", version = "" }
 
 #

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,8 @@ def r2dbcModules = [
         'mysql',
         'oracle-xe',
         'postgresql',
-        'mssql'
+        'mssql',
+        'pool'
 ]
 
 include 'test-resources-bom'

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -73,6 +73,7 @@ public final class TestResourcesClasspath implements KnownModules {
         ORACLE_DRIVER_11
     );
     private static final String REACTIVE_ORACLE_DRIVER = "com.oracle.database.r2dbc:oracle-r2dbc";
+    private static final String REACTIVE_POOL_DRIVER = "io.r2dbc:r2dbc-pool";
 
     private static final String ELASTICSEARCH_MODULE = "elasticsearch";
     private static final String KAFKA_MODULE = "kafka";
@@ -92,6 +93,7 @@ public final class TestResourcesClasspath implements KnownModules {
     private static final String MSSQL_MODULE = "jdbc-mssql";
     private static final String REACTIVE_MSSQL_MODULE = "r2dbc-mssql";
     private static final String HASHICORP_VAULT_MODULE = "hashicorp-vault";
+    private static final String REACTIVE_POOL_MODULE = "r2dbc-pool";
 
     private TestResourcesClasspath() {
 
@@ -136,6 +138,7 @@ public final class TestResourcesClasspath implements KnownModules {
             m.onArtifact(MICRONAUT_RABBITMQ, RABBITMQ_MODULE);
             m.onArtifact(MICRONAUT_REDIS, REDIS_MODULE);
             m.onArtifact(MICRONAUT_DISCOVERY_CLIENT, HASHICORP_VAULT_MODULE);
+            m.onModule(REACTIVE_POOL_DRIVER, REACTIVE_POOL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_NEO4J), deps -> true, NEO4J_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(artifactEquals(MYSQL_CONNECTOR_JAVA)), MYSQL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(POSTGRESQL_DRIVER)), POSTGRESQL_MODULE);
@@ -159,7 +162,8 @@ public final class TestResourcesClasspath implements KnownModules {
                 REACTIVE_POSTGRESQL_DRIVER,
                 REACTIVE_ORACLE_DRIVER,
                 MSSQL_DRIVER,
-                REACTIVE_MSSQL_DRIVER
+                REACTIVE_MSSQL_DRIVER,
+                REACTIVE_POOL_DRIVER
             );
         });
     }
@@ -206,8 +210,18 @@ public final class TestResourcesClasspath implements KnownModules {
             onArtifact(name, testResource(moduleId));
         }
 
+        public void onModule(String module, String moduleId) {
+            onModule(module, testResource(moduleId));
+        }
+
         public void onArtifact(String name, Supplier<Stream<MavenDependency>> supplier) {
             if (input.getArtifact().equals(name)) {
+                output = Stream.concat(output, supplier.get());
+            }
+        }
+
+        public void onModule(String module, Supplier<Stream<MavenDependency>> supplier) {
+            if (input.getModule().equals(module)) {
                 output = Stream.concat(output, supplier.get());
             }
         }

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -46,26 +46,28 @@ class TestResourcesClasspathTest extends Specification {
         inferredClasspathEquals(
                 'io.micronaut.testresources:micronaut-test-resources-server:1.0.34',
                 'io.micronaut.testresources:micronaut-test-resources-testcontainers:1.0.34',
-                "$driver:1.0"
+                "$driver:1.0",
+                *extra
         )
 
         where:
-        driver << [
-                'mysql:mysql-connector-java',
-                'org.postgresql:postgresql',
-                'org.mariadb.jdbc:mariadb-java-client',
-                'com.oracle.database.jdbc:ojdbc5',
-                'com.oracle.database.jdbc:ojdbc6',
-                'com.oracle.database.jdbc:ojdbc8',
-                'com.oracle.database.jdbc:ojdbc10',
-                'com.oracle.database.jdbc:ojdbc11',
-                'dev.miku:r2dbc-mysql',
-                'org.mariadb:r2dbc-mariadb',
-                'org.postgresql:r2dbc-postgresql',
-                'com.oracle.database.r2dbc:oracle-r2dbc',
-                'com.microsoft.sqlserver:mssql-jdbc',
-                'io.r2dbc:r2dbc-mssql'
-        ]
+        driver                                   | extra
+        'mysql:mysql-connector-java'             | []
+        'org.postgresql:postgresql'              | []
+        'org.mariadb.jdbc:mariadb-java-client'   | []
+        'com.oracle.database.jdbc:ojdbc5'        | []
+        'com.oracle.database.jdbc:ojdbc6'        | []
+        'com.oracle.database.jdbc:ojdbc8'        | []
+        'com.oracle.database.jdbc:ojdbc10'       | []
+        'com.oracle.database.jdbc:ojdbc11'       | []
+        'dev.miku:r2dbc-mysql'                   | []
+        'org.mariadb:r2dbc-mariadb'              | []
+        'org.postgresql:r2dbc-postgresql'        | []
+        'com.oracle.database.r2dbc:oracle-r2dbc' | []
+        'com.microsoft.sqlserver:mssql-jdbc'     | []
+        'io.r2dbc:r2dbc-mssql'                   | []
+        'io.r2dbc:r2dbc-pool'                    | ['io.micronaut.testresources:micronaut-test-resources-r2dbc-pool:1.0.34']
+
     }
 
     def "infers Micronaut Data module"() {
@@ -129,6 +131,7 @@ class TestResourcesClasspathTest extends Specification {
         'org.postgresql:r2dbc-postgresql'        | 'postgresql'
         'com.oracle.database.r2dbc:oracle-r2dbc' | 'oracle-xe'
         'io.r2dbc:r2dbc-mssql'                   | 'mssql'
+        'io.r2dbc:r2dbc-pool'                    | 'pool'
     }
 
     private void inferredClasspathEquals(String... dependencies) {

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Provides constants and helper methods used by several test resources.
+ */
+public class R2dbcSupport {
+    public static final String DATASOURCES = "datasources";
+    public static final String R2DBC_PREFIX = "r2dbc.";
+    public static final String R2DBC_DATASOURCES = R2DBC_PREFIX + DATASOURCES;
+    public static final String DIALECT = "dialect";
+    public static final String DRIVER = "driverClassName";
+    public static final String TYPE = "db-type";
+
+    public static final List<String> REQUIRED_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+        DIALECT,
+        DRIVER,
+        TYPE
+    ));
+    public static final List<String> REQUIRED_PROPERTY_ENTRIES_LIST = Collections.unmodifiableList(Arrays.asList(R2DBC_DATASOURCES, DATASOURCES));
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(R2dbcSupport.class);
+
+    private R2dbcSupport() {
+
+    }
+
+    public static List<String> findRequiredProperties(String expression) {
+        if (expression.startsWith(R2dbcSupport.R2DBC_DATASOURCES)) {
+            // If we resolve r2dbc.datasources.default.url, we will
+            // try to find a regular datasource with the same name
+            // and reuse it if it exists.
+            String regularDatasource = R2dbcSupport.removeR2dbPrefixFrom(expression);
+            String datasourceName = R2dbcSupport.datasourceNameFrom(regularDatasource);
+            List<String> requiredProperties = Stream.concat(
+                Stream.of(regularDatasource),
+                REQUIRED_PROPERTIES.stream().map(k -> R2dbcSupport.r2dbDatasourceExpressionOf(datasourceName, k))
+            ).collect(Collectors.toList());
+
+            LOGGER.debug("Required properties: {}", requiredProperties);
+            return requiredProperties;
+        }
+        return Collections.emptyList();
+    }
+
+    public static List<String> findResolvableProperties(Map<String, Collection<String>> propertyEntries, List<String> resolvableKeys) {
+        Collection<String> r2dbcDatasources = propertyEntries.getOrDefault(R2dbcSupport.R2DBC_DATASOURCES, Collections.emptyList());
+        Collection<String> datasources = propertyEntries.getOrDefault(R2dbcSupport.DATASOURCES, Collections.emptyList());
+        List<String> properties = Stream.concat(r2dbcDatasources.stream(), datasources.stream())
+            .flatMap(name -> resolvableKeys.stream().map(key -> R2dbcSupport.R2DBC_DATASOURCES + "." + name + "." + key))
+            .distinct()
+            .collect(Collectors.toList());
+        LOGGER.debug("Resolvable properties: {}", properties);
+        return properties;
+    }
+
+    public static String removeR2dbPrefixFrom(String propertyName) {
+        return propertyName.substring(R2DBC_PREFIX.length());
+    }
+
+    public static String datasourceNameFrom(String expression) {
+        String remainder = expression.substring(1 + expression.indexOf('.'));
+        return remainder.substring(0, remainder.indexOf("."));
+    }
+
+    public static String r2dbDatasourceExpressionOf(String datasource, String property) {
+        return R2DBC_DATASOURCES + "." + datasource + "." + property;
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 /**
  * Provides constants and helper methods used by several test resources.
  */
-public class R2dbcSupport {
+public final class R2dbcSupport {
     public static final String DATASOURCES = "datasources";
     public static final String R2DBC_PREFIX = "r2dbc.";
     public static final String R2DBC_DATASOURCES = R2DBC_PREFIX + DATASOURCES;

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
@@ -9,6 +9,6 @@ Provides support for R2DBC pool resources.
 dependencies {
     testRuntimeOnly(project(":test-resources-r2dbc-postgresql"))
     testRuntimeOnly(libs.reactive.postgres)
-    testRuntimeOnly(libs.reactive.pool)
+    testImplementation(libs.reactive.pool)
     testRuntimeOnly(libs.postgres)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'io.micronaut.build.internal.r2dbc-module'
+}
+
+description = """
+Provides support for R2DBC pool resources.
+"""
+
+dependencies {
+    testRuntimeOnly(project(":test-resources-r2dbc-postgresql"))
+    testRuntimeOnly(libs.reactive.postgres)
+    testRuntimeOnly(libs.reactive.pool)
+    testRuntimeOnly(libs.postgres)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/java/io/micronaut/testresources/r2dbc/pool/R2DBCPoolTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/java/io/micronaut/testresources/r2dbc/pool/R2DBCPoolTestResourceProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.r2dbc.pool;
+
+import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.r2dbc.core.R2dbcSupport;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider for configuring the R2DBC pool.
+ */
+public class R2DBCPoolTestResourceProvider implements TestResourcesResolver {
+
+    private static final String PROTOCOL = "options.protocol";
+    private static final String DRIVER = "options.driver";
+    private static final List<String> RESOLVABLE_KEYS = Collections.unmodifiableList(Arrays.asList(
+        PROTOCOL,
+        DRIVER
+    ));
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return R2dbcSupport.REQUIRED_PROPERTY_ENTRIES_LIST;
+    }
+
+    @Override
+    public List<String> getRequiredProperties(String expression) {
+        return R2dbcSupport.findRequiredProperties(expression);
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return R2dbcSupport.findResolvableProperties(propertyEntries, RESOLVABLE_KEYS);
+    }
+
+    @Override
+    public Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
+        if (!propertyName.startsWith(R2dbcSupport.R2DBC_PREFIX)) {
+            return Optional.empty();
+        }
+        String baseDatasourceExpression = R2dbcSupport.removeR2dbPrefixFrom(propertyName);
+        String datasource = R2dbcSupport.datasourceNameFrom(baseDatasourceExpression);
+        if (R2dbcSupport.r2dbDatasourceExpressionOf(datasource, PROTOCOL).equals(propertyName)) {
+            Object dialect = properties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.DIALECT));
+            if (dialect != null) {
+                return Optional.of(String.valueOf(dialect).replace("_", "").toLowerCase(Locale.ROOT));
+            }
+        } else if (R2dbcSupport.r2dbDatasourceExpressionOf(datasource, DRIVER).equals(propertyName)) {
+            return Optional.of("pool");
+        }
+        return Optional.empty();
+    }
+
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.pool.R2DBCPoolTestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.pool
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.POSTGRES)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/StandaloneStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/StandaloneStartPostgreSQLTest.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.testresources.r2dbc.pool
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["standalone"] )
+class StandaloneStartPostgreSQLTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    @Value('${r2dbc.datasources.default.options.protocol}')
+    String protocol
+
+    @Value('${r2dbc.datasources.default.options.driver}')
+    String driver
+
+    def "starts a reactive PostgreSQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        protocol == 'postgres'
+        driver == 'pool'
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/StandaloneStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/StandaloneStartPostgreSQLTest.groovy
@@ -4,6 +4,8 @@ import io.micronaut.context.annotation.Value
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.jdbc.AbstractJDBCSpec
 import io.micronaut.testresources.jdbc.Book
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.spi.ConnectionFactory
 import jakarta.inject.Inject
 
 @MicronautTest(environments = ["standalone"] )
@@ -17,6 +19,9 @@ class StandaloneStartPostgreSQLTest extends AbstractJDBCSpec {
     @Value('${r2dbc.datasources.default.options.driver}')
     String driver
 
+    @Inject
+    ConnectionFactory connectionFactory
+
     def "starts a reactive PostgreSQL container"() {
         def book = new Book(title: "Micronaut for Spring developers")
         repository.save(book).block()
@@ -27,6 +32,7 @@ class StandaloneStartPostgreSQLTest extends AbstractJDBCSpec {
         then:
         protocol == 'postgres'
         driver == 'pool'
+        connectionFactory instanceof ConnectionPool
         books.size() == 1
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/WithJdbcStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/WithJdbcStartPostgreSQLTest.groovy
@@ -4,6 +4,8 @@ import io.micronaut.context.annotation.Value
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.jdbc.AbstractJDBCSpec
 import io.micronaut.testresources.jdbc.Book
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.spi.ConnectionFactory
 import jakarta.inject.Inject
 
 @MicronautTest(environments = ["jdbc"] )
@@ -18,6 +20,9 @@ class WithJdbcStartPostgreSQLTest extends AbstractJDBCSpec {
     @Value('${r2dbc.datasources.default.options.driver}')
     String driver
 
+    @Inject
+    ConnectionFactory connectionFactory
+
     def "starts a reactive PostgreSQL container"() {
         def book = new Book(title: "Micronaut for Spring developers")
         repository.save(book).block()
@@ -28,6 +33,7 @@ class WithJdbcStartPostgreSQLTest extends AbstractJDBCSpec {
         then:
         protocol == 'postgres'
         driver == 'pool'
+        connectionFactory instanceof ConnectionPool
         books.size() == 1
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/WithJdbcStartPostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/WithJdbcStartPostgreSQLTest.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.testresources.r2dbc.pool
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["jdbc"] )
+class WithJdbcStartPostgreSQLTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    @Value('${r2dbc.datasources.default.options.protocol}')
+    String protocol
+
+    @Value('${r2dbc.datasources.default.options.driver}')
+    String driver
+
+    def "starts a reactive PostgreSQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        protocol == 'postgres'
+        driver == 'pool'
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+datasources:
+  default:
+    driverClassName: org.postgresql.Driver
+    schema-generate: CREATE_DROP
+    dialect: POSTGRES
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: POSTGRES

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-standalone.yml
@@ -1,0 +1,5 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: POSTGRES

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>


### PR DESCRIPTION
This commit introduces an additional resolver for R2DBC, which would configure
the R2DBC pool properties if the `io.r2dbc:r2dbc-pool` dependency is present
on classpath.

Fixes #41