### PR TITLE
Remove Maven support from docs

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -13,14 +13,6 @@ plugins {
 
 Please refer to the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Gradle plugin documentation] for more information about configuring the test resources plugin.
 
-For Maven, you can enable test resources support by adding the following configuration:
+Maven support is coming soon.
 
-.Maven
-[source,xml,subs="verbatim,attributes"]
-----
-<configuration>
-    <TODO/>
-</configuration>
-----
-
-Please refer to the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Maven plugin documentation] for more information about configuring the test resources plugin.
+Please refer to the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Maven plugin documentation] for more information.


### PR DESCRIPTION
As discussed during our coordination meeting, this removes the mention to the Maven plugin.
This is the last item before releasing 1.0.0, unless @alvarosanchez sees a blocker.