### PR TITLE
Align MsSQL version with TestContainers in starter

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -3,6 +3,7 @@ The following properties will automatically be set when using a JDBC database:
 - `datasources.*.url`
 - `datasources.*.username`
 - `datasources.*.password`
+- `datasources.*.dialect`
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -31,3 +31,14 @@ test-resources:
 ----
 
 The `db-type` property value can be found in the table above.
+
+[NOTE]
+====
+Using the Microsoft SQL Server container will require you to accept its license. In order to do this, you must set the `test-resources.containers.mssql.accept-license` property to true:
+```yaml
+test-resources:
+  containers:
+    mssql:
+      accept-license: true
+```
+====

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -18,6 +18,7 @@ package io.micronaut.testresources.mssql;
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.LicenseAcceptance;
 
 import java.util.Map;
 
@@ -26,6 +27,8 @@ import java.util.Map;
  */
 public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MSSQLServerContainer<?>> {
 
+    public static final String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
+
     @Override
     protected String getSimpleName() {
         return "mssql";
@@ -33,12 +36,28 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
+        return DEFAULT_IMAGE_NAME;
     }
 
     @Override
     protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
-        return new MSSQLServerContainer<>(imageName);
+        return createMSSQLContainer(imageName, getSimpleName(), testResourcesConfiguration);
+    }
+
+    public static MSSQLServerContainer<?> createMSSQLContainer(DockerImageName imageName, String simpleName, Map<String, Object> testResourcesConfiguration) {
+        MSSQLServerContainer<?> container = new MSSQLServerContainer<>(imageName);
+        String licenseKey = "containers." + simpleName + ".accept-license";
+        Boolean acceptLicense = (Boolean) testResourcesConfiguration.get(licenseKey);
+        if (Boolean.TRUE.equals(acceptLicense)) {
+            container.acceptLicense();
+        } else {
+            try {
+                LicenseAcceptance.assertLicenseAccepted(imageName.toString());
+            } catch (IllegalStateException ex) {
+                throw new IllegalStateException("You must set the property 'test-resources." + licenseKey + "' to true in order to use a Microsoft SQL Server test container", ex);
+            }
+        }
+        return container;
     }
 
 }

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -33,7 +33,7 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2017-CU12";
+        return "mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04";
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -33,7 +33,7 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04";
+        return "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/test/resources/container-license-acceptance.txt
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/test/resources/container-license-acceptance.txt
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04
+mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
@@ -8,7 +8,7 @@ Provides support for MS SQL Server R2DBC test resources.
 
 dependencies {
     implementation(libs.testcontainers.mssql)
-    runtimeOnly(project(":test-resources-jdbc-mssql"))
+    implementation(project(":test-resources-jdbc-mssql"))
 
     testRuntimeOnly(libs.reactive.mssql)
     testRuntimeOnly(libs.mssql)

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.r2dbc.mssql;
 
+import io.micronaut.testresources.mssql.MSSQLTestResourceProvider;
 import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
@@ -37,7 +38,7 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
+        return MSSQLTestResourceProvider.DEFAULT_IMAGE_NAME;
     }
 
     @Override
@@ -51,7 +52,7 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
 
     @Override
     protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
-        return new MSSQLServerContainer<>(imageName);
+        return MSSQLTestResourceProvider.createMSSQLContainer(imageName, getSimpleName(), testResourcesConfiguration);
     }
 
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
@@ -37,7 +37,7 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04";
+        return "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
@@ -37,7 +37,7 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
 
     @Override
     protected String getDefaultImageName() {
-        return "mcr.microsoft.com/mssql/server:2017-CU12";
+        return "mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04";
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/application-jdbc.yml
@@ -1,3 +1,4 @@
+test-resources.containers.mssql.accept-license: true
 datasources:
   default:
     db-type: mssql

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/application-standalone.yml
@@ -1,3 +1,4 @@
+test-resources.containers.mssql.accept-license: true
 r2dbc:
   datasources:
     default:

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,0 @@
-mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU4-ubuntu-16.04
+mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04


### PR DESCRIPTION
In the starter project, if a user pulls in the TestContainers feature, they get the URL and EULA for `2019-CU4-ubuntu-16.04`

https://github.com/micronaut-projects/micronaut-starter/blob/f7902691bb355c8a4f923dce086b113c846b8346/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java#L64
https://github.com/micronaut-projects/micronaut-starter/blob/f7902691bb355c8a4f923dce086b113c846b8346/starter-core/src/main/java/io/micronaut/starter/feature/database/TestContainers.java#L148

In the test-resources spike branch of starter, we're seeing weird results if the user now pulls in TestContainers as the feature
writes the EULA for `2019-CU4-ubuntu-16.04` but then the version TestResources starts is `2017-CU2`.

This PR aligns these versions so they are at least the same.

However, it raises 2 questions:

1. Should we upgrade to a later CU?
2. What should actually happen if a user pulls in TestResources?

For 2, they have TestResources implicitly so they get no jdbc/r2dbc URL, but then we're writing EULA files. We need to think
about what a user would expect from pulling in both of these features.