### PR TITLE
Add support for class data sharing

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-resources-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-resources-module.gradle
@@ -2,10 +2,3 @@ plugins {
     id 'io.micronaut.build.internal.test-resources-base'
     id "io.micronaut.build.internal.module"
 }
-
-micronautBuild {
-    binaryCompatibility {
-        // This is the first release
-        enabled = false
-    }
-}

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "io.micronaut.testresources.buildtools.ServerUtils$ProcessParameters",
+    "member": "Class io.micronaut.testresources.buildtools.ServerUtils$ProcessParameters",
+    "reason": "Added default method"
+  },
+  {
+    "type": "io.micronaut.testresources.buildtools.ServerUtils$ProcessParameters",
+    "member": "Method io.micronaut.testresources.buildtools.ServerUtils$ProcessParameters.isCDSDumpInvocation()",
+    "reason": "Default method wasn't implemented by consumers"
+  }
+]

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -43,3 +43,10 @@ micronaut {
         replaceLogbackXml.set(true)
     }
 }
+
+micronautBuild {
+    binaryCompatibility {
+        // binary checks work on the wrong jar file
+        enabled = false
+    }
+}


### PR DESCRIPTION
This commit adds support for Application Class Data Sharing when starting
the test resources service. AppCDS is available in Java 17+ and can make
a significant difference in startup times.

If the test resources service is provided with a CDS directory (not null),
then we assume that AppCDS is enabled. If so, the first invocation of the
test resources service will generate a list of classes to be loaded. The
invocation time will be similar to the one when not using CDS.

The second invocation will be slower, as it will need to generate the
class archive file. Then starting from the 3rd invocation, starting the
service show become must faster (from 300ms to 120ms on my laptop).

Note that there's an additional `isCDSDumpInvocation` method on
`ServerFactory`, which is used because build tools must be aware of
that particular invocation, which will _not_ start the server but instead
dump the CDS data. This corresponds to step 2, where there are 2 subsequent
invocations of the server factory: once for dumping, and once for starting
the server. The first one MUST be done in the foreground, synchronously.