### PR TITLE
Proof of concept for Localstack support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,9 @@ reactive-oracle-xe = { module = "com.oracle.database.r2dbc:oracle-r2dbc", versio
 reactive-pool = { module = "io.r2dbc:r2dbc-pool", version = "" }
 reactive-postgres = { module = "org.postgresql:r2dbc-postgresql", version = "" }
 
+amazon-awssdk-v1-dynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version.ref = "amazon-awssdk-v1"}
 amazon-awssdk-v1-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "amazon-awssdk-v1"}
+amazon-awssdk-v2-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "amazon-awssdk-v2"}
 amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2"}
 
 #

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ micronaut = "3.5.1"
 micronaut-docs = "2.0.0"
 micronaut-test = "3.1.1"
 micronaut-gradle-plugin = "3.5.1"
+
+amazon-awssdk-v1 = "1.12.274"
+amazon-awssdk-v2 = "2.17.245"
 groovy = "3.0.10"
 spock = "2.1-groovy-3.0"
 
@@ -34,6 +37,7 @@ testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", ve
 testcontainers-jdbc = { module = "org.testcontainers:jdbc", version = "" }
 testcontainers-hivemq = { module = "org.testcontainers:hivemq", version = "" }
 testcontainers-kafka = { module = "org.testcontainers:kafka", version = "" }
+testcontainers-localstack = { module = "org.testcontainers:localstack", version = "" }
 testcontainers-mariadb = { module = "org.testcontainers:mariadb", version = "" }
 testcontainers-mongodb = { module = "org.testcontainers:mongodb", version = "" }
 testcontainers-mssql = { module = "org.testcontainers:mssqlserver", version = "" }
@@ -58,6 +62,9 @@ reactive-mysql = { module = "dev.miku:r2dbc-mysql", version = "" }
 reactive-oracle-xe = { module = "com.oracle.database.r2dbc:oracle-r2dbc", version = "" }
 reactive-pool = { module = "io.r2dbc:r2dbc-pool", version = "" }
 reactive-postgres = { module = "org.postgresql:r2dbc-postgresql", version = "" }
+
+amazon-awssdk-v1-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "amazon-awssdk-v1"}
+amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2"}
 
 #
 # Managed dependencies appear in the BOM

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,8 @@ def r2dbcModules = [
 
 def localstackModules = [
         'core',
-        's3'
+        's3',
+        'dynamodb'
 ]
 
 include 'test-resources-bom'

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,11 @@ def r2dbcModules = [
         'pool'
 ]
 
+def localstackModules = [
+        'core',
+        's3'
+]
+
 include 'test-resources-bom'
 include 'test-resources-build-tools'
 include 'test-resources-core'
@@ -54,6 +59,11 @@ r2dbcModules.each {
     String projectName = "test-resources-r2dbc-$it"
     include projectName
     project(":test-resources-r2dbc-$it").projectDir = file("test-resources-r2dbc/$projectName")
+}
+localstackModules.each {
+    String projectName = "test-resources-localstack-$it"
+    include projectName
+    project(":test-resources-localstack-$it").projectDir = file("test-resources-localstack/$projectName")
 }
 
 micronautBuild {

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+    id 'java-test-fixtures'
+}
+
+description = """
+Provides core support for launching Localstack test containers.
+"""
+
+dependencies {
+    api(libs.testcontainers.localstack)
+    testFixturesApi(platform(mn.micronaut.bom))
+    testFixturesImplementation(mn.groovy)
+    testFixturesImplementation(mn.spock)
+    testFixturesApi(testFixtures(project(":test-resources-testcontainers"))) {
+        because "exposes AbstractTestContainersSpec"
+    }
+}
+
+// TODO: enable once first release of Localstack support is available
+micronautBuild.binaryCompatibility.enabled = false

--- a/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/aws/localstack/LocalStackService.java
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/aws/localstack/LocalStackService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws.localstack;
+
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for localstack service loading.
+ */
+public interface LocalStackService {
+    /**
+     * Returns the service kind.
+     * @return the service kind.
+     */
+    LocalStackContainer.Service getServiceKind();
+
+    /**
+     * Returns the list of properties that this service
+     * can configure.
+     * @return the list of supported properties
+     */
+    List<String> getResolvableProperties();
+
+    /**
+     * Resolves a property.
+     * @param propertyName the property to resolve
+     * @param container the localstack container
+     * @return the resolved property, if available
+     */
+    Optional<String> resolveProperty(String propertyName, LocalStackContainer container);
+}

--- a/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/aws/localstack/LocalStackTestResourceProvider.java
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/aws/localstack/LocalStackTestResourceProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws.localstack;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A test resource provider which will spawn LocalStack test containers.
+ */
+public class LocalStackTestResourceProvider extends AbstractTestContainersProvider<LocalStackContainer> {
+
+    private static final String DEFAULT_IMAGE = "localstack/localstack";
+    private static final String NAME = "localstack";
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_KEY = "aws.secretKey";
+    private static final String AWS_REGION = "aws.region";
+
+    private static final List<String> COMMON_PROPERTIES;
+
+    private static final Map<LocalStackContainer.Service, List<String>> RESOLVABLE_PROPERTIES;
+    private static final Set<String> ALL_SUPPORTED_KEYS;
+    private static final List<LocalStackService> SERVICES;
+    private static final Map<String, LocalStackService> PROPERTY_TO_SERVICE;
+
+    static {
+        SERVICES = StreamSupport.stream(ServiceLoader.load(LocalStackService.class).spliterator(), false)
+                .collect(Collectors.toList());
+        Map<LocalStackContainer.Service, List<String>> resolvableProperties = new EnumMap<>(LocalStackContainer.Service.class);
+        Map<String, LocalStackService> propertyToService = new HashMap<>();
+        COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            AWS_ACCESS_KEY_ID,
+            AWS_SECRET_KEY,
+            AWS_REGION
+        ));
+        for (LocalStackService localStackService : SERVICES) {
+            List<String> supportedProperties = localStackService.getResolvableProperties();
+            resolvableProperties.put(localStackService.getServiceKind(), supportedProperties);
+            for (String supportedProperty : supportedProperties) {
+                propertyToService.put(supportedProperty, localStackService);
+            }
+        }
+        RESOLVABLE_PROPERTIES = Collections.unmodifiableMap(resolvableProperties);
+        ALL_SUPPORTED_KEYS = Stream.concat(
+            COMMON_PROPERTIES.stream(),
+            RESOLVABLE_PROPERTIES.values().stream().flatMap(Collection::stream)
+        ).collect(Collectors.toSet());
+        PROPERTY_TO_SERVICE = Collections.unmodifiableMap(propertyToService);
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return Stream.concat(
+                SERVICES.stream().flatMap(service -> service.getResolvableProperties().stream()),
+                COMMON_PROPERTIES.stream()
+            ).distinct()
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected LocalStackContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
+        LocalStackContainer localStackContainer = new LocalStackContainer(imageName);
+        localStackContainer.withServices(SERVICES.stream().map(LocalStackService::getServiceKind).toArray(LocalStackContainer.Service[]::new));
+        return localStackContainer;
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfiguration) {
+        return ALL_SUPPORTED_KEYS.contains(propertyName);
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
+        switch (propertyName) {
+            case AWS_ACCESS_KEY_ID:
+                return Optional.of(container.getAccessKey());
+            case AWS_SECRET_KEY:
+                return Optional.of(container.getSecretKey());
+            case AWS_REGION:
+                return Optional.of(container.getRegion());
+            default:
+                LocalStackService service = PROPERTY_TO_SERVICE.get(propertyName);
+                if (service != null) {
+                    return service.resolveProperty(propertyName, container);
+                }
+        }
+        return Optional.empty();
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-core/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.aws.localstack.LocalStackTestResourceProvider

--- a/test-resources-localstack/test-resources-localstack-core/src/testFixtures/groovy/io/micronaut/testresources/aws/localstack/AbstractLocalStackSpec.groovy
+++ b/test-resources-localstack/test-resources-localstack-core/src/testFixtures/groovy/io/micronaut/testresources/aws/localstack/AbstractLocalStackSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.testresources.aws.localstack
+
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+
+abstract class AbstractLocalStackSpec extends AbstractTestContainersSpec {
+
+    @Override
+    String getScopeName() {
+        'localstack'
+    }
+
+    @Override
+    String getImageName() {
+        'localstack'
+    }
+
+}

--- a/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+description = """
+Provides support for Localstack DynamoDB.
+"""
+
+dependencies {
+    implementation(project(":test-resources-localstack-core"))
+    runtimeOnly(libs.amazon.awssdk.v1.dynamodb) {
+        because "Localstack requires the AWS SDK in version 1 at runtime"
+    }
+    testImplementation(testFixtures(project(":test-resources-localstack-core")))
+    testImplementation(libs.amazon.awssdk.v2.dynamodb)
+}
+
+// TODO: enable once first release of Localstack support is available
+micronautBuild.binaryCompatibility.enabled = false

--- a/test-resources-localstack/test-resources-localstack-dynamodb/src/main/java/io/micronaut/testresources/aws/localstack/dynamodb/LocalStackDynamoDBService.java
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/src/main/java/io/micronaut/testresources/aws/localstack/dynamodb/LocalStackDynamoDBService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws.localstack.dynamodb;
+
+import io.micronaut.testresources.aws.localstack.LocalStackService;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Localstack DynamoDB.
+ */
+public class LocalStackDynamoDBService implements LocalStackService {
+
+    private static final String AWS_DYNAMODB_ENDPOINT_OVERRIDE = "aws.dynamodb.endpoint-override";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
+        if (AWS_DYNAMODB_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpointOverride(LocalStackContainer.Service.DYNAMODB).toString());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public LocalStackContainer.Service getServiceKind() {
+        return LocalStackContainer.Service.DYNAMODB;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_DYNAMODB_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-dynamodb/src/main/resources/META-INF/services/io.micronaut.testresources.aws.localstack.LocalStackService
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/src/main/resources/META-INF/services/io.micronaut.testresources.aws.localstack.LocalStackService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.aws.localstack.dynamodb.LocalStackDynamoDBService

--- a/test-resources-localstack/test-resources-localstack-dynamodb/src/test/groovy/io/micronaut/testresources/aws/localstack/dynamodb/LocalStackDynamoDBTest.groovy
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/src/test/groovy/io/micronaut/testresources/aws/localstack/dynamodb/LocalStackDynamoDBTest.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.testresources.aws.localstack.dynamodb
+
+
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.aws.localstack.AbstractLocalStackSpec
+import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+
+@MicronautTest
+class LocalStackDynamoDBTest extends AbstractLocalStackSpec {
+
+    @Inject
+    DynamoDBConfig dynamoConfig
+
+    def "automatically starts an DynamoDB container"() {
+        given:
+        def client = buildClient()
+        client.createTable {
+            it.tableName('test-table')
+            it.keySchema(KeySchemaElement.builder()
+                    .attributeName('id')
+                    .keyType(KeyType.HASH)
+                    .build()
+            )
+            it.attributeDefinitions(AttributeDefinition.builder()
+                    .attributeName('name')
+                    .attributeType(ScalarAttributeType.S)
+                    .build()
+            )
+            it.attributeDefinitions(AttributeDefinition.builder()
+                    .attributeName('id')
+                    .attributeType(ScalarAttributeType.S)
+                    .build()
+            )
+            it.provisionedThroughput {
+                it.readCapacityUnits(1L)
+                it.writeCapacityUnits(1L)
+            }
+        }
+
+        when:
+        client.putItem {
+            it.tableName("test-table")
+            it.item(['id': AttributeValue.builder().s("1").build(), 'name': AttributeValue.builder().s("Cédric").build()])
+        }
+
+        then:
+        def read = client.getItem {
+            it.tableName("test-table")
+            it.key(['id': AttributeValue.builder().s("1").build()])
+        }
+        read.item().get('name').s() == 'Cédric'
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private DynamoDbClient buildClient() {
+        DynamoDbClient.builder()
+                .endpointOverride(new URI(dynamoConfig.dynamodb.endpointOverride))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(dynamoConfig.accessKeyId, dynamoConfig.secretKey)
+                        )
+                )
+                .region(Region.of(dynamoConfig.region))
+                .build()
+    }
+
+    @ConfigurationProperties("aws")
+    static class DynamoDBConfig {
+        String accessKeyId
+        String secretKey
+        String region
+
+        @ConfigurationBuilder(configurationPrefix = "dynamodb")
+        final Dynamo dynamodb = new Dynamo()
+
+        static class Dynamo {
+            String endpointOverride
+        }
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-dynamodb/src/test/resources/logback.xml
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-localstack/test-resources-localstack-s3/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-s3/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+description = """
+Provides support for Localstack S3.
+"""
+
+dependencies {
+    implementation(project(":test-resources-localstack-core"))
+    runtimeOnly(libs.amazon.awssdk.v1.s3) {
+        because "Localstack requires the AWS SDK in version 1 at runtime"
+    }
+    testImplementation(testFixtures(project(":test-resources-localstack-core")))
+    testImplementation(libs.amazon.awssdk.v2.s3)
+}
+
+// TODO: enable once first release of Localstack support is available
+micronautBuild.binaryCompatibility.enabled = false

--- a/test-resources-localstack/test-resources-localstack-s3/src/main/java/io/micronaut/testresources/aws/localstack/s3/LocalStackS3Service.java
+++ b/test-resources-localstack/test-resources-localstack-s3/src/main/java/io/micronaut/testresources/aws/localstack/s3/LocalStackS3Service.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws.localstack.s3;
+
+import io.micronaut.testresources.aws.localstack.LocalStackService;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Localstack S3.
+ */
+public class LocalStackS3Service implements LocalStackService {
+
+    private static final String AWS_S3_ENDPOINT_OVERRIDE = "aws.s3.endpoint-override";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
+        if (AWS_S3_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpointOverride(LocalStackContainer.Service.S3).toString());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public LocalStackContainer.Service getServiceKind() {
+        return LocalStackContainer.Service.S3;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_S3_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-s3/src/main/resources/META-INF/services/io.micronaut.testresources.aws.localstack.LocalStackService
+++ b/test-resources-localstack/test-resources-localstack-s3/src/main/resources/META-INF/services/io.micronaut.testresources.aws.localstack.LocalStackService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.aws.localstack.s3.LocalStackS3Service

--- a/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/aws/localstack/s3/LocalStackS3Test.groovy
+++ b/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/aws/localstack/s3/LocalStackS3Test.groovy
@@ -1,0 +1,69 @@
+package io.micronaut.testresources.aws.localstack.s3
+
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.aws.localstack.AbstractLocalStackSpec
+import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+
+@MicronautTest
+class LocalStackS3Test extends AbstractLocalStackSpec {
+
+    @Inject
+    S3Config s3Config
+
+    def "automatically starts an S3 container"() {
+        given:
+        def client = buildClient()
+
+        when:
+        def bucket = client.createBucket {
+            it.bucket("test-bucket")
+        }
+        client.putObject({
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }, RequestBody.fromString("test data"))
+
+        then:
+        def read = client.getObject {
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }
+        read.readLines() == ["test data"]
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private S3Client buildClient() {
+        S3Client.builder()
+                .endpointOverride(new URI(s3Config.s3.endpointOverride))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(s3Config.accessKeyId, s3Config.secretKey)
+                        )
+                )
+                .region(Region.of(s3Config.region))
+                .build()
+    }
+
+    @ConfigurationProperties("aws")
+    static class S3Config {
+        String accessKeyId
+        String secretKey
+        String region
+
+        @ConfigurationBuilder(configurationPrefix = "s3")
+        final S3 s3 = new S3()
+
+        static class S3 {
+            String endpointOverride
+        }
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-s3/src/test/resources/logback.xml
+++ b/test-resources-localstack/test-resources-localstack-s3/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This commit adds a new Localstack module support. Localstack supports
multiple services, and we don't want to arbitrarily increase the number
of dependencies loaded in the test resources service, so this module
is split into a core module and support modules. The core module uses
service loading to locate local stack service providers. Those service
providers may add additional dependencies, and are the things which
can resolve extra properties. For example, there's an S3 provider which
can resolve the `aws.s3.endpoint-override` property.