### PR TITLE
Let the user tweak database parameters

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -10,3 +10,7 @@ In order for the database to be properly detected, _one of_ the following proper
 - `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgresql`)
 - `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
+- `datasources.*.db-name`: overrides the default test database name
+- `datasources.*.username`: overrides the default test user
+- `datasources.*.password`: overrides the default test password
+- `datasources.*.init-script-path`: a path to a SQL file on classpath, which will be executed at container startup

--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -17,6 +17,10 @@ In addition, R2DBC databases can be configured simply by reading the traditional
 - `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgresql`)
 - `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
+- `datasources.*.db-name`: overrides the default test database name
+- `datasources.*.username`: overrides the default test user
+- `datasources.*.password`: overrides the default test password
+- `datasources.*.init-script-path`: a path to a SQL file on classpath, which will be executed at container startup
 
 In which case, the name of the datasource must match the name of the R2DBC datasource.
 This can be useful when using modules like Flyway which only support JDBC for updating schemas, but still have your application use R2DBC: in this case the container which will be used for R2DBC and JDBC will be the same.

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -120,6 +121,22 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
      */
     protected String resolveDbSpecificProperty(String propertyName, JdbcDatabaseContainer<?> container) {
         return null;
+    }
+
+    @Override
+    protected void configureContainer(T container, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
+        super.configureContainer(container, properties, testResourcesConfiguration);
+        ifPresent("init-script-path", testResourcesConfiguration, container::withInitScript);
+        ifPresent("username", testResourcesConfiguration, container::withUsername);
+        ifPresent("password", testResourcesConfiguration, container::withPassword);
+        ifPresent("db-name", testResourcesConfiguration, container::withDatabaseName);
+    }
+
+    private void ifPresent(String key, Map<String, Object> testResourcesConfiguration, Consumer<String> consumer) {
+        Object value = testResourcesConfiguration.get("containers." + getSimpleName() + "." + key);
+        if (value != null) {
+            consumer.accept(value.toString());
+        }
     }
 
     protected static String datasourceNameFrom(String expression) {

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -40,6 +40,8 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
     private static final String PASSWORD = "password";
     private static final String DIALECT = "dialect";
     private static final String DRIVER = "driverClassName";
+    private static final String DB_NAME = "db-name";
+    private static final String INIT_SCRIPT = "init-script-path";
 
     private static final String TYPE = "db-type";
 
@@ -126,10 +128,10 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
     @Override
     protected void configureContainer(T container, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
         super.configureContainer(container, properties, testResourcesConfiguration);
-        ifPresent("init-script-path", testResourcesConfiguration, container::withInitScript);
-        ifPresent("username", testResourcesConfiguration, container::withUsername);
-        ifPresent("password", testResourcesConfiguration, container::withPassword);
-        ifPresent("db-name", testResourcesConfiguration, container::withDatabaseName);
+        ifPresent(INIT_SCRIPT, testResourcesConfiguration, container::withInitScript);
+        ifPresent(USERNAME, testResourcesConfiguration, container::withUsername);
+        ifPresent(PASSWORD, testResourcesConfiguration, container::withPassword);
+        ifPresent(DB_NAME, testResourcesConfiguration, container::withDatabaseName);
     }
 
     private void ifPresent(String key, Map<String, Object> testResourcesConfiguration, Consumer<String> consumer) {

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/groovy/io/micronaut/testresources/jdbc/mariadb/StartMariaDBWithCustomizationsTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/groovy/io/micronaut/testresources/jdbc/mariadb/StartMariaDBWithCustomizationsTest.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.testresources.jdbc.mariadb
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["test", "init-script"])
+class StartMariaDBWithCustomizationsTest extends AbstractJDBCSpec {
+    @Inject
+    MariaDBBookRepository repository
+
+    @Value("\${datasources.default.username}")
+    String username
+
+    @Value("\${datasources.default.password}")
+    String password
+
+    @Value("\${datasources.default.url}")
+    String url
+
+
+    def "starts a MariaDB container with customizations"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book)
+
+        when:
+        def books = repository.findAll()
+
+        then:
+        books.size() == 2
+        books.find { it.title == "Understanding cats" }
+
+        and:
+        username == 'sherlock'
+        password == 'holmes'
+        url.endsWith("/howdy")
+    }
+
+    @Override
+    String getImageName() {
+        "mariadb"
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/application-init-script.yml
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/application-init-script.yml
@@ -1,0 +1,12 @@
+datasources:
+  default:
+    db-type: mariadb
+    schema-generate: NONE
+    dialect: MYSQL
+test-resources:
+  containers:
+    mariadb:
+      init-script-path: init.sql
+      username: sherlock
+      password: holmes
+      db-name: howdy

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/init.sql
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE book(
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL
+);
+INSERT INTO book(title) VALUES("Understanding cats");

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/logback.xml
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/resources/logback.xml
@@ -12,5 +12,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-
 </configuration>

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/JdbcWithCustomizationMariaDBSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/JdbcWithCustomizationMariaDBSQLTest.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.testresources.r2dbc.mariadb
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["customized-jdbc"] )
+class JdbcWithCustomizationMariaDBSQLTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    @Value("\${r2dbc.datasources.default.username}")
+    String username
+
+    @Value("\${r2dbc.datasources.default.password}")
+    String password
+
+    @Value("\${r2dbc.datasources.default.url}")
+    String url
+
+    def "starts a reactive MariaDB container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 2
+        books.find { it.title == "Understanding cats" }
+
+        and:
+        username == 'sherlock'
+        password == 'holmes'
+        url.endsWith("/howdy")
+    }
+
+    @Override
+    String getImageName() {
+        "mariadb"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-customized-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/application-customized-jdbc.yml
@@ -1,0 +1,16 @@
+datasources:
+  default:
+    db-type: mariadb
+    dialect: MYSQL
+r2dbc:
+  datasources:
+    default:
+      db-type: mariadb
+      dialect: MYSQL
+test-resources:
+  containers:
+    mariadb:
+      init-script-path: init.sql
+      username: sherlock
+      password: holmes
+      db-name: howdy

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/init.sql
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/resources/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE book(
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL
+);
+INSERT INTO book(title) VALUES("Understanding cats");

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -112,11 +112,15 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
                         }
                     }
                     T container = createContainer(imageName, properties, testResourcesConfiguration);
+                    configureContainer(container, properties, testResourcesConfiguration);
                     metadata.ifPresent(md -> TestContainerMetadataSupport.applyMetadata(md, container));
                     return container;
                 }));
         }
         return Optional.empty();
+    }
+
+    protected void configureContainer(T container, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
     }
 
     protected abstract Optional<String> resolveProperty(String propertyName, T container);


### PR DESCRIPTION
This commit introduces configuration which will let the user override
the default database name, username and password, as well as running
an init SQL script.

Closes #81