### PR TITLE
Disable JAnsi output for the test resources service

### DIFF
--- a/test-resources-server/src/main/resources/logback.xml
+++ b/test-resources-server/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
+        <withJansi>false</withJansi>
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
@@ -10,9 +10,9 @@
     </appender>
 
     <root level="info">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDOUT"/>
     </root>
-   <logger name="io.micronaut.runtime.Micronaut" level="warn" additivity="false">
+    <logger name="io.micronaut.runtime.Micronaut" level="warn" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 </configuration>


### PR DESCRIPTION
We don't really need this for the test resources process and it's
causing issues under Windows.

Fixes #76