### PR TITLE
Hint that Gradle/Maven plugin docs include specific Test Resources docs

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -13,9 +13,9 @@ plugins {
 }
 ----
 
-Please refer to the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Gradle plugin documentation] for more information about configuring the test resources plugin.
+Please refer to the (https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#test-resources)[Gradle plugin's Test Resources documentation] for more information about configuring the test resources plugin.
 
 In the case of Maven, you can enable test resources support simply by setting the property `micronaut.test.resources.enabled` (either in your
 POM or via the command-line).
 
-Please refer to the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Maven plugin documentation] for more information about configuring the test resources plugin.
+Please refer to the (https://micronaut-projects.github.io/micronaut-maven-plugin/latest/examples/test-resources.html)[Maven plugin's Test Resources documentation] for more information about configuring the test resources plugin.


### PR DESCRIPTION
I made the mistake of skipping over the Gradle plugin reference when reading about Micronaut Test Resources, so I added a more direct link/more reference to the fact that the Gradle and Maven plugins contain Test Resources-specific information.