### PR TITLE
Avoid spawning an Oracle container when Oracle cloud is used

### DIFF
--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/groovy/io/micronaut/testresources/jdbc/xe/OracleATPTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/groovy/io/micronaut/testresources/jdbc/xe/OracleATPTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.jdbc.xe
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import spock.lang.Issue
+
+class OracleATPTest extends AbstractJDBCSpec {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-test-resources/issues/104")
+    def "an Oracle container isn't started if ATP prod environment is detected"() {
+        // because we test a production environment, ideally this should actually spawn a
+        // mock for Oracle ATP, but for now we will just check that the properties are
+        // not resolved by the test resources provider
+        when:
+        ApplicationContext.builder("test", "prod")
+            .packages("io.micronaut.testresources.jdbc.xe")
+            .start()
+
+        then:
+        BeanInstantiationException ex = thrown()
+        ex.message.contains("Could not resolve placeholder \${auto.test.resources.datasources.default")
+    }
+
+    @Override
+    String getImageName() {
+        "oracle-xe"
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/resources/application-prod.yml
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/resources/application-prod.yml
@@ -1,0 +1,3 @@
+datasources:
+  default:
+    ocid: SOME_ID

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/OracleATPReactiveTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/OracleATPReactiveTest.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import spock.lang.Issue
+
+class OracleATPReactiveTest extends AbstractJDBCSpec {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-test-resources/issues/104")
+    def "an Oracle container isn't started if ATP prod environment is detected"() {
+        // because we test a production environment, ideally this should actually spawn a
+        // mock for Oracle ATP, but for now we will just check that the properties are
+        // not resolved by the test resources provider
+        when:
+        ApplicationContext.builder(environments as String[])
+                .packages("io.micronaut.testresources.jdbc.xe")
+                .start()
+
+        then:
+        BeanInstantiationException ex = thrown()
+        ex.message.contains("Could not resolve placeholder \${$placeholder")
+
+        where:
+        environments                             | placeholder
+        ["test", "jdbc", "prod"]                 | "auto.test.resources.datasources.default"
+        ["test", "standalone", "standaloneprod"] | "auto.test.resources.r2dbc.datasources.default"
+
+    }
+
+    @Override
+    String getImageName() {
+        "oracle-xe"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-prod.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-prod.yml
@@ -1,0 +1,3 @@
+datasources:
+  default:
+    ocid: SOME_ID

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-standaloneprod.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-standaloneprod.yml
@@ -1,0 +1,4 @@
+r2dbc:
+  datasources:
+    default:
+      ocid: SOME_ID


### PR DESCRIPTION
In production, when Oracle ATP is used, we wouldn't set the datasource URL, but instead set the `ocid` property (and possibly others). This confuses test resources, because if a property is missing, then it would try to resolve it. Which is what happens here: even if the `url` property is effectively unused when the cloud environment is detected, the property was effectively resolved.

The workaround is to try to see if the `ocid` property is set, in which case the resolvers wouldn't do anything.