### PR TITLE
Rename `Application` -> `TestResourcesService`

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -65,7 +65,7 @@ public class ServerUtils {
     private static final String SERVER_ACCESS_TOKEN_MICRONAUT_PROPERTY = "server.access-token";
     private static final String SERVER_ACCESS_TOKEN = "server.access.token";
     private static final String SERVER_CLIENT_READ_TIMEOUT = "server.client.read.timeout";
-    private static final String SERVER_ENTRY_POINT = "io.micronaut.testresources.server.Application";
+    private static final String SERVER_ENTRY_POINT = "io.micronaut.testresources.server.TestResourcesService";
     private static final String MICRONAUT_SERVER_PORT = "micronaut.server.port";
     private static final String JMX_SYSTEM_PROPERTY = "com.sun.management.jmxremote";
     private static final String CDS_HASH = "cds.bin";

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -53,7 +53,7 @@ class ServerUtilsTest extends Specification {
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
-            assert params.mainClass == 'io.micronaut.testresources.server.Application'
+            assert params.mainClass == 'io.micronaut.testresources.server.TestResourcesService'
             assert params.classpath == classpath
             def sysProps = ['com.sun.management.jmxremote': null]
             if (token != null) {

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 application {
-    mainClass = "io.micronaut.testresources.server.Application"
+    mainClass = "io.micronaut.testresources.server.TestResourcesService"
 }
 
 micronaut {

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -33,12 +33,12 @@ import java.util.Arrays;
  * Main entry point for the server.
  */
 @Singleton
-public class Application {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
+public class TestResourcesService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestResourcesService.class);
 
     public static void main(String[] args) {
         long sd = System.nanoTime();
-        ApplicationContext context = Micronaut.run(Application.class, args);
+        ApplicationContext context = Micronaut.run(TestResourcesService.class, args);
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
             .findFirst()


### PR DESCRIPTION
This will make it look nicer when calling `jps`, for example, but it's a breaking change.

Fixes #116