### PR TITLE
Fix property resolving when client returns a 404

### DIFF
--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -49,6 +49,14 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         Arrays.asList(URL, USERNAME, PASSWORD, DRIVER)
     );
 
+    /**
+     * Returns the list of db-types supported by this provider.
+     * @return the list of db types
+     */
+    protected List<String> getDbTypes() {
+        return Collections.singletonList(getSimpleName());
+    }
+
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
         Collection<String> datasources = propertyEntries.getOrDefault(PREFIX, Collections.emptyList());
@@ -81,7 +89,7 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         }
         String datasource = datasourceNameFrom(propertyName);
         String type = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, TYPE)));
-        if (type != null && type.equalsIgnoreCase(getSimpleName())) {
+        if (type != null && getDbTypes().stream().anyMatch(type::equalsIgnoreCase)) {
             return true;
         }
         String dialect = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, DIALECT)));

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
@@ -19,12 +19,18 @@ import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
  * A test resource provider which will spawn a MySQL test container.
  */
 public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<PostgreSQLContainer<?>> {
+    private static final List<String> SUPPORTED_DB_TYPES = Collections.unmodifiableList(
+        Arrays.asList("postgresql", "postgres", "pg")
+    );
 
     @Override
     protected String getSimpleName() {
@@ -34,6 +40,11 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
     @Override
     protected String getDefaultImageName() {
         return "postgres";
+    }
+
+    @Override
+    protected List<String> getDbTypes() {
+        return SUPPORTED_DB_TYPES;
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -25,6 +25,7 @@ import org.testcontainers.containers.GenericContainer;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,6 +54,14 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         PASSWORD
     );
 
+    /**
+     * Returns the list of db-types supported by this provider.
+     * @return the list of db types
+     */
+    protected List<String> getDbTypes() {
+        return Collections.singletonList(getSimpleName());
+    }
+
     @Override
     public List<String> getRequiredPropertyEntries() {
         return R2dbcSupport.REQUIRED_PROPERTY_ENTRIES_LIST;
@@ -76,7 +85,7 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         String baseDatasourceExpression = R2dbcSupport.removeR2dbPrefixFrom(propertyName);
         String datasource = R2dbcSupport.datasourceNameFrom(baseDatasourceExpression);
         String type = stringOrNull(requestedProperties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.TYPE)));
-        if (type != null && type.equalsIgnoreCase(getSimpleName())) {
+        if (type != null && getDbTypes().stream().anyMatch(type::equalsIgnoreCase)) {
             return true;
         }
         String driver = stringOrNull(requestedProperties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.DRIVER)));

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -22,6 +22,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -29,6 +32,9 @@ import java.util.Optional;
  * A test resource provider for reactive PostgreSQL.
  */
 public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<PostgreSQLContainer<?>> {
+    private static final List<String> SUPPORTED_DB_TYPES = Collections.unmodifiableList(
+        Arrays.asList("postgresql", "postgres", "pg")
+    );
 
     @Override
     protected String getSimpleName() {
@@ -38,6 +44,11 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
     @Override
     protected String getDefaultImageName() {
         return "postgres";
+    }
+
+    @Override
+    protected List<String> getDbTypes() {
+        return SUPPORTED_DB_TYPES;
     }
 
     @Override


### PR DESCRIPTION
This commit fixes handling of the resolution result whenever the client throws an error, which is the case if the resolver returns an empty optional. This improves the error message on the client side.

It also improves the PostgreSQL providers so that they support both `postgres` and `postgresql` as `db-type`, since it's a common mistake.

Fixes #129