### PR TITLE
Support reading server connection details from system properties

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/ConfigFinder.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/ConfigFinder.java
@@ -21,8 +21,13 @@ import java.net.URL;
 import java.util.Optional;
 
 final class ConfigFinder {
+    public static final String SYSTEM_PROP_PREFIX = "micronaut.test.resources";
 
     public static final String TEST_RESOURCES_PROPERTIES = "/test-resources.properties";
+
+    private ConfigFinder() {
+
+    }
 
     static Optional<URL> findConfiguration(ResourceLoader loader) {
         Optional<URL> resource = Optional.empty();
@@ -33,5 +38,9 @@ final class ConfigFinder {
             resource = Optional.ofNullable(ConfigFinder.class.getResource(TEST_RESOURCES_PROPERTIES));
         }
         return resource;
+    }
+
+    static String systemPropertyNameOf(String propertyName) {
+        return SYSTEM_PROP_PREFIX + "." + propertyName;
     }
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -49,8 +49,11 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
 
     private static TestResourcesClient createClient(Environment env) {
         Optional<URL> config = findConfiguration(env);
-        return config.map(TestResourcesClientFactory::configuredAt)
-            .orElse(NoOpClient.INSTANCE);
+        if (config.isPresent()) {
+            return config.map(TestResourcesClientFactory::configuredAt)
+                .get();
+        }
+        return TestResourcesClientFactory.fromSystemProperties().orElse(NoOpClient.INSTANCE);
     }
 
     private static class NoOpClient implements TestResourcesClient {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
@@ -62,7 +62,8 @@ public class TestResourcesClientPropertySourceLoader extends LazyTestResourcesPr
             try {
                 if (client == null) {
                     Optional<URL> config = findConfiguration(resourceLoader);
-                    config.ifPresent(url -> client = TestResourcesClientFactory.configuredAt(url));
+                    client = config.map(TestResourcesClientFactory::configuredAt)
+                        .orElseGet(() -> TestResourcesClientFactory.fromSystemProperties().orElse(null));
                 }
                 return Optional.ofNullable(client);
             } finally {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
@@ -6,23 +6,20 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
-import spock.lang.TempDir
-
-import java.nio.file.Path
 
 @MicronautTest
-class TestResourcesClientTest extends Specification {
-
-    @TempDir
-    Path tempDir
+class TestResourcesClientPropertiesTest extends Specification {
 
     @Inject
     EmbeddedServer server
 
-    def "property source loader registers properties from server"() {
+    def "client can be configured from system properties"() {
+        System.setProperty("micronaut.test.resources.server.uri", server.getURI().toString())
+
+        when:
         def app = createApplication()
 
-        expect:
+        then:
         app.getProperty("dummy1", String).get() == 'value for dummy1'
         app.getProperty("dummy2", String).get() == 'value for dummy2'
 
@@ -32,29 +29,18 @@ class TestResourcesClientTest extends Specification {
         then:
         ConfigurationException e = thrown()
         e.message == 'Could not resolve placeholder ${auto.test.resources.missing}'
+
+        cleanup:
+        System.clearProperty("micronaut.test.resources.server.uri")
     }
 
     private ApplicationContext createApplication() {
-        def propertiesFile = tempDir.resolve("test-resources.properties").toFile()
-        def cl = new URLClassLoader([] as URL[], this.class.classLoader) {
-            @Override
-            URL findResource(String name) {
-                if ("/test-resources.properties" == name) {
-                    return propertiesFile.toURI().toURL()
-                }
-                return super.findResource(name)
-            }
-        }
-
-        propertiesFile << """
-            ${TestResourcesClient.SERVER_URI}=${server.getURI()}
-        """.stripIndent()
         def app = ApplicationContext.builder()
-                .classLoader(cl)
                 .properties(['server': 'false'])
                 .start()
         assert !app.findBean(TestServer).present
         return app
     }
+
 
 }

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.testresources.client
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.testresources.core.TestResourcesResolver
+
+@Controller("/")
+@Requires(property = 'server', notEquals = 'false')
+ class TestServer implements TestResourcesResolver {
+
+    @Override
+    @Post("/list")
+    List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        ["dummy1", "dummy2", "missing"]
+    }
+
+    @Override
+    @Get("/requirements/expr/{expression}")
+    List<String> getRequiredProperties(String expression) {
+        []
+    }
+
+    @Override
+    @Get("/requirements/entries")
+    List<String> getRequiredPropertyEntries() {
+        []
+    }
+
+    @Override
+    @Post('/resolve')
+    Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
+        if ("missing" == name) {
+            return Optional.empty()
+        }
+        Optional.of("value for $name".toString())
+    }
+
+    @Get("/close/all")
+    void closeAll() {
+
+    }
+}


### PR DESCRIPTION
This commit adds the ability for the client to get the server connection details from system properties. Before, the only possible solution was to have a `test-resources.properties` file on classpath.

Because the client and the configuration had to be injected via classpath, it meant that a change to the server configuration would typically invalidate classpath and cause tasks to be out-of-date in Gradle (see https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/579)

The new option makes it possible to read the server configuration from system properties if the file isn't found on classpath. This preserves backwards compatibility while offering a convenient way to pass in the parameters.

Note that we are not using environment variables, because there would be no option to pass them via Gradle.

This is considered a bug as it prevents up-to-date checking (and therefore caching) to work properly with Gradle.