### PR TITLE
Provide a method to get the client from an application context

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.client;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.HttpClientConfiguration;
@@ -79,5 +80,22 @@ public final class TestResourcesClientFactory {
             return Optional.of(new DefaultTestResourcesClient(client, accessToken));
         }
         return Optional.empty();
+    }
+
+    /**
+     * Extracts the {@link TestResourcesClient} from the given {@link ApplicationContext}.
+     * @param context the application context
+     * @return the test resources client
+     */
+    public static TestResourcesClient extractFrom(ApplicationContext context) {
+        return context.getEnvironment()
+            .getPropertySourceLoaders()
+            .stream()
+            .filter(TestResourcesClientPropertySourceLoader.class::isInstance)
+            .map(TestResourcesClientPropertySourceLoader.class::cast)
+            .map(TestResourcesClientPropertySourceLoader::getClient)
+            .findFirst()
+            .orElse(Optional.empty())
+            .orElse(null);
     }
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
@@ -39,6 +39,10 @@ public class TestResourcesClientPropertySourceLoader extends LazyTestResourcesPr
         super(new ClientTestResourcesResolver());
     }
 
+    public final Optional<TestResourcesClient> getClient() {
+        return Optional.ofNullable(((ClientTestResourcesResolver) getProducer()).client);
+    }
+
     private static class ClientTestResourcesResolver implements PropertyExpressionProducer {
         private final ReentrantLock lock = new ReentrantLock();
         private TestResourcesClient client;

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -42,6 +42,10 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
         this.producer = producer;
     }
 
+    protected final PropertyExpressionProducer getProducer() {
+        return producer;
+    }
+
     @Override
     public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader) {
         return Optional.of(new LazyPropertySource(resourceLoader));


### PR DESCRIPTION
This method can be used in tests, whenever for some reason it is required to interact with the test resources server directly. This can be the case, for example, if a test should ensure that the resources are closed after the test, in order to avoid exhausting memory.