### PR TITLE
Fix possible values for db-type in documentation

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -7,7 +7,7 @@ The following properties will automatically be set when using a JDBC database:
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgresql`)
+- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgres`)
 - `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 - `datasources.*.db-name`: overrides the default test database name


### PR DESCRIPTION
I have lost a very long time because of this and hope to help others avoid such issues.

I suggest to improve the error message in case the value is not properly configured because the cause of the issue was really not evident from the error message I was getting: 

```
  Message: Not Found
  Path Taken: DataSource.dataSource(DatasourceConfiguration datasourceConfiguration) --> DataSource.dataSource([DatasourceConfiguration datasourceConfiguration])
  Caused by: io.micronaut.http.client.exceptions.HttpClientResponseException: Not Found
```