### PR TITLE
Fix flat jar being deleted when directories change

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -501,8 +501,7 @@ public class ServerUtils {
                     File cdsFile = new File(cdsDir, CDS_FILE);
                     File cdsClassList = new File(cdsDir, CDS_CLASS_LST);
                     File cdsHashFile = new File(cdsDir, CDS_HASH);
-                    File cdsFlatJar = new File(cdsDir, FLAT_JAR);
-                    configureCdsOptions(jvmArguments, cdsFile, cdsClassList, cdsHashFile, cdsFlatJar);
+                    configureCdsOptions(jvmArguments, cdsFile, cdsClassList, cdsHashFile);
                 }
             }
             jvmArgs = Collections.unmodifiableList(jvmArguments);
@@ -512,8 +511,7 @@ public class ServerUtils {
         private void configureCdsOptions(List<String> jvmArguments,
                                          File cdsFile,
                                          File cdsClassList,
-                                         File cdsHashFile,
-                                         File cdsFlatJar) {
+                                         File cdsHashFile) {
             if (cdsClassList.exists()) {
                 try {
                     byte[] actualHash = computeClasspathHash(getClasspath().stream());
@@ -521,13 +519,13 @@ public class ServerUtils {
                         byte[] cdsHash = Files.readAllBytes(cdsHashFile.toPath());
                         if (!Arrays.equals(actualHash, cdsHash)) {
                             // Classpath changed, invalidate CDS cache
-                            deleteCdsFiles(cdsFile, cdsClassList, cdsHashFile, cdsFlatJar);
+                            deleteCdsFiles(cdsFile, cdsClassList, cdsHashFile);
                         }
                     } else {
                         Files.write(cdsHashFile.toPath(), actualHash);
                     }
                 } catch (IOException e) {
-                    deleteCdsFiles(cdsFile, cdsClassList, cdsHashFile, cdsFlatJar);
+                    deleteCdsFiles(cdsFile, cdsClassList, cdsHashFile);
                 }
             }
             if (cdsClassList.exists()) {
@@ -563,10 +561,10 @@ public class ServerUtils {
                 // Workaround for https://bugs.openjdk.org/browse/JDK-8290417
                 fileContent.removeIf(content ->
                     content.contains("SingleThreadedBufferingProcessor") ||
-                        content.contains("org/testcontainers") ||
-                        content.contains("org/graalvm") ||
-                        content.contains("io/netty/handler") ||
-                        content.contains("jdk/proxy"));
+                    content.contains("org/testcontainers") ||
+                    content.contains("org/graalvm") ||
+                    content.contains("io/netty/handler") ||
+                    content.contains("jdk/proxy"));
                 Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
             } catch (IOException e) {
                 // ignore
@@ -579,8 +577,16 @@ public class ServerUtils {
         private static byte[] computeClasspathHash(Stream<File> files) {
             try {
                 MessageDigest digest = MessageDigest.getInstance("SHA1");
-                files.map(file -> file.getAbsolutePath() + ":" + file.length() + ":" + file.lastModified())
-                    .forEachOrdered(line -> digest.update(line.getBytes(StandardCharsets.UTF_8)));
+                files.flatMap(fileOrDir -> {
+                    try (Stream<Path> s = Files.walk(fileOrDir.toPath())){
+                        return s.map(p -> {
+                            File file = p.toFile();
+                            return file.getAbsolutePath() + ":" + file.length() + ":" + file.lastModified();
+                        }).collect(Collectors.toList()).stream();
+                    } catch (IOException e) {
+                        return Stream.empty();
+                    }
+                }).forEachOrdered(line -> digest.update(line.getBytes(StandardCharsets.UTF_8)));
                 return digest.digest();
             } catch (NoSuchAlgorithmException e) {
                 return new byte[0];

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -201,7 +201,6 @@ class ServerUtilsTest extends Specification {
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
             assert params.classpath == []
-            assert !Files.exists(cdsFlatJar)
             Files.write(cdsClassList, "test".getBytes())
         }
         1 * factory.waitFor(_) >> {


### PR DESCRIPTION
This commit fixes an issue with the logic when the AppCDS classpath changes: we have logic to "snapshot" the classpath in order to detect changes. We also have logic to make sure that we build a "flat jar" which contains the contents of all directories on classpath (because AppCDS only supports jars on classpath).

When a directory on classpath changed, for example if we made a change to `src/testResources/main/some/Resource.java`, then we would properly detect the change, but we accidentally deleted the newly generated flat jar.

Fixes #148