### PR TITLE
Default to Oracle XE slim-faststart

### DIFF
--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -2,15 +2,15 @@
 
 Micronaut Test Resources provides support for the following databases:
 
-[cols="2,1,1,1"]
+[cols="2,1,1,1,1"]
 |===
-|Database | JDBC | R2DBC | Database identifier
+|Database | JDBC | R2DBC | Database identifier | Default image
 
-| https://mariadb.org/[MariaDB] | Yes | Yes | mariadb
-| https://www.mysql.com/[MySQL] | Yes | Yes | mysql
-| https://www.oracle.com/fr/database/technologies/appdev/xe.html[Oracle Express Edition] | Yes | Yes | oracle-xe
-| https://www.postgresql.org/[PostgreSQL] | Yes | Yes | postgres
-| https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | mssql
+| https://mariadb.org/[MariaDB] | Yes | Yes | mariadb | mariadb
+| https://www.mysql.com/[MySQL] | Yes | Yes | mysql | mysql
+| https://www.oracle.com/fr/database/technologies/appdev/xe.html[Oracle Express Edition] | Yes | Yes | oracle-xe | gvenzl/oracle-xe:slim-faststart
+| https://www.postgresql.org/[PostgreSQL] | Yes | Yes | postgres | postgres
+| https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | mssql | mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04
 
 |===
 

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleXETestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleXETestResourceProvider.java
@@ -33,7 +33,7 @@ public class HibernateReactiveOracleXETestResourceProvider extends AbstractHiber
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe";
+        return "gvenzl/oracle-xe:slim-faststart";
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
@@ -62,7 +62,7 @@ public class OracleXETestResourceProvider extends AbstractJdbcTestResourceProvid
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe";
+        return "gvenzl/oracle-xe:slim-faststart";
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleXETestResourceProvider.java
@@ -73,7 +73,7 @@ public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResource
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe";
+        return "gvenzl/oracle-xe:slim-faststart";
     }
 
     @Override


### PR DESCRIPTION
This commit updates the default Oracle XE image used to slim-faststart, in order to make it faster to start tests.

Fixes #144