### PR TITLE
Upgrade to build plugins 6.3.3

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.hibernate-reactive-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.hibernate-reactive-module.gradle
@@ -7,9 +7,9 @@ micronautBuild {
 }
 
 dependencies {
-    api(project(':test-resources-hibernate-reactive-core'))
+    api(project(':micronaut-test-resources-hibernate-reactive-core'))
 
-    testImplementation(testFixtures(project(':test-resources-hibernate-reactive-core')))
+    testImplementation(testFixtures(project(':micronaut-test-resources-hibernate-reactive-core')))
     testCompileOnly(mnData.micronaut.data.processor)
     testCompileOnly(mn.micronaut.inject.groovy)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 dependencies {
-    api(project(':test-resources-jdbc-core'))
+    api(project(':micronaut-test-resources-jdbc-core'))
 
     testCompileOnly(mnData.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+    testImplementation(testFixtures(project(":micronaut-test-resources-jdbc-core")))
     testRuntimeOnly(mnSql.micronaut.jdbc.hikari)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    api(project(':test-resources-r2dbc-core'))
+    api(project(':micronaut-test-resources-r2dbc-core'))
     testImplementation(mnData.micronaut.data.r2dbc)
     testImplementation(mnData.micronaut.data.processor)
-    testImplementation(testFixtures(project(":test-resources-jdbc-core")))
+    testImplementation(testFixtures(project(":micronaut-test-resources-jdbc-core")))
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
+    api(project(':micronaut-test-resources-core'))
+    api(project(':micronaut-test-resources-testcontainers'))
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(project(":micronaut-test-resources-embedded"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.3.1'
+    id 'io.micronaut.build.shared.settings' version '6.3.3'
 }
 rootProject.name = 'testresources-parent'
 
@@ -86,6 +86,7 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
 }
 
 micronautBuild {
+    useStandardizedProjectNames = true
     addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-aws")

--- a/test-resources-build-tools/build.gradle
+++ b/test-resources-build-tools/build.gradle
@@ -31,7 +31,7 @@ def writeModuleList = tasks.register("writeModuleList", WriteModuleList) {
     getPackage().set("io.micronaut.testresources.buildtools")
     def thisProject = project
     modules = rootProject.allprojects.findAll { it != thisProject && it != rootProject }
-            .collect { it.name - 'test-resources-' }
+            .collect { it.name - 'micronaut-test-resources-' }
             .groupBy {
                 if (it.startsWith('jdbc')) {
                     'jdbc'
@@ -39,6 +39,8 @@ def writeModuleList = tasks.register("writeModuleList", WriteModuleList) {
                     'r2dbc'
                 } else if (it in ['core', 'bom', 'embedded', 'client', 'testcontainers']) {
                     'core'
+                } else if (it.startsWith('localstack')) {
+                    'localstack'
                 } else {
                     'modules'
                 }
@@ -47,6 +49,7 @@ def writeModuleList = tasks.register("writeModuleList", WriteModuleList) {
     moduleDescriptions.put('jdbc', 'JDBC modules')
     moduleDescriptions.put('r2dbc', 'R2DBC modules')
     moduleDescriptions.put('modules', 'Extra modules')
+    moduleDescriptions.put('localstack', 'Localstack modules')
 }
 
 sourceSets.main.java.srcDirs(writeVersion, writeModuleList)

--- a/test-resources-client/build.gradle
+++ b/test-resources-client/build.gradle
@@ -10,7 +10,7 @@ and provide their value on demand.
 
 dependencies {
     api(mn.micronaut.http.client)
-    api(project(':test-resources-core'))
+    api(project(':micronaut-test-resources-core'))
 
     testRuntimeOnly(mn.micronaut.http.server.netty)
 }

--- a/test-resources-embedded/build.gradle
+++ b/test-resources-embedded/build.gradle
@@ -8,5 +8,5 @@ The resource resolvers are loaded via service loading.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
+    api(project(':micronaut-test-resources-core'))
 }

--- a/test-resources-hashicorp-vault/build.gradle
+++ b/test-resources-hashicorp-vault/build.gradle
@@ -9,7 +9,7 @@ Provides support for launching a Hashicorp Vault test container.
 dependencies {
     implementation(libs.testcontainers.vault)
 
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))
     testImplementation(libs.micronaut.discovery)
     testImplementation(mnSecurity.micronaut.security.oauth2)
 }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a MariaDB test container for Hibernate Reactive.
 
 dependencies {
     implementation(libs.testcontainers.mariadb)
-    runtimeOnly(project(":test-resources-jdbc-mariadb"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-mariadb"))
 
     testRuntimeOnly(mnSql.mariadb.java.client)
     testRuntimeOnly(libs.vertx.mysql)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a MSSQL test container for Hibernate Reactive.
 
 dependencies {
     implementation(libs.testcontainers.mssql)
-    implementation(project(":test-resources-jdbc-mssql"))
+    implementation(project(":micronaut-test-resources-jdbc-mssql"))
 
     testRuntimeOnly(mnSql.mssql.jdbc)
     testRuntimeOnly(libs.vertx.mssql)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a MariaDB test container for Hibernate Reactive.
 
 dependencies {
     implementation(libs.testcontainers.mysql)
-    runtimeOnly(project(":test-resources-jdbc-mysql"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-mysql"))
 
     testRuntimeOnly(mnSql.mysql.connector.java)
     testRuntimeOnly(libs.vertx.mysql)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching an Oracle XE test container for Hibernate Reactiv
 
 dependencies {
     implementation(libs.testcontainers.oracle.xe)
-    runtimeOnly(project(":test-resources-jdbc-oracle-xe"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
 
     testRuntimeOnly(libs.vertx.oracle)
 }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a PostgreSQL test container for Hibernate Reactiv
 
 dependencies {
     implementation(libs.testcontainers.postgres)
-    runtimeOnly(project(":test-resources-jdbc-postgresql"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-postgresql"))
 
     testRuntimeOnly(mnSql.postgresql)
     testRuntimeOnly(libs.vertx.postgres)

--- a/test-resources-jdbc/test-resources-jdbc-core/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-core/build.gradle
@@ -16,9 +16,9 @@ dependencies {
     testFixturesCompileOnly(mnData.micronaut.data.processor)
     testFixturesImplementation(mn.groovy)
     testFixturesImplementation(libs.spock)
-    testFixturesApi(testFixtures(project(":test-resources-testcontainers"))) {
+    testFixturesApi(testFixtures(project(":micronaut-test-resources-testcontainers"))) {
         because "exposes AbstractTestContainersSpec"
     }
-    testFixturesImplementation(project(":test-resources-embedded"))
+    testFixturesImplementation(project(":micronaut-test-resources-embedded"))
     testFixturesRuntimeOnly(mnSql.micronaut.jdbc.hikari)
 }

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)
     testFixturesImplementation(libs.spock)
-    testFixturesApi(testFixtures(project(":test-resources-testcontainers"))) {
+    testFixturesApi(testFixtures(project(":micronaut-test-resources-testcontainers"))) {
         because "exposes AbstractTestContainersSpec"
     }
 }

--- a/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
@@ -7,11 +7,11 @@ Provides support for Localstack DynamoDB.
 """
 
 dependencies {
-    implementation(project(":test-resources-localstack-core"))
+    implementation(project(":micronaut-test-resources-localstack-core"))
     runtimeOnly(libs.amazon.awssdk.v1.dynamodb) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":test-resources-localstack-core")))
+    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
     testImplementation(libs.amazon.awssdk.v2.dynamodb)
 }
 

--- a/test-resources-localstack/test-resources-localstack-s3/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-s3/build.gradle
@@ -7,11 +7,11 @@ Provides support for Localstack S3.
 """
 
 dependencies {
-    implementation(project(":test-resources-localstack-core"))
+    implementation(project(":micronaut-test-resources-localstack-core"))
     runtimeOnly(libs.amazon.awssdk.v1.s3) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":test-resources-localstack-core")))
+    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
     testImplementation(libs.amazon.awssdk.v2.s3)
 }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
@@ -8,7 +8,7 @@ Provides support for R2DBC MariaDB test resources.
 
 dependencies {
     implementation(libs.testcontainers.mariadb)
-    runtimeOnly(project(":test-resources-jdbc-mariadb"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-mariadb"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mariadb)
     testRuntimeOnly(mnSql.mariadb.java.client)

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
@@ -8,7 +8,7 @@ Provides support for MS SQL Server R2DBC test resources.
 
 dependencies {
     implementation(libs.testcontainers.mssql)
-    implementation(project(":test-resources-jdbc-mssql"))
+    implementation(project(":micronaut-test-resources-jdbc-mssql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mssql)
     testRuntimeOnly(mnSql.mssql.jdbc)

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
@@ -8,7 +8,7 @@ Provides support for MySQL R2DBC test resources.
 
 dependencies {
     implementation(libs.testcontainers.mysql)
-    runtimeOnly(project(":test-resources-jdbc-mysql"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-mysql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mysql)
     testRuntimeOnly(mnSql.mysql.connector.java)

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
@@ -8,7 +8,7 @@ Provides support for Oracle XE R2DBC test resources.
 
 dependencies {
     implementation(libs.testcontainers.oracle.xe)
-    runtimeOnly(project(":test-resources-jdbc-oracle-xe"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.oracle)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
@@ -8,7 +8,7 @@ Provides support for R2DBC pool resources.
 
 dependencies {
     testImplementation(platform(mnR2dbc.micronaut.r2dbc.bom))
-    testRuntimeOnly(project(":test-resources-r2dbc-postgresql"))
+    testRuntimeOnly(project(":micronaut-test-resources-r2dbc-postgresql"))
     testRuntimeOnly(mnR2dbc.r2dbc.postgresql)
     testImplementation(mnR2dbc.r2dbc.pool)
     testRuntimeOnly(mnSql.postgresql)

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
@@ -8,7 +8,7 @@ Provides support for PostgreSQL R2DBC test resources.
 
 dependencies {
     implementation(libs.testcontainers.postgres)
-    runtimeOnly(project(":test-resources-jdbc-postgresql"))
+    runtimeOnly(project(":micronaut-test-resources-jdbc-postgresql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.postgresql)
     testRuntimeOnly(mnSql.postgresql)

--- a/test-resources-redis/build.gradle
+++ b/test-resources-redis/build.gradle
@@ -7,10 +7,10 @@ Provides support for launching a Redis test container.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
-    api(project(':test-resources-testcontainers'))
+    api(project(':micronaut-test-resources-core'))
+    api(project(':micronaut-test-resources-testcontainers'))
 
-    testImplementation(project(":test-resources-embedded"))
-    testImplementation(testFixtures(project(":test-resources-testcontainers")))
+    testImplementation(project(":micronaut-test-resources-embedded"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))
     testImplementation(mnRedis.micronaut.redis.lettuce)
 }

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -14,16 +14,16 @@ client.
 dependencies {
     implementation(mn.micronaut.http.server.netty)
     implementation(mn.reactor)
-    implementation(project(':test-resources-core'))
-    implementation(project(':test-resources-embedded'))
-    implementation(project(':test-resources-testcontainers'))
+    implementation(project(':micronaut-test-resources-core'))
+    implementation(project(':micronaut-test-resources-embedded'))
+    implementation(project(':micronaut-test-resources-testcontainers'))
     runtimeOnly(mn.logback.classic)
     runtimeOnly(mn.micronaut.management)
     runtimeOnly(mnSerde.micronaut.serde.jackson)
     runtimeOnly(mn.snakeyaml)
 
-    testImplementation(project(':test-resources-client'))
-    testRuntimeOnly(project(':test-resources-kafka'))
+    testImplementation(project(':micronaut-test-resources-client'))
+    testRuntimeOnly(project(':micronaut-test-resources-kafka'))
 
     // For logback conversion
     aotPlugins(mn.logback.classic)

--- a/test-resources-testcontainers/build.gradle
+++ b/test-resources-testcontainers/build.gradle
@@ -9,12 +9,12 @@ of testcontainers.
 """
 
 dependencies {
-    api(project(':test-resources-core'))
+    api(project(':micronaut-test-resources-core'))
     api(libs.testcontainers.core)
     api(platform(libs.boms.testcontainers))
     implementation(mn.micronaut.context)
 
-    testImplementation(project(":test-resources-embedded"))
+    testImplementation(project(":micronaut-test-resources-embedded"))
     testImplementation(mnEmail.micronaut.email)
     testImplementation(mnEmail.micronaut.email.javamail)
     testImplementation(mn.snakeyaml)


### PR DESCRIPTION
This commit moves to build plugins 6.3.3 and enables standardized project names.