### PR TITLE
Enable parallel build

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.database-testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.database-testing.gradle
@@ -1,0 +1,13 @@
+import io.micronaut.internal.ParallelGateService
+
+String resourceName = project.name
+        .replace("micronaut-test-resources-jdbc-", "")
+        .replace("micronaut-test-resources-r2dbc-", "")
+        .replace("micronaut-test-resources-hibernate-reactive-", "")
+        .capitalize()
+
+// We test at most 3 different databases in parallel
+ParallelGateService.requiresResource(project, "db", 3)
+
+// but only one of a particular kind
+ParallelGateService.requiresResource(project, "db${resourceName}")

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.hibernate-reactive-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.hibernate-reactive-module.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.database-testing'
 }
 
 micronautBuild {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.jdbc-module.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.database-testing'
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-testing.gradle
@@ -1,0 +1,3 @@
+import io.micronaut.internal.ParallelGateService
+
+ParallelGateService.requiresResource(project, "kafka")

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.localstack-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.localstack-module.gradle
@@ -1,0 +1,7 @@
+import io.micronaut.internal.ParallelGateService
+
+plugins {
+    id "io.micronaut.build.internal.testcontainers-module"
+}
+
+ParallelGateService.requiresResource(project, "localstack")

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-module.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.database-testing'
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.testcontainers-module.gradle
@@ -1,3 +1,5 @@
+import io.micronaut.internal.ParallelGateService
+
 plugins {
     id 'io.micronaut.build.internal.test-resources-module'
 }
@@ -9,3 +11,9 @@ dependencies {
     testImplementation(project(":micronaut-test-resources-embedded"))
     testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))
 }
+
+// We allow at most 2 containers to run in parallel on CI
+ParallelGateService.requiresResource(project,
+        "containers",
+        micronautBuild.environment.isGithubAction().map { isCi -> isCi ? 2 : Runtime.getRuntime().availableProcessors() }.get()
+)

--- a/buildSrc/src/main/groovy/io/micronaut/internal/ParallelGateService.java
+++ b/buildSrc/src/main/groovy/io/micronaut/internal/ParallelGateService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.internal;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.api.tasks.testing.Test;
+
+/**
+ * A build service which responsibility is simply to make sure that
+ * we don't execute tests in parallel.
+ */
+public abstract class ParallelGateService implements BuildService<BuildServiceParameters.None> {
+    private static final Logger LOGGER = Logging.getLogger(ParallelGateService.class);
+
+    public static void requiresResource(Project p, String category) {
+        requiresResource(p, category, 1);
+    }
+
+    public static void requiresResource(Project p, String category, int maxParallelUsages) {
+        Provider<ParallelGateService> serviceProvider = p.getGradle().getSharedServices().registerIfAbsent(category + "Semaphore", ParallelGateService.class, spec -> {
+            spec.getMaxParallelUsages().set(maxParallelUsages);
+        });
+        p.getTasks().withType(Test.class).configureEach(test -> {
+            test.usesService(serviceProvider);
+            //noinspection Convert2Lambda
+            test.doFirst(new Action<>() {
+                @Override
+                public void execute(Task task) {
+                    serviceProvider.get().acquired(category);
+                }
+            });
+        });
+    }
+
+    private void acquired(String name) {
+        LOGGER.info("Acquired semaphore for {}", name);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,5 @@ githubCoreBranch=4.0.x
 
 
 org.gradle.caching=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g

--- a/test-resources-kafka/build.gradle
+++ b/test-resources-kafka/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.kafka-testing'
 }
 
 description = """

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.localstack-module'
     id 'java-test-fixtures'
 }
 

--- a/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.localstack-module'
 }
 
 description = """

--- a/test-resources-localstack/test-resources-localstack-s3/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-s3/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.testcontainers-module'
+    id 'io.micronaut.build.internal.localstack-module'
 }
 
 description = """

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/build.gradle
@@ -1,3 +1,5 @@
+import io.micronaut.internal.ParallelGateService
+
 plugins {
     id 'io.micronaut.build.internal.r2dbc-module'
 }
@@ -13,3 +15,5 @@ dependencies {
     testImplementation(mnR2dbc.r2dbc.pool)
     testRuntimeOnly(mnSql.postgresql)
 }
+
+ParallelGateService.requiresResource(project, "dbPostgresql")

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'io.micronaut.build.internal.server-module'
+    // server uses kafka in tests
+    id 'io.micronaut.build.internal.kafka-testing'
     alias(libs.plugins.micronaut.miniapp)
     alias(libs.plugins.micronaut.aot)
 }


### PR DESCRIPTION
This commit enables parallel building of projects. While I was investigating support for Gradle's configuration cache, I noticed that if the cache is enabled, then projects are built in parallel _even if parallel is false_ or that `--no-parallel` is used. While this may be a bug in Gradle, there is value in supporting parallel builds.

The reason it wasn't done before is that test resources tests are resource intensive: most of them require docker containers. In addition, the tests make assertions on the number of containers which are started. If 2 projects use the same container kind in parallel (say, Kafka), then the assertions would fail, as seen in https://ge.micronaut.io/s/sl32a7lohhmio/tests/:micronaut-test-resources-localstack-s3:test/io.micronaut.testresources.localstack.s3.LocalStackS3Test/automatically%20starts%20an%20S3%20container?top-execution=1

Therefore, we introduce a parallel gate service, which allows declaring resources in use, and combine them. For example, a project can declare that it uses MySQL. We only allow a single database type to be used in parallel (that is to say that a single test using MySQL can run at a point in time), but we do allow multiple tests using different dbs to run in parallel. However, we also limit the number of concurrent db tests. In addition, we can cap the total number of parallel tests.