### PR TITLE
Only use kebab case for resolvable properties

### DIFF
--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public class ElasticsearchTestResourceProvider extends AbstractTestContainersProvider<ElasticsearchContainer> {
 
-    public static final String ELASTICSEARCH_HOSTS = "elasticsearch.httpHosts";
+    public static final String ELASTICSEARCH_HOSTS = "elasticsearch.http-hosts";
     public static final String SIMPLE_NAME = "elasticsearch";
     public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
     public static final String DEFAULT_TAG = "8.4.3";

--- a/test-resources-embedded/build.gradle
+++ b/test-resources-embedded/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.test-resources-module'
+    id 'jvm-test-suite'
 }
 
 description = """
@@ -9,4 +10,27 @@ The resource resolvers are loaded via service loading.
 
 dependencies {
     api(project(':test-resources-core'))
+}
+
+testing {
+    suites {
+        // This new test suite is used to test invalid test resources resolvers.
+        // Because the resolvers are loaded from classpath, we have to use a
+        // separate source set, otherwise other test suites will fail.
+        test2(JvmTestSuite) {
+            dependencies {
+                implementation(project)
+            }
+            useJUnitJupiter()
+        }
+    }
+}
+
+configurations {
+    test2CompileOnly.extendsFrom(testCompileOnly)
+    test2Implementation.extendsFrom(testImplementation)
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.test2)
 }

--- a/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/FailingBean.groovy
+++ b/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/FailingBean.groovy
@@ -1,0 +1,12 @@
+package io.micronaut.testresources.embedded
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+
+@Singleton
+@CompileStatic
+class FailingBean {
+    @Value('my-property')
+    String property
+}

--- a/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/InvalidTestResourcesTest.groovy
+++ b/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/InvalidTestResourcesTest.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.testresources.embedded
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class InvalidTestResourcesTest extends Specification {
+
+    def "fails if a resolver uses camel case in properties"() {
+        when:
+        def context = ApplicationContext.builder().build()
+        context.start()
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == 'Test resources resolver [io.micronaut.testresources.embedded.support.FailingResolver] : Property key [myProperty] is not valid. Property keys must be in kebab case.'
+    }
+
+}

--- a/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/support/FailingResolver.java
+++ b/test-resources-embedded/src/test2/groovy/io/micronaut/testresources/embedded/support/FailingResolver.java
@@ -1,0 +1,25 @@
+package io.micronaut.testresources.embedded.support;
+
+import io.micronaut.testresources.core.TestResourcesResolver;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resources resolver which will fail because it returns a camel case property.
+ */
+public class FailingResolver implements TestResourcesResolver {
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        // must not use camel case
+        return Collections.singletonList("myProperty");
+    }
+
+    @Override
+    public Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
+        return Optional.empty();
+    }
+}

--- a/test-resources-embedded/src/test2/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-embedded/src/test2/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.embedded.support.FailingResolver

--- a/test-resources-embedded/src/test2/resources/logback.xml
+++ b/test-resources-embedded/src/test2/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -39,7 +39,7 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
     private static final String DIALECT = "dialect";
-    private static final String DRIVER = "driverClassName";
+    private static final String DRIVER = "driver-class-name";
     private static final String DB_NAME = "db-name";
     private static final String INIT_SCRIPT = "init-script-path";
 


### PR DESCRIPTION
This commit fixes the test resource resolvers which were returning properties using camel case. In order to make sure new resolvers, or resolvers implemented by users, only make use of kebab case, we added a check in the embedded resolver: this resolver is the one which is used to collect all resolvers from classpath, and is used in both the test resources service and in embedded mode.

Fixes #183