### PR TITLE
Fix close methods returning void

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
@@ -88,13 +88,13 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
     }
 
     @Override
-    public void closeAll() {
-        doGet(CLOSE_ALL_URI, Argument.STRING);
+    public boolean closeAll() {
+        return doGet(CLOSE_ALL_URI, Argument.BOOLEAN);
     }
 
     @Override
-    public void closeScope(@Nullable String id) {
-        doGet(CLOSE_URI, Argument.STRING, id);
+    public boolean closeScope(@Nullable String id) {
+        return doGet(CLOSE_URI, Argument.BOOLEAN, id);
     }
 
     private <T> T doGet(URI uri, Argument<T> clazz, String... pathElements) {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
@@ -60,8 +60,8 @@ public interface TestResourcesClient extends TestResourcesResolver {
      * Closes all test resources.
      */
     @Get("/close/all")
-    void closeAll();
+    boolean closeAll();
 
     @Get("/close/{id}")
-    void closeScope(@Nullable String id);
+    boolean closeScope(@Nullable String id);
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -81,11 +81,13 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
         }
 
         @Override
-        public void closeAll() {
+        public boolean closeAll() {
+            return true;
         }
 
         @Override
-        public void closeScope(@Nullable String id) {
+        public boolean closeScope(@Nullable String id) {
+            return true;
         }
     }
 

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
@@ -97,13 +97,13 @@ public final class TestResourcesController implements TestResourcesResolver {
     }
 
     @Get("/close/all")
-    public void closeAll() {
-        TestContainers.closeAll();
+    public boolean closeAll() {
+        return TestContainers.closeAll();
     }
 
     @Get("/close/{id}")
-    public void closeScope(@Nullable String id) {
-        TestContainers.closeScope(id);
+    public boolean closeScope(@Nullable String id) {
+        return TestContainers.closeScope(id);
     }
 
     @Get("/testcontainers")

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesControllerTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesControllerTest.groovy
@@ -63,9 +63,9 @@ class TestResourcesControllerTest extends Specification {
          * Closes all test resources.
          */
         @Get("/close/all")
-        void closeAll();
+        boolean closeAll();
 
         @Get("/close/{id}")
-        void closeScope(@Nullable String id);
+        boolean closeScope(@Nullable String id);
     }
 }


### PR DESCRIPTION
This causes errors with the HTTP client. As it is an API breaking change, it's only for 2.0.0.