### PR TITLE
Remove publication of test fixtures

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-fixtures.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-fixtures.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java-test-fixtures'
+}
+
+components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-core/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
-    id 'java-test-fixtures'
+    id 'io.micronaut.build.internal.test-fixtures'
 }
 
 description = """

--- a/test-resources-jdbc/test-resources-jdbc-core/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.testcontainers-module'
-    id 'java-test-fixtures'
+    id 'io.micronaut.build.internal.test-fixtures'
 }
 
 description = """

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.localstack-module'
-    id 'java-test-fixtures'
+    id 'io.micronaut.build.internal.test-fixtures'
 }
 
 description = """

--- a/test-resources-testcontainers/build.gradle
+++ b/test-resources-testcontainers/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.micronaut.build.internal.test-resources-module'
-    id 'java-test-fixtures'
+    id 'io.micronaut.build.internal.test-fixtures'
 }
 
 description = """


### PR DESCRIPTION
Those test fixtures were published on Maven Central, but they are not intended for external consumption. This will make the publication of Micronaut Test Resources 2.0.0 easier, since we won't depend on any other Micronaut module (except for core).