### PR TITLE
Add tmpfs support

### DIFF
--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -65,6 +65,24 @@ test-resources:
         - "path/to/local/readwrite-file.conf": /path/to/container/readwrite-file.conf
 ----
 
+Furthermore, generic containers can use tmpfs bindings (in read-only or read-write mode):
+
+[configuration]
+----
+test-resources:
+  containers:
+    mycontainer:
+      image-name: my/container
+      hostnames:
+        - my.service.host
+      exposed-ports:
+        - my.service.port: 1883
+      ro-tmpfs-mappings:
+        - /path/to/readonly/container/file
+      rw-fs-bind:
+        - /path/to/readwrite/container/file
+----
+
 It is also possible to copy files from the host to the container:
 
 [configuration]

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -65,7 +65,7 @@ test-resources:
         - "path/to/local/readwrite-file.conf": /path/to/container/readwrite-file.conf
 ----
 
-Furthermore, generic containers can use tmpfs bindings (in read-only or read-write mode):
+Furthermore, generic containers can use tmpfs mappings (in read-only or read-write mode):
 
 [configuration]
 ----
@@ -79,7 +79,7 @@ test-resources:
         - my.service.port: 1883
       ro-tmpfs-mappings:
         - /path/to/readonly/container/file
-      rw-fs-bind:
+      rw-tmpfs-mappings:
         - /path/to/readwrite/container/file
 ----
 

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
@@ -33,6 +33,8 @@ final class TestContainerMetadata {
 
     private final Map<String, String> rwFsBinds;
     private final Map<String, String> roFsBinds;
+    private final Set<String> rwTmpfsMappings;
+    private final Set<String> roTmpfsMappings;
     private final List<String> command;
     private final String workingDirectory;
     private final Map<String, String> env;
@@ -54,6 +56,8 @@ final class TestContainerMetadata {
                           Set<String> hostNames,
                           Map<String, String> rwFsBinds,
                           Map<String, String> roFsBinds,
+                          Set<String> rwTmpfsMappings,
+                          Set<String> roTmpfsMappings,
                           List<String> command,
                           String workingDirectory,
                           Map<String, String> env,
@@ -73,6 +77,8 @@ final class TestContainerMetadata {
         this.hostNames = hostNames;
         this.rwFsBinds = rwFsBinds;
         this.roFsBinds = roFsBinds;
+        this.rwTmpfsMappings = rwTmpfsMappings;
+        this.roTmpfsMappings = roTmpfsMappings;
         this.command = command;
         this.workingDirectory = workingDirectory;
         this.env = env;
@@ -161,6 +167,14 @@ final class TestContainerMetadata {
 
     public Optional<WaitStrategy> getWaitStrategy() {
         return Optional.ofNullable(waitStrategy);
+    }
+
+    public Set<String> getRwTmpfsMappings() {
+        return rwTmpfsMappings;
+    }
+
+    public Set<String> getRoTmpfsMappings() {
+        return roTmpfsMappings;
     }
 
     public static final class CopyFileToContainer {

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -116,6 +116,29 @@ class TestContainerMetadataSupportTest extends Specification {
         }
     }
 
+    def "reads tmpfs mappings"() {
+        def config = """
+            containers:
+                foo:
+                    ro-tmpfs-mappings:
+                        - /some/path
+                        - /some/other/path
+                    rw-tmpfs-mappings:
+                        - /yet/another/path
+                        - /yet/another/other/path
+        """
+
+        when:
+        def md = metadataFrom(config, "foo")
+
+        then:
+        md.present
+        md.get().with {
+            assert it.roTmpfsMappings.containsAll(['/some/path', '/some/other/path'])
+            assert it.rwTmpfsMappings.containsAll(['/yet/another/path', '/yet/another/other/path'])
+        }
+    }
+
     def "reads command"() {
         def config = """
                 containers:


### PR DESCRIPTION
`testcontainers-java` added [tmpfs](https://docs.docker.com/storage/tmpfs/) support in https://github.com/testcontainers/testcontainers-java/issues/673. This allows for containers to have lightning fast ephemeral storage, which may be preferable for containers that are for data storage. (e.g. elasticsearch container is _way_ faster with a tmpfs bind).

This PR adds the option to configure tmpfs mappings on `GenericContainer`s.

Follow up PRs could add true/false tmpfs mapping option to jdbc/mongo/elasticsearch.