### PR TITLE
Add support for multiple mongodb server uris

### DIFF
--- a/src/main/docs/guide/modules-mongodb.adoc
+++ b/src/main/docs/guide/modules-mongodb.adoc
@@ -3,3 +3,9 @@ MongoDB support will automatically start a https://www.mongodb.com[MongoDB conta
 The default image can be overwritten by setting the `test-resources.containers.mongodb.image-name` property.
 
 The default database name can be overwritten by setting the `test-resources.containers.mongodb.db-name` property.
+
+Alternatively, if you have multiple MongoDB servers declared in your configuration, the test resources service will supply a different replica set for each database.
+
+For example, if you have `mongodb.servers.users` and `mongodb.servers.books` defined, then the test resources service will supply the `mongodb.servers.users.uri` and `mondodb.servers.books.uri` properties.
+
+Note that in this case, a _single_ server is used, the value of `test-resources.containers.mongodb.db-name` is ignored, and the database name is set to the name of the database you declared (in this example, this would be respectively `users` and `books`).

--- a/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/BookRepository.groovy
+++ b/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/BookRepository.groovy
@@ -3,7 +3,7 @@ package io.micronaut.testresources.mongodb
 import io.micronaut.data.mongodb.annotation.MongoRepository
 import io.micronaut.data.repository.CrudRepository
 
-@MongoRepository
+@MongoRepository(databaseName = "default")
 interface BookRepository extends CrudRepository<Book, String> {
 
 }

--- a/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/MultipleMongoDBTest.groovy
+++ b/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/MultipleMongoDBTest.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.testresources.mongodb
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+
+@MicronautTest(environments = "multiple-servers")
+class MultipleMongoDBTest extends AbstractMongoDBSpec {
+
+    @Inject
+    BookRepository bookRepository
+
+    @Inject
+    UserRepository userRepository
+
+    @Value("\${mongodb.servers.default.uri}")
+    String mongodbDefaultUri
+
+    @Value("\${mongodb.servers.another.uri}")
+    String mongodbAnotherUri
+
+    def "automatically starts a MongoDB container"() {
+        given:
+        def book = new Book(title: "Micronaut for Spring developers")
+        bookRepository.save(book)
+
+        def user = new User(name: "Cédric Champeau")
+        userRepository.save(user)
+
+        when:
+        def books = bookRepository.findAll()
+        def users = userRepository.findAll()
+
+        then:
+        books.size() == 1
+        users.size() == 1
+
+        and:
+        mongodbDefaultUri.endsWith('/default')
+        mongodbAnotherUri.endsWith('/another')
+    }
+
+}

--- a/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/User.groovy
+++ b/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/User.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.testresources.mongodb
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+
+@MappedEntity
+@Introspected
+class User {
+    @GeneratedValue
+    @Id
+    String id
+
+    String name
+}

--- a/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/UserRepository.groovy
+++ b/test-resources-mongodb/src/test/groovy/io/micronaut/testresources/mongodb/UserRepository.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testresources.mongodb
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.data.mongodb.annotation.MongoRepository
+import io.micronaut.data.repository.CrudRepository
+
+@MongoRepository(databaseName = "another")
+@Requires(env = "multiple-servers")
+interface UserRepository extends CrudRepository<User, String> {
+
+}

--- a/test-resources-mongodb/src/test/resources/application-multiple-servers.yml
+++ b/test-resources-mongodb/src/test/resources/application-multiple-servers.yml
@@ -1,0 +1,5 @@
+mongodb:
+  servers:
+    default:
+      use-serde: false
+    another:


### PR DESCRIPTION
This commit adds the ability to use multiple MongoDB databases. It's worth noting that we will spawn a _single_ MongoDB container, and that the name of the replica set is going to be set to the database name in your Micronaut configuration.

Closes #142