### PR TITLE
fix: handle accept license as string

### DIFF
--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -47,8 +47,7 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     public static MSSQLServerContainer<?> createMSSQLContainer(DockerImageName imageName, String simpleName, Map<String, Object> testResourcesConfiguration) {
         MSSQLServerContainer<?> container = new MSSQLServerContainer<>(imageName);
         String licenseKey = "containers." + simpleName + ".accept-license";
-        Boolean acceptLicense = (Boolean) testResourcesConfiguration.get(licenseKey);
-        if (Boolean.TRUE.equals(acceptLicense)) {
+        if (shouldAcceptLicense(licenseKey, testResourcesConfiguration)) {
             container.acceptLicense();
         } else {
             try {
@@ -60,4 +59,21 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
         return container;
     }
 
+    /**
+     *
+     * @param licenseKey License Key
+     * @param testResourcesConfiguration Test Resources Configuration
+     * @return {@code false} if no value found in Test Resources Configuration for the license key, otherwise it returns the object if it is a  boolean, or it parses the value to a boolean using {@link Boolean#parseBoolean(String)}.
+     */
+    public static boolean shouldAcceptLicense(String licenseKey, Map<String, Object> testResourcesConfiguration) {
+        Object obj = testResourcesConfiguration.get(licenseKey);
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof Boolean b) {
+            return b;
+        } else {
+            return Boolean.parseBoolean(obj.toString());
+        }
+    }
 }

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/test/groovy/io/micronaut/testresources/mssql/MSSQLTestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/test/groovy/io/micronaut/testresources/mssql/MSSQLTestResourceProviderSpec.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.testresources.mssql
+
+import io.micronaut.core.util.StringUtils;
+import spock.lang.Specification;
+
+class MSSQLTestResourceProviderSpec extends Specification {
+
+    void "verify String is parsed into boolean for the value of accept-license"(Object value) {
+        String licenseKey = "containers.mssql.accept-license"
+        Map<String, Object> testResourcesConfiguration = [(licenseKey): value]
+        when:
+        boolean accept = MSSQLTestResourceProvider.shouldAcceptLicense(licenseKey, testResourcesConfiguration)
+
+        then:
+        noExceptionThrown()
+        accept
+
+        where:
+        value << [StringUtils.TRUE, true, Boolean.TRUE]
+    }
+
+
+}


### PR DESCRIPTION
solve issues found in starter

```
ERROR i.m.http.server.RouteExecutor - Unexpected error occurred: class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')
	at io.micronaut.testresources.mssql.MSSQLTestResourceProvider.createMSSQLContainer(MSSQLTestResourceProvider.java:50)
``