### PR TITLE
Fix scope listeners

### DIFF
--- a/test-resources-extensions/test-resources-extensions-junit-platform/build.gradle
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     api(projects.micronautTestResourcesClient)
     implementation(libs.junit.jupiter.api)
     implementation(libs.junit.platform.launcher)
+    compileOnly(mnTest.micronaut.test.spock) {
+        because("This project provides a Spock extension for @Shared fields")
+    }
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)
     testFixturesAnnotationProcessor(mn.micronaut.inject.java)

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/koTest/kotlin/io/micronaut/test/extensions/junit5/BeforeSpecScopeTest.kt
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/koTest/kotlin/io/micronaut/test/extensions/junit5/BeforeSpecScopeTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5
+
+import io.kotest.matchers.shouldBe
+import io.micronaut.test.extensions.junit5.annotation.ScopeNamingStrategy
+import io.micronaut.test.extensions.junit5.annotation.TestResourcesScope
+import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+
+@MicronautTest
+@TestResourcesScope(namingStrategy = ScopeNamingStrategy.TestClassName::class)
+internal class BeforeSpecScopeTest : ParentTestWithScope({
+    var scope: String? = null
+
+    beforeSpec {
+        scope = ScopeHolder.get().orElse(null)
+    }
+
+    "scope name is the current test class name"() {
+        scope shouldBe BeforeSpecScopeTest::class.java.name
+    }
+})

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/ScopeHolder.java
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/ScopeHolder.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * service loading, we are using a thread local to share information.
  */
 @Internal
-final class ScopeHolder {
+public final class ScopeHolder {
     private static final ThreadLocal<String> CURRENT_SCOPE = ThreadLocal.withInitial(() -> null);
 
     private ScopeHolder() {

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/SpockScopeExtension.java
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/SpockScopeExtension.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5;
+
+import io.micronaut.test.extensions.junit5.annotation.ScopeNamingStrategy;
+import org.spockframework.runtime.extension.IGlobalExtension;
+import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.model.SpecInfo;
+
+import static io.micronaut.test.extensions.junit5.TestResourcesScopeListener.findTestResourceScopeAnnotation;
+
+/**
+ * A Spock extension which handles fields annotated with the shared
+ * annotation.
+ */
+public class SpockScopeExtension implements IGlobalExtension {
+    @Override
+    public void visitSpec(SpecInfo spec) {
+        spec.addSharedInitializerInterceptor(invocation -> {
+            maybeSetScope(invocation);
+            invocation.proceed();
+        });
+    }
+
+    private static void maybeSetScope(IMethodInvocation invocation) {
+        var clazz = invocation.getInstance().getClass();
+        findTestResourceScopeAnnotation(clazz).ifPresent(scopeAnn -> {
+            String scopeName = scopeAnn.value();
+            if (scopeName == null || scopeName.isEmpty()) {
+                var namingStrategy = scopeAnn.namingStrategy();
+                if (!namingStrategy.equals(ScopeNamingStrategy.class)) {
+                    var scopeNamingStrategy = TestResourcesScopeListener.instantitateStrategy(namingStrategy);
+                    scopeName = scopeNamingStrategy.scopeNameFor(clazz);
+                }
+            }
+            ScopeHolder.set(scopeName);
+        });
+    }
+}

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/TestResourcesLauncherSessionListener.java
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/TestResourcesLauncherSessionListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * In a single JVM, tests can be executed in different sessions (e.g when test
+ * distribution is active). This listener makes sure that all sessions share
+ * the same scope listener, so that scopes are not closed whenever a single
+ * session is done (because a resource can be used in different sessions at
+ * the same time).
+ */
+public class TestResourcesLauncherSessionListener implements LauncherSessionListener {
+    private final TestResourcesScopeListener scopeListener = new TestResourcesScopeListener();
+
+    @Override
+    public void launcherSessionOpened(LauncherSession session) {
+        session.getLauncher().registerTestExecutionListeners(scopeListener);
+    }
+}

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/annotation/ScopeNamingStrategy.java
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/java/io/micronaut/test/extensions/junit5/annotation/ScopeNamingStrategy.java
@@ -15,43 +15,26 @@
  */
 package io.micronaut.test.extensions.junit5.annotation;
 
-import org.junit.platform.engine.support.descriptor.ClassSource;
-import org.junit.platform.launcher.TestIdentifier;
-
 /**
  * Provides the name of a test resources scope to
  * be used in a test class.
  */
 @FunctionalInterface
 public interface ScopeNamingStrategy {
-    String scopeNameFor(TestIdentifier testId);
+    String scopeNameFor(Class<?> testClass);
 
     class TestClassName implements ScopeNamingStrategy {
         @Override
-        public String scopeNameFor(TestIdentifier testId) {
-            var source = testId.getSource();
-            if (source.isPresent()) {
-                var testSource = source.get();
-                if (testSource instanceof ClassSource classSource) {
-                    return classSource.getClassName();
-                }
-            }
-            return null;
+        public String scopeNameFor(Class<?> testClass) {
+            return testClass.getName();
         }
     }
 
     class PackageName implements ScopeNamingStrategy {
 
         @Override
-        public String scopeNameFor(TestIdentifier testId) {
-            var source = testId.getSource();
-            if (source.isPresent()) {
-                var testSource = source.get();
-                if (testSource instanceof ClassSource classSource) {
-                    return classSource.getJavaClass().getPackageName();
-                }
-            }
-            return null;
+        public String scopeNameFor(Class<?> testClass) {
+            return testClass.getPackageName();
         }
     }
 }

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+io.micronaut.test.extensions.junit5.TestResourcesLauncherSessionListener

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,1 +1,0 @@
-io.micronaut.test.extensions.junit5.TestResourcesScopeListener

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,1 @@
+io.micronaut.test.extensions.junit5.SpockScopeExtension

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/spockTest/groovy/io/micronaut/test/extensions/junit5/SetupAnnotationScopeTest.groovy
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/spockTest/groovy/io/micronaut/test/extensions/junit5/SetupAnnotationScopeTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5
+
+import io.micronaut.test.extensions.junit5.annotation.TestResourcesScope
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+
+@MicronautTest
+@TestResourcesScope("hello")
+class SetupAnnotationScopeTest extends AbstractScopedTest {
+
+    static String scopeName
+
+    def setupSpec() {
+        scopeName = ScopeHolder.get().orElse(null)
+    }
+
+    def "sees the current class scope"() {
+        expect:
+        "hello" == scopeName
+    }
+
+}

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/spockTest/groovy/io/micronaut/test/extensions/junit5/SharedAnnotationScopeTest.groovy
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/spockTest/groovy/io/micronaut/test/extensions/junit5/SharedAnnotationScopeTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.junit5
+
+import io.micronaut.test.extensions.junit5.annotation.TestResourcesScope
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Shared
+
+@MicronautTest
+@TestResourcesScope("hello")
+class SharedAnnotationScopeTest extends AbstractScopedTest {
+
+    @Shared
+    String scopeName = ScopeHolder.get().orElse(null)
+
+    def "sees the current class scope"() {
+        expect:
+        "hello" == scopeName
+    }
+
+}


### PR DESCRIPTION
This commit fixes a few issues with the current scope listening implementation:

1. use the test class for naming strategy instead of the test id: this avoids leaking the launcher API types and makes it easier to use without JUnit specific APIs
2. whenever tests were using a single JVM but multiple sessions, which happens when test distribution is enabled, then the scopes could be closed even if the next session had a test reusing the same scope
3. Spock provides a `@Shared` annotation which can be used to initialize shared state, but this code is executed _before_ the test is considered started, which breaks the assumption made in the scope listener

This should fix issues with Micronaut Data not closing scopes.