### PR TITLE
Make sure we can't use MariaDB instead of MySQL

### DIFF
--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -89,8 +89,8 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         }
         String datasource = datasourceNameFrom(propertyName);
         String type = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, TYPE)));
-        if (type != null && getDbTypes().stream().anyMatch(type::equalsIgnoreCase)) {
-            return true;
+        if (type != null) {
+            return getDbTypes().stream().anyMatch(type::equalsIgnoreCase);
         }
         String dialect = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, DIALECT)));
         if (dialect != null && dialect.equalsIgnoreCase(getSimpleName())) {


### PR DESCRIPTION
or the other way around. Currently, if both the MariaDB and MySQL test resources providers are present, then because they share the same dialect, it is possible that we select one provider or the other randomly, based on which comes first.

To fix this, we now make sure that if the `db-type` property is set, then we only return a container if it is actually capable of handling that db type. Since this test comes first, before the dialect, it has higher precedence and we wouldn't pick one container for the other.