### PR TITLE
Fix YamlPropertySourceLoader being added on classpath

### DIFF
--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -46,8 +46,8 @@ micronaut {
         convertYamlToJava.set(false)
         precomputeOperations.set(true)
         deduceEnvironment.set(true)
-        // Workaround for an AOT conversion bug
         replaceLogbackXml.set(true)
+        configFile.set(file("src/aot/aot.properties"))
     }
 }
 

--- a/test-resources-server/src/aot/aot.properties
+++ b/test-resources-server/src/aot/aot.properties
@@ -1,0 +1,1 @@
+serviceloading.rejected.impls=io.micronaut.context.env.yaml.YamlPropertySourceLoader


### PR DESCRIPTION
The previous fix (#266) wasn't sufficient, as when you don't use any YAML configuration file, the YAML property source loader is still added my Micronaut AOT to the list of services which are "statically" loaded. This probably requires a fix in Micronaut AOT. In between, this configuration makes sure that the loader isn't added.