### PR TITLE
Reverting mysql r2dbc library, did not work well in micronaut data tests

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -51,7 +51,7 @@ public final class TestResourcesClasspath implements KnownModules {
     private static final String MICRONAUT_DATA_MONGODB = "micronaut-data-mongodb";
     private static final String MICRONAUT_DATA_R2DBC = "micronaut-data-r2dbc";
     private static final String MYSQL_CONNECTOR_JAVA = "mysql-connector-java";
-    private static final String REACTIVE_MYSQL_DRIVER = "io.asyncer:r2dbc-mysql";
+    private static final String REACTIVE_MYSQL_DRIVER = "dev.miku:r2dbc-mysql";
     private static final String MSSQL_DRIVER = "com.microsoft.sqlserver:mssql-jdbc";
     private static final String REACTIVE_MSSQL_DRIVER = "io.r2dbc:r2dbc-mssql";
     private static final String MYSQL_MYSQL_CONNECTOR_JAVA = "mysql:mysql-connector-java";

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -61,7 +61,7 @@ class TestResourcesClasspathTest extends Specification {
         'com.oracle.database.jdbc:ojdbc8'        | []
         'com.oracle.database.jdbc:ojdbc10'       | []
         'com.oracle.database.jdbc:ojdbc11'       | []
-        'io.asyncer:r2dbc-mysql'                 | []
+        'dev.miku:r2dbc-mysql'                   | []
         'org.mariadb:r2dbc-mariadb'              | []
         'org.postgresql:r2dbc-postgresql'        | []
         'com.oracle.database.r2dbc:oracle-r2dbc' | []
@@ -131,7 +131,7 @@ class TestResourcesClasspathTest extends Specification {
 
         where:
         driver                                   | module
-        'io.asyncer:r2dbc-mysql'                 | 'mysql'
+        'dev.miku:r2dbc-mysql'                   | 'mysql'
         'org.mariadb:r2dbc-mariadb'              | 'mariadb'
         'org.postgresql:r2dbc-postgresql'        | 'postgresql'
         'com.oracle.database.r2dbc:oracle-r2dbc' | 'oracle-xe'


### PR DESCRIPTION
Need to revert this, tests passed in r2dbc but are failing in micronaut-data. This does not appear to be reliable library yet, at least not compatible with retrieving results as previous one we used.