### PR TITLE
Implement binary protocol between client and server

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -8,5 +8,15 @@
     "type": "io.micronaut.testresources.client.DefaultTestResourcesClient",
     "member": "Constructor io.micronaut.testresources.client.DefaultTestResourcesClient(io.micronaut.http.client.HttpClient,java.lang.String)",
     "reason": "This type is internal API"
+  },
+  {
+    "type": "io.micronaut.testresources.client.TestResourcesClient",
+    "member": "Implemented interface io.micronaut.testresources.core.TestResourcesResolver",
+    "reason": "With the custom codec the client can no longer directly implement the interface"
+  },
+  {
+    "type": "io.micronaut.testresources.client.TestResourcesClient",
+    "member": "Implemented interface io.micronaut.core.order.Ordered",
+    "reason": "Was supplied by the test resources resolver"
   }
 ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,7 @@ def localstackModules = [
 
 include 'test-resources-bom'
 include 'test-resources-build-tools'
+include 'test-resources-codec'
 include 'test-resources-core'
 include 'test-resources-client'
 include 'test-resources-elasticsearch'

--- a/test-resources-client/build.gradle
+++ b/test-resources-client/build.gradle
@@ -9,8 +9,7 @@ and provide their value on demand.
 """
 
 dependencies {
-    api(mn.micronaut.json.core)
     api(project(':micronaut-test-resources-core'))
-
-    testRuntimeOnly(mn.micronaut.http.server.netty)
+    api(project(":micronaut-test-resources-codec"))
+    testImplementation(mn.micronaut.http.server.netty)
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
@@ -16,9 +16,7 @@
 package io.micronaut.testresources.client;
 
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Post;
-import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.codec.Result;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -30,38 +28,27 @@ import java.util.Optional;
  * A client responsible for connecting to a test resources
  * server.
  */
-public interface TestResourcesClient extends TestResourcesResolver {
+public interface TestResourcesClient {
     String SERVER_URI = "server.uri";
     String ACCESS_TOKEN = "server.access.token";
     String CLIENT_READ_TIMEOUT = "server.client.read.timeout";
 
-    @Get("/list")
-    default List<String> getResolvableProperties() {
+    default Result<List<String>> getResolvableProperties() {
         return getResolvableProperties(Collections.emptyMap(), Collections.emptyMap());
     }
 
-    @Override
-    @Post("/list")
-    List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig);
+    Result<List<String>> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig);
 
-    @Override
-    @Post("/resolve")
-    Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig);
+    Optional<Result<String>> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig);
 
-    @Override
-    @Get("/requirements/expr/{expression}")
-    List<String> getRequiredProperties(String expression);
+    Result<List<String>> getRequiredProperties(String expression);
 
-    @Override
-    @Get("/requirements/entries")
-    List<String> getRequiredPropertyEntries();
+    Result<List<String>> getRequiredPropertyEntries();
 
     /**
      * Closes all test resources.
      */
-    @Get("/close/all")
-    boolean closeAll();
+    Result<Boolean> closeAll();
 
-    @Get("/close/{id}")
-    boolean closeScope(@Nullable String id);
+    Result<Boolean> closeScope(@Nullable String id);
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertySourceLoader.java
@@ -16,6 +16,7 @@
 package io.micronaut.testresources.client;
 
 import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.testresources.codec.Result;
 import io.micronaut.testresources.core.LazyTestResourcesPropertySourceLoader;
 import io.micronaut.testresources.core.PropertyExpressionProducer;
 
@@ -51,6 +52,7 @@ public class TestResourcesClientPropertySourceLoader extends LazyTestResourcesPr
         public List<String> getPropertyEntries() {
             return findClient(null)
                 .map(TestResourcesClient::getRequiredPropertyEntries)
+                .map(Result::value)
                 .orElse(Collections.emptyList());
         }
 
@@ -58,6 +60,7 @@ public class TestResourcesClientPropertySourceLoader extends LazyTestResourcesPr
         public List<String> produceKeys(ResourceLoader resourceLoader, Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
             return findClient(resourceLoader)
                 .map(client -> client.getResolvableProperties(propertyEntries, testResourcesConfig))
+                .map(Result::value)
                 .orElse(Collections.emptyList());
         }
 

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
@@ -1,44 +1,45 @@
 package io.micronaut.testresources.client
 
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
-import io.micronaut.testresources.core.TestResourcesResolver
+import io.micronaut.http.annotation.Produces
+import io.micronaut.testresources.codec.Result
+import io.micronaut.testresources.codec.TestResourcesMediaType
 
 @Controller("/")
 @Requires(property = 'server', notEquals = 'false')
-class TestServer implements TestResourcesResolver {
+@Produces(TestResourcesMediaType.TEST_RESOURCES_BINARY)
+@Consumes(TestResourcesMediaType.TEST_RESOURCES_BINARY)
+class TestServer {
 
-    @Override
     @Post("/list")
-    List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        ["dummy1", "dummy2", "missing"]
+    Result<List<String>> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        Result.of(["dummy1", "dummy2", "missing"])
     }
 
-    @Override
     @Get("/requirements/expr/{expression}")
-    List<String> getRequiredProperties(String expression) {
-        []
+    Result<List<String>> getRequiredProperties(String expression) {
+        Result.of([])
     }
 
-    @Override
     @Get("/requirements/entries")
-    List<String> getRequiredPropertyEntries() {
-        []
+    Result<List<String>> getRequiredPropertyEntries() {
+        Result.of([])
     }
 
-    @Override
     @Post('/resolve')
-    Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+    Optional<Result<String>> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
         if ("missing" == name) {
             return Optional.empty()
         }
-        Optional.of("value for $name".toString())
+        Result.asOptional("value for $name".toString())
     }
 
     @Get("/close/all")
-    void closeAll() {
-
+    Result<Boolean> closeAll() {
+        Result.TRUE
     }
 }

--- a/test-resources-codec/build.gradle
+++ b/test-resources-codec/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id("io.micronaut.build.internal.test-resources-module")
+}
+
+dependencies {
+    implementation(mn.micronaut.http)
+}
+
+micronautBuild {
+    def simpleVersion = version
+    if (version.contains('-')) {
+        simpleVersion = version.substring(0, version.indexOf('-'))
+    }
+    def (String major, String minor, String patch) = simpleVersion.split("[.]")
+    binaryCompatibility.enabled = major.toInteger() >=2 && minor.toInteger() >= 0 && patch.toInteger() > 0
+}

--- a/test-resources-codec/src/main/java/io/micronaut/testresources/codec/Result.java
+++ b/test-resources-codec/src/main/java/io/micronaut/testresources/codec/Result.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.codec;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A wrapper type which is used for all messages between the client and
+ * the server as return types. This is done because types like String are
+ * otherwise treated differently by Micronaut, bypassing our codec.
+ *
+ * Note that it is possible to skip this type for types like `List`
+ * or `Map` but it makes the code less understandable since in some
+ * cases the codec would be called and some others not.
+ *
+ * Therefore, for consistency, all argument types are wrapped in that
+ * result type.
+ *
+ * @param value the value to be wrapped
+ * @param <T> the type of the result
+ */
+public record Result<T>(T value) {
+    public static final Result<Boolean> TRUE = new Result<>(true);
+    public static final Result<Boolean> FALSE = new Result<>(false);
+
+    private static final Result<?> EMPTY_LIST = new Result<>(Collections.emptyList());
+
+    /**
+     * Wraps a value into a result type.
+     * @param value the value
+     * @return the wrapped value
+     * @param <V> the type of the value
+     */
+    public static <V> Result<V> of(@NonNull V value) {
+        return new Result<>(value);
+    }
+
+    /**
+     * Wraps a potentially null value into an optional.
+     * If the value is null, then it returns an empty optional.
+     * If the value is not null, then it returns an optional
+     * which value is a wrapped result.
+     * @param value the value
+     * @return an optional of wrapped value
+     * @param <V> the type of the value
+     */
+    public static <V> Optional<Result<V>> asOptional(@Nullable V value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Result<>(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <V> Result<List<V>> emptyList() {
+        return (Result<List<V>>) EMPTY_LIST;
+    }
+}

--- a/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesBodyHandler.java
+++ b/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesBodyHandler.java
@@ -20,6 +20,7 @@ import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.Headers;
 import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Produces;
@@ -72,7 +73,7 @@ public class TestResourcesBodyHandler<T> implements MessageBodyHandler<T> {
             }
             return (T) result;
         } catch (IOException e) {
-            throw new CodecException("Invalid binary stream", e);
+            throw new CodecException("Test resources wasn't able to decode response", e);
         }
     }
 
@@ -80,10 +81,10 @@ public class TestResourcesBodyHandler<T> implements MessageBodyHandler<T> {
     public void writeTo(Argument<T> type, MediaType mediaType, T object, MutableHeaders outgoingHeaders, OutputStream outputStream) throws CodecException {
         try {
             var dos = new DataOutputStream(outputStream);
-            outgoingHeaders.set("Content-Type", TEST_RESOURCES_BINARY_MEDIA_TYPE);
+            outgoingHeaders.set(HttpHeaders.CONTENT_TYPE, TEST_RESOURCES_BINARY_MEDIA_TYPE);
             TestResourcesCodec.writeObject(object, dos);
         } catch (IOException e) {
-            throw new CodecException("Invalid binary stream", e);
+            throw new CodecException("Test resources wasn't able to encode response", e);
         }
     }
 

--- a/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesBodyHandler.java
+++ b/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesBodyHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.codec;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.core.convert.value.ConvertibleValues;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.Headers;
+import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.body.MessageBodyHandler;
+import io.micronaut.http.codec.CodecException;
+import jakarta.inject.Singleton;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import static io.micronaut.testresources.codec.TestResourcesMediaType.TEST_RESOURCES_BINARY;
+import static io.micronaut.testresources.codec.TestResourcesMediaType.TEST_RESOURCES_BINARY_MEDIA_TYPE;
+
+/**
+ * The test resources binary protocol body handler.
+ *
+ * @param <T> the type of the arguments
+ * @since 2.0.0
+ */
+@Singleton
+@Consumes(TEST_RESOURCES_BINARY)
+@Produces(TEST_RESOURCES_BINARY)
+@BootstrapContextCompatible
+public class TestResourcesBodyHandler<T> implements MessageBodyHandler<T> {
+    @Override
+    public boolean isReadable(Argument<T> type, MediaType mediaType) {
+        return mediaType.matches(TEST_RESOURCES_BINARY_MEDIA_TYPE);
+    }
+
+    @Override
+    public boolean isWriteable(Argument<T> type, MediaType mediaType) {
+        return mediaType.matches(TEST_RESOURCES_BINARY_MEDIA_TYPE);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T read(Argument<T> type, MediaType mediaType, Headers httpHeaders, InputStream inputStream) throws CodecException {
+        try {
+            var dis = new DataInputStream(inputStream);
+            var result = TestResourcesCodec.readObject(dis);
+            if (result instanceof Map map && type.getType().equals(ConvertibleValues.class)) {
+                return (T) ConvertibleValues.of(map);
+            }
+            if (Result.class.equals(type.getType())) {
+                return (T) Result.of(result);
+            }
+            return (T) result;
+        } catch (IOException e) {
+            throw new CodecException("Invalid binary stream", e);
+        }
+    }
+
+    @Override
+    public void writeTo(Argument<T> type, MediaType mediaType, T object, MutableHeaders outgoingHeaders, OutputStream outputStream) throws CodecException {
+        try {
+            var dos = new DataOutputStream(outputStream);
+            outgoingHeaders.set("Content-Type", TEST_RESOURCES_BINARY_MEDIA_TYPE);
+            TestResourcesCodec.writeObject(object, dos);
+        } catch (IOException e) {
+            throw new CodecException("Invalid binary stream", e);
+        }
+    }
+
+}

--- a/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesCodec.java
+++ b/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesCodec.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.codec;
+
+import io.micronaut.http.codec.CodecException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This codec is responsible for (de)serializing the binary stream
+ * between the test resources client and server. It is used by the
+ * message body handler in the controller, but also directly by
+ * the test resources client to decode messages.
+ *
+ * @since 2.0.0
+ */
+public final class TestResourcesCodec {
+    private TestResourcesCodec() {
+
+    }
+
+    public static <V> V readObject(DataInputStream dis) throws IOException {
+        var kind = SupportedType.of(dis.readByte());
+        return switch (kind) {
+            case NULL -> null;
+            case RESULT -> readObject(dis);
+            case BOOLEAN -> cast(dis.readBoolean());
+            case INTEGER -> cast(dis.readInt());
+            case STRING -> cast(dis.readUTF());
+            case LIST -> {
+                int count = dis.readInt();
+                List<Object> list = new ArrayList<>(count);
+                for (int i = 0; i < count; i++) {
+                    list.add(readObject(dis));
+                }
+                yield cast(Collections.unmodifiableList(list));
+            }
+            case MAP -> {
+                int count = dis.readInt();
+                Map<Object, Object> map = new HashMap<>();
+                for (int i = 0; i < count; i++) {
+                    Object key = readObject(dis);
+                    Object value = readObject(dis);
+                    map.put(key, value);
+                }
+                yield cast(Collections.unmodifiableMap(map));
+            }
+        };
+    }
+
+    public static void writeObject(Object object, DataOutputStream dos) throws IOException {
+        var kind = SupportedType.kindOf(object);
+        if (SupportedType.RESULT == kind) {
+            writeObject(((Result<?>) object).value(), dos);
+            return;
+        }
+        dos.write(kind.asByte());
+        switch (kind) {
+            case BOOLEAN -> dos.writeBoolean((Boolean) object);
+            case INTEGER -> dos.writeInt((Integer) object);
+            case STRING -> dos.writeUTF((String) object);
+            case LIST -> {
+                List<Object> list = cast(object);
+                dos.writeInt(list.size());
+                for (Object o : list) {
+                    writeObject(o, dos);
+                }
+            }
+            case MAP -> {
+                Map<Object, Object> map = cast(object);
+                dos.writeInt(map.size());
+                for (Map.Entry<Object, Object> entry : map.entrySet()) {
+                    writeObject(entry.getKey(), dos);
+                    writeObject(entry.getValue(), dos);
+                }
+            }
+            default -> {
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <V> V cast(Object o) {
+        return (V) o;
+    }
+
+    enum SupportedType {
+        NULL,
+        RESULT,
+        BOOLEAN,
+        INTEGER,
+        STRING,
+        LIST,
+        MAP;
+
+        byte asByte() {
+            return (byte) ordinal();
+        }
+
+        static SupportedType of(byte b) {
+            return SupportedType.values()[b];
+        }
+
+        public static SupportedType kindOf(Object o) {
+            if (o == null) {
+                return NULL;
+            }
+            var clazz = o.getClass();
+            if (Result.class.equals(clazz)) {
+                return RESULT;
+            }
+            if (Boolean.TYPE.equals(clazz) || Boolean.class.equals(clazz)) {
+                return BOOLEAN;
+            }
+            if (String.class.equals(clazz)) {
+                return STRING;
+            }
+            if (List.class.isAssignableFrom(clazz)) {
+                return LIST;
+            }
+            if (Map.class.isAssignableFrom(clazz)) {
+                return MAP;
+            }
+            throw new CodecException("Unsupported type " + clazz);
+        }
+
+    }
+}

--- a/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesMediaType.java
+++ b/test-resources-codec/src/main/java/io/micronaut/testresources/codec/TestResourcesMediaType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.codec;
+
+import io.micronaut.http.MediaType;
+
+/**
+ * Provides constants used to declare the test resources binary
+ * protocol media type.
+ *
+ * @since 2.0.0
+ */
+public final class TestResourcesMediaType {
+    public static final String TEST_RESOURCES_BINARY = "application/x-test-resources+binary";
+    public static final MediaType TEST_RESOURCES_BINARY_MEDIA_TYPE = MediaType.of(TEST_RESOURCES_BINARY);
+
+    private TestResourcesMediaType() {
+
+    }
+}

--- a/test-resources-extensions/test-resources-extensions-core/build.gradle
+++ b/test-resources-extensions/test-resources-extensions-core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api(platform(mnTest.micronaut.test.bom))
     api(mnTest.micronaut.test.core)
     implementation(projects.micronautTestResourcesClient)
+    implementation(projects.micronautTestResourcesCodec)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)

--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
@@ -17,6 +17,7 @@ package io.micronaut.test.extensions.testresources;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.testresources.client.TestResourcesClient;
+import io.micronaut.testresources.codec.Result;
 
 import java.util.Collection;
 import java.util.List;
@@ -58,37 +59,37 @@ public final class TestResourcesClientHolder {
         }
 
         @Override
-        public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        public Result<List<String>> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
             return nullSafe(CLIENT::getResolvableProperties);
         }
 
         @Override
-        public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        public Optional<Result<String>> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
             return nullSafe(() -> CLIENT.resolve(name, properties, testResourcesConfig));
         }
 
         @Override
-        public List<String> getRequiredProperties(String expression) {
+        public Result<List<String>> getRequiredProperties(String expression) {
             return nullSafe(() -> CLIENT.getRequiredProperties(expression));
         }
 
         @Override
-        public List<String> getRequiredPropertyEntries() {
+        public Result<List<String>> getRequiredPropertyEntries() {
             return nullSafe(CLIENT::getRequiredPropertyEntries);
         }
 
         @Override
-        public boolean closeAll() {
+        public Result<Boolean> closeAll() {
             return nullSafe(CLIENT::closeAll);
         }
 
         @Override
-        public boolean closeScope(String id) {
+        public Result<Boolean> closeScope(String id) {
             return nullSafe(() -> CLIENT.closeScope(id));
         }
 
         @Override
-        public List<String> getResolvableProperties() {
+        public Result<List<String>> getResolvableProperties() {
             return nullSafe(CLIENT::getResolvableProperties);
         }
 

--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
@@ -19,6 +19,7 @@ import io.micronaut.test.extensions.testresources.annotation.TestResourcesProper
 import io.micronaut.test.support.TestPropertyProvider;
 import io.micronaut.test.support.TestPropertyProviderFactory;
 import io.micronaut.testresources.client.TestResourcesClientFactory;
+import io.micronaut.testresources.codec.Result;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
@@ -67,7 +68,7 @@ public class TestResourcesPropertiesFactory implements TestPropertyProviderFacto
                 Map<String, String> resolvedProperties = Stream.of(requestedProperties)
                     .map(v -> new Object() {
                         private final String key = v;
-                        private final String value = client.resolve(v, Map.of(), testResourcesConfig).orElse(null);
+                        private final String value = client.resolve(v, Map.of(), testResourcesConfig).map(Result::value).orElse(null);
                     })
                     .filter(o -> o.value != null)
                     .collect(Collectors.toMap(e -> e.key, e -> e.value));

--- a/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
@@ -16,6 +16,7 @@
 package io.micronaut.test.extensions.testresources;
 
 import io.micronaut.testresources.client.TestResourcesClient;
+import io.micronaut.testresources.codec.Result;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,32 +31,32 @@ public class FakeTestResourcesClient implements TestResourcesClient {
     );
 
     @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return MOCK_PROPERTIES.keySet().stream().toList();
+    public Result<List<String>> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return new Result<>(MOCK_PROPERTIES.keySet().stream().toList());
     }
 
     @Override
-    public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-        return Optional.ofNullable(MOCK_PROPERTIES.get(name));
+    public Optional<Result<String>> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        return Result.asOptional(MOCK_PROPERTIES.get(name));
     }
 
     @Override
-    public List<String> getRequiredProperties(String expression) {
-        return List.of();
+    public Result<List<String>> getRequiredProperties(String expression) {
+        return Result.emptyList();
     }
 
     @Override
-    public List<String> getRequiredPropertyEntries() {
-        return List.of();
+    public Result<List<String>> getRequiredPropertyEntries() {
+        return Result.emptyList();
     }
 
     @Override
-    public boolean closeAll() {
-        return true;
+    public Result<Boolean> closeAll() {
+        return Result.TRUE;
     }
 
     @Override
-    public boolean closeScope(String id) {
-        return true;
+    public Result<Boolean> closeScope(String id) {
+        return Result.TRUE;
     }
 }

--- a/test-resources-extensions/test-resources-extensions-junit-platform/src/testFixtures/java/io/micronaut/test/extensions/testresources/junit5/FakeTestResourcesClient.java
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/src/testFixtures/java/io/micronaut/test/extensions/testresources/junit5/FakeTestResourcesClient.java
@@ -16,6 +16,7 @@
 package io.micronaut.test.extensions.testresources.junit5;
 
 import io.micronaut.testresources.client.TestResourcesClient;
+import io.micronaut.testresources.codec.Result;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -32,34 +33,34 @@ public class FakeTestResourcesClient implements TestResourcesClient {
     private static final ThreadLocal<Set<String>> CLOSED_SCOPES = ThreadLocal.withInitial(HashSet::new);
 
     @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return MOCK_PROPERTIES.keySet().stream().toList();
+    public Result<List<String>> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return Result.of(MOCK_PROPERTIES.keySet().stream().toList());
     }
 
     @Override
-    public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-        return Optional.ofNullable(MOCK_PROPERTIES.get(name));
+    public Optional<Result<String>> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        return Result.asOptional(MOCK_PROPERTIES.get(name));
     }
 
     @Override
-    public List<String> getRequiredProperties(String expression) {
-        return List.of();
+    public Result<List<String>> getRequiredProperties(String expression) {
+        return Result.emptyList();
     }
 
     @Override
-    public List<String> getRequiredPropertyEntries() {
-        return List.of();
+    public Result<List<String>> getRequiredPropertyEntries() {
+        return Result.emptyList();
     }
 
     @Override
-    public boolean closeAll() {
-        return true;
+    public Result<Boolean> closeAll() {
+        return Result.TRUE;
     }
 
     @Override
-    public boolean closeScope(String id) {
+    public Result<Boolean> closeScope(String id) {
         CLOSED_SCOPES.get().add(id);
-        return true;
+        return Result.TRUE;
     }
 
     public static Set<String> closedScopes() {

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -19,9 +19,9 @@ dependencies {
     implementation(project(':micronaut-test-resources-core'))
     implementation(project(':micronaut-test-resources-embedded'))
     implementation(project(':micronaut-test-resources-testcontainers'))
+    implementation(project(':micronaut-test-resources-codec'))
     runtimeOnly(mnLogging.logback.classic)
     runtimeOnly(mn.micronaut.management)
-    runtimeOnly(mnSerde.micronaut.serde.jackson)
 
     testImplementation(mn.micronaut.http.client)
     testImplementation(project(':micronaut-test-resources-client'))

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestContainer.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestContainer.java
@@ -18,6 +18,8 @@ package io.micronaut.testresources.server;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 
+import java.util.Map;
+
 /**
  * Stores metadata about a running test container.
  */
@@ -67,6 +69,15 @@ public final class TestContainer {
     @Nullable
     public String getScope() {
         return scope;
+    }
+
+    public Map<String, String> asMap() {
+        return Map.of(
+            "name", name,
+            "imageName", imageName,
+            "id", id,
+            "scope", scope
+        );
     }
 
     @Override


### PR DESCRIPTION
This commit introduces a custom protocol for communicating between the client and the server. Instead of using JSON, it now uses a binary protocol. This removes the requirement of having Micronaut JSON on the user classpath (on the client side) and further reduces the number of dependencies of the server.

This is a major breaking change, and it's no longer possible to directly use tools like cURL or httpie to talk to the server.

This is blocked by https://github.com/micronaut-projects/micronaut-core/issues/9331