### PR TITLE
Let the client factory find local configuration files

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -25,7 +25,6 @@ import io.micronaut.testresources.core.TestResourcesResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static io.micronaut.testresources.client.ConfigFinder.findConfiguration;
 import static io.micronaut.testresources.core.PropertyResolverSupport.resolveRequiredProperties;
 
 /**
@@ -48,12 +46,7 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
     }
 
     private static TestResourcesClient createClient(Environment env) {
-        Optional<URL> config = findConfiguration(env);
-        if (config.isPresent()) {
-            return config.map(TestResourcesClientFactory::configuredAt)
-                .get();
-        }
-        return TestResourcesClientFactory.fromSystemProperties().orElse(NoOpClient.INSTANCE);
+        return TestResourcesClientFactory.findByConvention().orElse(NoOpClient.INSTANCE);
     }
 
     private static class NoOpClient implements TestResourcesClient {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
@@ -6,6 +6,7 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
 
 @MicronautTest
 class TestResourcesClientPropertiesTest extends Specification implements ClientCleanup {
@@ -13,6 +14,7 @@ class TestResourcesClientPropertiesTest extends Specification implements ClientC
     @Inject
     EmbeddedServer server
 
+    @RestoreSystemProperties
     def "client can be configured from system properties"() {
         System.setProperty("micronaut.test.resources.server.uri", server.getURI().toString())
 


### PR DESCRIPTION
In normal operation mode, the server settings are passed to the client via system properties. This lets the client figure out on which server to connect. In particular, there may be more than one test resources server running, and there can be shared servers as well as namespaced servers.

However, in practice IDEs may not delegate to the build tool, which means that the configuration is not passed to the client. We want to make it possible to support the following scenario:

1. start a test resources service from command line via the build tool, e.g `mvn mn:start-test-resources-service`
2. in the IDE, run tests or main application without delegating to the build tool
3. tests should pass

It is currently working by accident for tests in Maven, because the properties file is on classpath. It doesn't work for the main application, though.

This commit removes the ability to search for the configuration on classpath, which is unreliable, and replaces it with a "conventional" lookup, which searches the configuration in that order:

1. from system properties, the preferred way, configured by build plugins
2. from a project local directory, `.micronaut/test-resources`
3. from the user home, under `.micronaut/test-resources`

While 1. is reliable, 2 and 3 are not, since they _cannot_ support all the scenarios that test resources support. In particular, they don't support namespacing. The Gradle plugin doesn't write its configuration into `.micronaut/test-resources` either, since it is possible for a project to run several test resources services concurrently.