### PR TITLE
Make testcontainers dependencies managed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,20 +44,38 @@ spock = "2.3-groovy-4.0"
 vertx-client = "4.4.2"
 amazon-awssdk-v1 = "1.12.489"
 amazon-awssdk-v2 = "2.20.86"
-testcontainers-redis = "1.6.4"
 
 # Managed versions appear in the BOM
 managed-testcontainers = "1.18.3"
+managed-testcontainers-redis = "1.6.4"
 
 [libraries]
-# Core
-micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
-
+# Testcontainers
 boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
 
+managed-testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "managed-testcontainers" }
+managed-testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version.ref = "managed-testcontainers" }
+managed-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "managed-testcontainers" }
+managed-testcontainers-hivemq = { module = "org.testcontainers:hivemq", version.ref = "managed-testcontainers" }
+managed-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "managed-testcontainers" }
+managed-testcontainers-localstack = { module = "org.testcontainers:localstack", version.ref = "managed-testcontainers" }
+managed-testcontainers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "managed-testcontainers" }
+managed-testcontainers-mongodb = { module = "org.testcontainers:mongodb", version.ref = "managed-testcontainers" }
+managed-testcontainers-mssql = { module = "org.testcontainers:mssqlserver", version.ref = "managed-testcontainers" }
+managed-testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "managed-testcontainers" }
+managed-testcontainers-neo4j = { module = "org.testcontainers:neo4j", version.ref = "managed-testcontainers" }
+managed-testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "managed-testcontainers" }
+managed-testcontainers-postgres = { module = "org.testcontainers:postgresql", version.ref = "managed-testcontainers" }
+managed-testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq", version.ref = "managed-testcontainers" }
+managed-testcontainers-redis = { module = "com.redis.testcontainers:testcontainers-redis", version.ref = "managed-testcontainers-redis" }
+managed-testcontainers-r2dbc = { module = "org.testcontainers:r2dbc", version.ref = "managed-testcontainers" }
+managed-testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "managed-testcontainers" }
+
+# Core
+micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher"}
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 
 micronaut-aws = { module = "io.micronaut.aws:micronaut-aws-bom", version.ref = "micronaut-aws" }
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
@@ -77,24 +95,6 @@ micronaut-security = { module = "io.micronaut.security:micronaut-security-bom", 
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
 
-testcontainers-core = { module = "org.testcontainers:testcontainers", version = "" }
-testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version = "" }
-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version = "" }
-testcontainers-hivemq = { module = "org.testcontainers:hivemq", version = "" }
-testcontainers-kafka = { module = "org.testcontainers:kafka", version = "" }
-testcontainers-localstack = { module = "org.testcontainers:localstack", version = "" }
-testcontainers-mariadb = { module = "org.testcontainers:mariadb", version = "" }
-testcontainers-mongodb = { module = "org.testcontainers:mongodb", version = "" }
-testcontainers-mssql = { module = "org.testcontainers:mssqlserver", version = "" }
-testcontainers-mysql = { module = "org.testcontainers:mysql", version = "" }
-testcontainers-neo4j = { module = "org.testcontainers:neo4j", version = "" }
-testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version = "" }
-testcontainers-postgres = { module = "org.testcontainers:postgresql", version = "" }
-testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq", version = "" }
-testcontainers-redis = { module = "com.redis.testcontainers:testcontainers-redis", version.ref = "testcontainers-redis" }
-testcontainers-r2dbc = { module = "org.testcontainers:r2dbc", version = "" }
-testcontainers-vault = { module = "org.testcontainers:vault", version = "" }
-
 vertx-mysql = { module = "io.vertx:vertx-mysql-client", version.ref = "vertx.client" }
 vertx-mssql = { module = "io.vertx:vertx-mssql-client", version.ref = "vertx.client" }
 vertx-postgres = { module = "io.vertx:vertx-pg-client", version.ref = "vertx.client" }
@@ -102,12 +102,12 @@ vertx-oracle = { module = "io.vertx:vertx-oracle-client", version.ref = "vertx.c
 scram = { module = "com.ongres.scram:client", version = "2.1" }
 spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
 
-amazon-awssdk-v1-dynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version.ref = "amazon-awssdk-v1"}
-amazon-awssdk-v1-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "amazon-awssdk-v1"}
-amazon-awssdk-v1-sqs = { module = "com.amazonaws:aws-java-sdk-sqs", version.ref = "amazon-awssdk-v1"}
-amazon-awssdk-v2-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "amazon-awssdk-v2"}
-amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2"}
-amazon-awssdk-v2-sqs = { module = "software.amazon.awssdk:sqs", version.ref = "amazon-awssdk-v2"}
+amazon-awssdk-v1-dynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version.ref = "amazon-awssdk-v1" }
+amazon-awssdk-v1-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "amazon-awssdk-v1" }
+amazon-awssdk-v1-sqs = { module = "com.amazonaws:aws-java-sdk-sqs", version.ref = "amazon-awssdk-v1" }
+amazon-awssdk-v2-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "amazon-awssdk-v2" }
+amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2" }
+amazon-awssdk-v2-sqs = { module = "software.amazon.awssdk:sqs", version.ref = "amazon-awssdk-v2" }
 #
 # Managed dependencies appear in the BOM
 #

--- a/test-resources-elasticsearch/build.gradle
+++ b/test-resources-elasticsearch/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching an Elasticsearch test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.elasticsearch)
+    implementation(libs.managed.testcontainers.elasticsearch)
 
     testImplementation(mnElasticsearch.micronaut.elasticsearch)
     testRuntimeOnly(mn.micronaut.jackson.databind)

--- a/test-resources-hashicorp-vault/build.gradle
+++ b/test-resources-hashicorp-vault/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a Hashicorp Vault test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.vault)
+    implementation(libs.managed.testcontainers.vault)
 
     testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))
     testImplementation(libs.micronaut.discovery)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-core/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-core/build.gradle
@@ -12,7 +12,7 @@ micronautBuild {
 }
 
 dependencies {
-    api(libs.testcontainers.jdbc)
+    api(libs.managed.testcontainers.jdbc)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesApi(platform(mnSql.micronaut.sql.bom))
     testFixturesCompileOnly(mnData.micronaut.data.processor)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MariaDB test container for Hibernate Reactive.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mariadb)
+    implementation(libs.managed.testcontainers.mariadb)
     runtimeOnly(project(":micronaut-test-resources-jdbc-mariadb"))
 
     testRuntimeOnly(mnSql.mariadb.java.client)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MSSQL test container for Hibernate Reactive.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mssql)
+    implementation(libs.managed.testcontainers.mssql)
     implementation(project(":micronaut-test-resources-jdbc-mssql"))
 
     testRuntimeOnly(mnSql.mssql.jdbc)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MariaDB test container for Hibernate Reactive.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mysql)
+    implementation(libs.managed.testcontainers.mysql)
     runtimeOnly(project(":micronaut-test-resources-jdbc-mysql"))
 
     testRuntimeOnly(mnSql.mysql.connector.java)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching an Oracle XE test container for Hibernate Reactiv
 """
 
 dependencies {
-    implementation(libs.testcontainers.oracle.xe)
+    implementation(libs.managed.testcontainers.oracle.xe)
     runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
 
     testRuntimeOnly(libs.vertx.oracle)

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a PostgreSQL test container for Hibernate Reactiv
 """
 
 dependencies {
-    implementation(libs.testcontainers.postgres)
+    implementation(libs.managed.testcontainers.postgres)
     runtimeOnly(project(":micronaut-test-resources-jdbc-postgresql"))
 
     testRuntimeOnly(mnSql.postgresql)

--- a/test-resources-hivemq/build.gradle
+++ b/test-resources-hivemq/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a HiveMQ test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.hivemq)
+    implementation(libs.managed.testcontainers.hivemq)
 
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnMqtt.micronaut.mqttv5)

--- a/test-resources-jdbc/test-resources-jdbc-core/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-core/build.gradle
@@ -8,7 +8,7 @@ Provides core support for JDBC test containers.
 """
 
 dependencies {
-    implementation(libs.testcontainers.jdbc)
+    implementation(libs.managed.testcontainers.jdbc)
 
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesApi(mnData.micronaut.data.jdbc)

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MariaDB test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mariadb)
+    implementation(libs.managed.testcontainers.mariadb)
 
     testRuntimeOnly(mnSql.mariadb.java.client)
 }

--- a/test-resources-jdbc/test-resources-jdbc-mssql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MS SQL test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mssql)
+    implementation(libs.managed.testcontainers.mssql)
 
     testRuntimeOnly(mnSql.mssql.jdbc)
 }

--- a/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MySQL test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mysql)
+    implementation(libs.managed.testcontainers.mysql)
 
     testRuntimeOnly(mnSql.mysql.connector.java)
 }

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a Oracle XE test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.oracle.xe)
+    implementation(libs.managed.testcontainers.oracle.xe)
 
     testRuntimeOnly(mnSql.ojdbc8)
 }

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a PostgreSQL test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.postgres)
+    implementation(libs.managed.testcontainers.postgres)
 
     testRuntimeOnly(mnSql.postgresql)
 }

--- a/test-resources-kafka/build.gradle
+++ b/test-resources-kafka/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a Kafka test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.kafka)
+    implementation(libs.managed.testcontainers.kafka)
 
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnKafka.micronaut.kafka)

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -8,7 +8,7 @@ Provides core support for launching Localstack test containers.
 """
 
 dependencies {
-    api(libs.testcontainers.localstack)
+    api(libs.managed.testcontainers.localstack)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)
     testFixturesImplementation(libs.spock)

--- a/test-resources-mongodb/build.gradle
+++ b/test-resources-mongodb/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching a MongoDB test container.
 
 dependencies {
     implementation(platform(libs.micronaut.serde))
-    implementation(libs.testcontainers.mongodb)
+    implementation(libs.managed.testcontainers.mongodb)
 
     testCompileOnly(mnData.micronaut.data.document.processor)
     testImplementation(platform(mnMongo.micronaut.mongo.bom))

--- a/test-resources-neo4j/build.gradle
+++ b/test-resources-neo4j/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a MongoDB test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.neo4j)
+    implementation(libs.managed.testcontainers.neo4j)
 
     testImplementation(mnNeo4j.micronaut.neo4j.bolt)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/build.gradle
@@ -7,5 +7,5 @@ Provides core support for R2DBC test resources.
 """
 
 dependencies {
-    api(libs.testcontainers.r2dbc)
+    api(libs.managed.testcontainers.r2dbc)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/build.gradle
@@ -7,7 +7,7 @@ Provides support for R2DBC MariaDB test resources.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mariadb)
+    implementation(libs.managed.testcontainers.mariadb)
     runtimeOnly(project(":micronaut-test-resources-jdbc-mariadb"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mariadb)

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/build.gradle
@@ -7,7 +7,7 @@ Provides support for MS SQL Server R2DBC test resources.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mssql)
+    implementation(libs.managed.testcontainers.mssql)
     implementation(project(":micronaut-test-resources-jdbc-mssql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mssql)

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/build.gradle
@@ -7,7 +7,7 @@ Provides support for MySQL R2DBC test resources.
 """
 
 dependencies {
-    implementation(libs.testcontainers.mysql)
+    implementation(libs.managed.testcontainers.mysql)
     runtimeOnly(project(":micronaut-test-resources-jdbc-mysql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.mysql)

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
@@ -7,7 +7,7 @@ Provides support for Oracle XE R2DBC test resources.
 """
 
 dependencies {
-    implementation(libs.testcontainers.oracle.xe)
+    implementation(libs.managed.testcontainers.oracle.xe)
     runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.oracle)

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
@@ -7,7 +7,7 @@ Provides support for PostgreSQL R2DBC test resources.
 """
 
 dependencies {
-    implementation(libs.testcontainers.postgres)
+    implementation(libs.managed.testcontainers.postgres)
     runtimeOnly(project(":micronaut-test-resources-jdbc-postgresql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.postgresql)

--- a/test-resources-rabbitmq/build.gradle
+++ b/test-resources-rabbitmq/build.gradle
@@ -7,7 +7,7 @@ Provides support for launching a RabbitMQ test container.
 """
 
 dependencies {
-    implementation(libs.testcontainers.rabbitmq)
+    implementation(libs.managed.testcontainers.rabbitmq)
 
     testImplementation(mnRabbitmq.micronaut.rabbitmq)
 }

--- a/test-resources-redis/build.gradle
+++ b/test-resources-redis/build.gradle
@@ -9,7 +9,7 @@ Provides support for launching a Redis test container.
 dependencies {
     api(project(':micronaut-test-resources-core'))
     api(project(':micronaut-test-resources-testcontainers'))
-    api(libs.testcontainers.redis)
+    api(libs.managed.testcontainers.redis)
 
     testImplementation(project(":micronaut-test-resources-embedded"))
     testImplementation(testFixtures(project(":micronaut-test-resources-testcontainers")))

--- a/test-resources-testcontainers/build.gradle
+++ b/test-resources-testcontainers/build.gradle
@@ -10,7 +10,7 @@ of testcontainers.
 
 dependencies {
     api(project(':micronaut-test-resources-core'))
-    api(libs.testcontainers.core)
+    api(libs.managed.testcontainers.core)
     api(platform(libs.boms.testcontainers))
     compileOnly(mn.micronaut.context)
 


### PR DESCRIPTION
Currently only the version is managed, so the individual modules are not visible when using catalogs.