### PR TITLE
Use a fixed version for Vault

### DIFF
--- a/test-resources-hashicorp-vault/src/main/java/io/micronaut/testresources/hashicorp/vault/VaultTestResourceProvider.java
+++ b/test-resources-hashicorp-vault/src/main/java/io/micronaut/testresources/hashicorp/vault/VaultTestResourceProvider.java
@@ -41,7 +41,7 @@ public class VaultTestResourceProvider extends AbstractTestContainersProvider<Va
     ));
     public static final Set<String> RESOLVABLE_PROPERTIES_SET = Collections.unmodifiableSet(new HashSet<>(RESOLVABLE_PROPERTIES_LIST));
     public static final String VAULT_CLIENT_TOKEN_VALUE = "vault-token";
-    public static final String DEFAULT_IMAGE = "vault";
+    public static final String DEFAULT_IMAGE = "vault:1.13.3";
     public static final String SIMPLE_NAME = "hashicorp-vault";
     public static final String HASHICORP_VAULT_TOKEN_KEY = "containers.hashicorp-vault.token";
     public static final String TEST_RESOURCES_CONTAINERS_PATH_KEY = "containers.hashicorp-vault.path";


### PR DESCRIPTION
The `latest` tag is no longer available.