### PR TITLE
Add support for dependencies between containers

### DIFF
--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -131,6 +131,7 @@ test-resources:
 
 Please refer to the <<configurationreference#io.micronaut.testresources.testcontainers.TestContainersConfiguration,configuration properties reference>> for details.
 
+[[advanced-networking]]
 == Advanced networking
 
 By default, each container is spawned in its own network.
@@ -219,3 +220,25 @@ test-resources:
             all:
               timeout: 120s
 ----
+
+== Dependencies between containers
+
+In some cases, your containers may require other containers to be started before they start.
+You can declare such dependencies with the `depends-on` property:
+
+[configuration]
+----
+test-resources:
+  containers:
+    mycontainer:
+        image-name: my/container
+        depends-on: other
+        ...
+    other:
+        image-name: my/other
+        ...
+----
+
+It's worth noting that such containers need to be declared on the <<#advanced-networking,same network>> in order to be able to communicate with each other.
+
+WARNING: Dependencies between containers **only work between generic containers**. It is not possible to create a dependency between a generic container and a container created with the other test resources resolvers. For example, you cannot add a dependency on a container which provides a MySQL database by adding a `depends-on: mysql`.

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
@@ -19,6 +19,7 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,6 +48,7 @@ final class TestContainerMetadata {
     private final String network;
     private final Set<String> networkAliases;
     private final WaitStrategy waitStrategy;
+    private final Set<String> dependencies;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     TestContainerMetadata(String id,
@@ -69,7 +71,7 @@ final class TestContainerMetadata {
                           Long sharedMemory,
                           String network,
                           Set<String> networkAliases,
-                          WaitStrategy waitStrategy) {
+                          WaitStrategy waitStrategy, Set<String> dependencies) {
         this.id = id;
         this.imageName = imageName;
         this.imageTag = imageTag;
@@ -91,6 +93,7 @@ final class TestContainerMetadata {
         this.network = network;
         this.networkAliases = networkAliases;
         this.waitStrategy = waitStrategy;
+        this.dependencies = dependencies;
     }
 
     public String getId() {
@@ -175,6 +178,10 @@ final class TestContainerMetadata {
 
     public Set<String> getRoTmpfsMappings() {
         return roTmpfsMappings;
+    }
+
+    public Set<String> getDependencies() {
+        return Collections.unmodifiableSet(dependencies);
     }
 
     public static final class CopyFileToContainer {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
@@ -95,8 +95,9 @@ final class TestContainerMetadataSupport {
         Long sharedMemory = extractMemoryParameterFrom(prefix, testResourcesConfig, "shared-memory");
         String network = extractStringParameterFrom(prefix, "network", testResourcesConfig);
         Set<String> networkAliases = extractSetFrom(prefix, testResourcesConfig, "network-aliases");
+        Set<String> dependsOn = extractSetFrom(prefix, testResourcesConfig, "depends-on");
         WaitStrategy waitStrategy = extractWaitStrategyFrom(prefix, testResourcesConfig);
-        return Optional.of(new TestContainerMetadata(name, imageName, imageTag, exposedPorts, hostNames, rwFsBinds, roFsBinds, rwTmpfsMappings, roTmpfsMappings, command, workingDirectory, env, labels, startupTimeout, fileCopies, memory, swapMemory, sharedMemory, network, networkAliases, waitStrategy));
+        return Optional.of(new TestContainerMetadata(name, imageName, imageTag, exposedPorts, hostNames, rwFsBinds, roFsBinds, rwTmpfsMappings, roTmpfsMappings, command, workingDirectory, env, labels, startupTimeout, fileCopies, memory, swapMemory, sharedMemory, network, networkAliases, waitStrategy, dependsOn));
     }
 
     private static Long extractMemoryParameterFrom(String prefix, Map<String, Object> testResourcesConfig, String key) {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachProperty;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents the mutable view of the container metadata, for
@@ -46,6 +47,7 @@ final class TestContainersConfiguration {
     private String sharedMemory;
     private String network;
     private List<String> networkAliases;
+    private Set<String> dependencies;
 
     /**
      * Returns the name of the docker image to use for the test resources container.
@@ -347,5 +349,21 @@ final class TestContainersConfiguration {
      */
     public void setNetworkAliases(List<String> networkAliases) {
         this.networkAliases = networkAliases;
+    }
+
+    /**
+     * The names of other containers this container depends on.
+     * @return the dependencies
+     */
+    public Set<String> getDependencies() {
+        return dependencies;
+    }
+
+    /**
+     * Sets the names of containers this container depends on.
+     * @param dependencies the dependencies
+     */
+    public void setDependencies(Set<String> dependencies) {
+        this.dependencies = dependencies;
     }
 }

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/ContainerDependenciesTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/ContainerDependenciesTest.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.testresources.testcontainers
+
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.core.Scope
+import spock.lang.Specification
+
+@MicronautTest
+class ContainerDependenciesTest extends Specification {
+    // we only inject the consumer, in order to make sure that the
+    // dependency on the producer is triggered
+    @Value("\${consumer.host}") String consumerHostname
+
+    def "test containers on same network can talk to each other"() {
+        when:
+        // Please note that a user wouldn't be able to communicate
+        // directly to the container, it's internal API of the process
+        // which spawns the test containers, which happens to be the
+        // test process here
+        def networks = TestContainers.networks
+        def stdout = TestContainers.listAll()
+                .get(Scope.ROOT)
+                .find {
+                    it.networkAliases.contains('alice')
+                }
+                ?.execInContainer("wget", "-O", "-", "http://bob:8080")
+                ?.stdout
+
+        then:
+        networks.size() == 1
+        networks['custom'].close()
+        "yay" == stdout
+    }
+}

--- a/test-resources-testcontainers/src/test/resources/application-test.yml
+++ b/test-resources-testcontainers/src/test/resources/application-test.yml
@@ -21,3 +21,4 @@ test-resources:
       network: custom
       network-aliases: alice
       hostnames: consumer.host
+      depends-on: producer


### PR DESCRIPTION
Because of technical reasons, the support is currently limited to generic containers: in this case, we know that the `properties` map which is passed when resolving a property will always be empty, because a generic container cannot declare such required properties. Therefore, when a container is resolved, we can look into the _other_ generic containers which are declared, and see if one matches the required id. If we find one, then we can trigger the resolution of the container by resolving one of the properties it provides (any property works).

This feature does _not_ rely on the `dependsOn` feature of Testcontainers for the very same reason: the resolver doesn't have access to other containers which are resolved, nor does it know how to create one at the point in time the resolution is triggerred. Therefore, we have no `Container` instance to pass to `dependsOn`.

Fixes #147