### PR TITLE
Add property to disable some test resources resolvers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.1-SNAPSHOT
+projectVersion=2.1.0-SNAPSHOT
 projectGroup=io.micronaut.testresources
 
 title=Micronaut Test Resources

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/ToggableTestResourcesResolver.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/ToggableTestResourcesResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.core;
+
+import java.util.Map;
+
+/**
+ * Interface for test resource resolvers which may be enabled or disabled
+ * on demand.
+ */
+public interface ToggableTestResourcesResolver extends TestResourcesResolver {
+    String getName();
+
+    default boolean isEnabled(Map<String, Object> testResourcesConfig) {
+        var o = testResourcesConfig.get(getName() + ".enabled");
+        if (o == null) {
+            return true;
+        }
+        if (o instanceof Boolean b) {
+            return b;
+        }
+        return Boolean.parseBoolean(String.valueOf(o));
+    }
+}

--- a/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertyExpressionResolver.java
+++ b/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertyExpressionResolver.java
@@ -20,6 +20,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.testresources.core.LazyTestResourcesExpressionResolver;
 import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,9 @@ public class EmbeddedTestResourcesPropertyExpressionResolver extends LazyTestRes
             List<TestResourcesResolver> resolvers = loader.getResolvers();
             Map<String, Object> testProperties = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
             for (TestResourcesResolver resolver : resolvers) {
+                if (resolver instanceof ToggableTestResourcesResolver toggable && !toggable.isEnabled(testProperties)) {
+                    continue;
+                }
                 if (canResolveExpression(propertyResolver, resolver, expression, testProperties)) {
                     Map<String, Object> props = resolveRequiredProperties(expression, propertyResolver, resolver);
                     Optional<String> resolve = resolver.resolve(expression, props, testProperties);

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/java/io/micronaut/testresources/r2dbc/pool/R2DBCPoolTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/main/java/io/micronaut/testresources/r2dbc/pool/R2DBCPoolTestResourceProvider.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.testresources.r2dbc.pool;
 
-import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import io.micronaut.testresources.r2dbc.core.R2dbcSupport;
 
 import java.util.Arrays;
@@ -29,7 +29,7 @@ import java.util.Optional;
 /**
  * A test resource provider for configuring the R2DBC pool.
  */
-public class R2DBCPoolTestResourceProvider implements TestResourcesResolver {
+public class R2DBCPoolTestResourceProvider implements ToggableTestResourcesResolver {
 
     private static final String PROTOCOL = "options.protocol";
     private static final String DRIVER = "options.driver";
@@ -37,6 +37,11 @@ public class R2DBCPoolTestResourceProvider implements TestResourcesResolver {
         PROTOCOL,
         DRIVER
     ));
+
+    @Override
+    public String getName() {
+        return "r2dbc-pool";
+    }
 
     @Override
     public List<String> getRequiredPropertyEntries() {

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/R2DBCPoolDisablingTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/groovy/io/micronaut/testresources/r2dbc/pool/R2DBCPoolDisablingTest.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.testresources.r2dbc.pool
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import io.r2dbc.spi.ConnectionFactory
+import jakarta.inject.Inject
+
+@MicronautTest(environments = ["r2dbc-pool-disabled"], transactional = false )
+class R2DBCPoolDisablingTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    @Inject
+    ConnectionFactory connectionFactory
+
+    def "starts a reactive PostgreSQL container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        connectionFactory.class.simpleName == 'PostgresqlConnectionFactory'
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-r2dbc-pool-disabled.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-pool/src/test/resources/application-r2dbc-pool-disabled.yml
@@ -1,0 +1,13 @@
+datasources:
+  default:
+    driverClassName: org.postgresql.Driver
+    schema-generate: CREATE_DROP
+    dialect: POSTGRES
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: POSTGRES
+test-resources:
+  r2dbc-pool:
+    enabled: false

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.testresources.testcontainers;
 
-import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -30,7 +30,12 @@ import static io.micronaut.testresources.testcontainers.TestContainerMetadataSup
  *
  * @param <T> the container type
  */
-public abstract class AbstractTestContainersProvider<T extends GenericContainer<? extends T>> implements TestResourcesResolver {
+public abstract class AbstractTestContainersProvider<T extends GenericContainer<? extends T>> implements ToggableTestResourcesResolver {
+    @Override
+    public String getName() {
+        return "containers." + getSimpleName();
+    }
+
     @Override
     public int getOrder() {
         return SPECIFIC_ORDER;

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.testresources.testcontainers;
 
-import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,8 +65,13 @@ import static io.micronaut.testresources.testcontainers.TestContainerMetadataSup
  * property.
  */
 @SuppressWarnings("unchecked")
-public class GenericTestContainerProvider implements TestResourcesResolver {
+public class GenericTestContainerProvider implements ToggableTestResourcesResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericTestContainerProvider.class);
+
+    @Override
+    public String getName() {
+        return "generic";
+    }
 
     @Override
     public int getOrder() {


### PR DESCRIPTION
This commit introduces a property to disable a test resolver. It was implemented in a backwards compatible fashion, by introducing a new subtype of resolver. Resolvers which can be disabled need to implement the `ToggableTestResourcesResolver` interface and provide a name.

This name is used at resolution time, to figure out a test resources property. For example, if the name of the resolver is foo, then at resolution time, we'd look into the test resources configuration for the property:

test-resources.foo.enabled

and ignore the resolver if that property is `false`. This flag should only be used for debugging purposes.

Fixes #399