### PR TITLE
Updated versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,16 +16,16 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "3.6.0"
+micronaut = "3.10.1"
 micronaut-docs = "2.0.0"
-micronaut-test = "3.1.1"
-micronaut-gradle-plugin = "3.6.5"
-groovy = "3.0.10"
-spock = "2.1-groovy-3.0"
-vertx-client = "4.3.2"
+micronaut-test = "3.9.2"
+micronaut-gradle-plugin = "3.7.10"
+groovy = "3.0.19"
+spock = "2.4-M1-groovy-3.0"
+vertx-client = "4.4.5"
 
 # Managed versions appear in the BOM
-managed-testcontainers = "1.17.6"
+managed-testcontainers = "1.19.0"
 
 [libraries]
 boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.4.5'
+    id 'io.micronaut.build.shared.settings' version '5.4.10'
 }
 rootProject.name = 'testresources-parent'
 

--- a/test-resources-hashicorp-vault/src/main/java/io/micronaut/testresources/hashicorp/vault/VaultTestResourceProvider.java
+++ b/test-resources-hashicorp-vault/src/main/java/io/micronaut/testresources/hashicorp/vault/VaultTestResourceProvider.java
@@ -41,7 +41,7 @@ public class VaultTestResourceProvider extends AbstractTestContainersProvider<Va
     ));
     public static final Set<String> RESOLVABLE_PROPERTIES_SET = Collections.unmodifiableSet(new HashSet<>(RESOLVABLE_PROPERTIES_LIST));
     public static final String VAULT_CLIENT_TOKEN_VALUE = "vault-token";
-    public static final String DEFAULT_IMAGE = "vault";
+    public static final String DEFAULT_IMAGE = "hashicorp/vault";
     public static final String SIMPLE_NAME = "hashicorp-vault";
     public static final String HASHICORP_VAULT_TOKEN_KEY = "containers.hashicorp-vault.token";
     public static final String TEST_RESOURCES_CONTAINERS_PATH_KEY = "containers.hashicorp-vault.path";


### PR DESCRIPTION
**Update versions for:**
micronaut => "3.10.1"
micronaut-test => "3.9.2"
micronaut-gradle-plugin => "3.7.10"
groovy => "3.0.19"
spock => "2.4-M1-groovy-3.0"
vertx-client => "4.4.5"

The update of the testcontainers-dependency also brought in the change of the hashicorpt-vault image name.
It changed from **vault** to **hashicorp/vault**, which is fixed in this PR.