### PR TITLE
Add support for mysql-connector-j

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -136,7 +136,7 @@ public final class TestResourcesClasspath implements KnownModules {
     }
 
     private static Stream<MavenDependency> inferSingle(MavenDependency input, List<MavenDependency> allDependencies, String testResourcesVersion) {
-        List<MavenDependency> matched = Matcher.match(input, allDependencies, testResourcesVersion, m -> {
+        return Matcher.match(input, allDependencies, testResourcesVersion, m -> {
             m.onArtifact(MICRONAUT_ELASTICSEARCH, ELASTICSEARCH_MODULE);
             m.onArtifact(MICRONAUT_KAFKA, KAFKA_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_MQTT), deps -> true, HIVEMQ_MODULE);
@@ -174,8 +174,7 @@ public final class TestResourcesClasspath implements KnownModules {
                 REACTIVE_MSSQL_DRIVER,
                 REACTIVE_POOL_DRIVER
             );
-        }).toList();
-        return matched.stream();
+        });
     }
 
     private static Predicate<MavenDependency> artifactEquals(String artifactId) {

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -50,7 +50,6 @@ public final class TestResourcesClasspath implements KnownModules {
     private static final String MICRONAUT_NEO4J = "micronaut-neo4j";
     private static final String MICRONAUT_DATA_MONGODB = "micronaut-data-mongodb";
     private static final String MICRONAUT_DATA_R2DBC = "micronaut-data-r2dbc";
-    private static final String MYSQL_CONNECTOR_JAVA = "mysql-connector-java";
     // Default driver for mysql r2dbc
     private static final String REACTIVE_MYSQL_DRIVER = "dev.miku:r2dbc-mysql";
     private static final String REACTIVE_MYSQL_IO_ASYNCER_DRIVER = "io.asyncer:r2dbc-mysql";
@@ -58,6 +57,8 @@ public final class TestResourcesClasspath implements KnownModules {
     private static final String MSSQL_DRIVER = "com.microsoft.sqlserver:mssql-jdbc";
     private static final String REACTIVE_MSSQL_DRIVER = "io.r2dbc:r2dbc-mssql";
     private static final String MYSQL_MYSQL_CONNECTOR_JAVA = "mysql:mysql-connector-java";
+    private static final String MYSQL_MYSQL_CONNECTOR_J = "com.mysql:mysql-connector-j";
+    private static final List<String> MYSQL_DRIVERS = Arrays.asList(MYSQL_MYSQL_CONNECTOR_JAVA, MYSQL_MYSQL_CONNECTOR_J);
     private static final String POSTGRESQL_DRIVER = "org.postgresql:postgresql";
     private static final String REACTIVE_POSTGRESQL_DRIVER = "org.postgresql:r2dbc-postgresql";
     private static final String MARIADB_JAVA_CLIENT = "org.mariadb.jdbc:mariadb-java-client";
@@ -135,7 +136,7 @@ public final class TestResourcesClasspath implements KnownModules {
     }
 
     private static Stream<MavenDependency> inferSingle(MavenDependency input, List<MavenDependency> allDependencies, String testResourcesVersion) {
-        return Matcher.match(input, allDependencies, testResourcesVersion, m -> {
+        List<MavenDependency> matched = Matcher.match(input, allDependencies, testResourcesVersion, m -> {
             m.onArtifact(MICRONAUT_ELASTICSEARCH, ELASTICSEARCH_MODULE);
             m.onArtifact(MICRONAUT_KAFKA, KAFKA_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_MQTT), deps -> true, HIVEMQ_MODULE);
@@ -147,7 +148,7 @@ public final class TestResourcesClasspath implements KnownModules {
             m.onArtifact(MICRONAUT_DISCOVERY_CLIENT, HASHICORP_VAULT_MODULE);
             m.onModule(REACTIVE_POOL_DRIVER, REACTIVE_POOL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_NEO4J), deps -> true, NEO4J_MODULE);
-            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(artifactEquals(MYSQL_CONNECTOR_JAVA)), MYSQL_MODULE);
+            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(d -> MYSQL_DRIVERS.contains(d.getModule())), MYSQL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(POSTGRESQL_DRIVER)), POSTGRESQL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(MARIADB_JAVA_CLIENT)), MARIADB_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(MSSQL_DRIVER)), MSSQL_MODULE);
@@ -157,7 +158,8 @@ public final class TestResourcesClasspath implements KnownModules {
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_POSTGRESQL_DRIVER)), REACTIVE_POSTGRESQL_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_ORACLE_DRIVER)), REACTIVE_ORACLE_XE_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_MSSQL_DRIVER)), REACTIVE_MSSQL_MODULE);
-            m.passthroughModules(MYSQL_MYSQL_CONNECTOR_JAVA,
+            m.passthroughModules(
+                MYSQL_MYSQL_CONNECTOR_JAVA, MYSQL_MYSQL_CONNECTOR_J,
                 POSTGRESQL_DRIVER,
                 MARIADB_JAVA_CLIENT,
                 MONGODB_DRIVER_ASYNC,
@@ -172,7 +174,8 @@ public final class TestResourcesClasspath implements KnownModules {
                 REACTIVE_MSSQL_DRIVER,
                 REACTIVE_POOL_DRIVER
             );
-        });
+        }).toList();
+        return matched.stream();
     }
 
     private static Predicate<MavenDependency> artifactEquals(String artifactId) {

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -54,6 +54,7 @@ class TestResourcesClasspathTest extends Specification {
         where:
         driver                                   | extra
         'mysql:mysql-connector-java'             | []
+        'com.mysql:mysql-connector-j'            | []
         'org.postgresql:postgresql'              | []
         'org.mariadb.jdbc:mariadb-java-client'   | []
         'com.oracle.database.jdbc:ojdbc5'        | []
@@ -87,6 +88,7 @@ class TestResourcesClasspathTest extends Specification {
         where:
         driver                                 | module
         'mysql:mysql-connector-java'           | 'mysql'
+        'com.mysql:mysql-connector-j'          | 'mysql'
         'org.postgresql:postgresql'            | 'postgresql'
         'org.mariadb.jdbc:mariadb-java-client' | 'mariadb'
         'com.oracle.database.jdbc:ojdbc8'      | 'oracle-xe'


### PR DESCRIPTION
Support added for mysql-connector-j besides already supported mysql-connector-java, needed for [micronaut-sql](https://github.com/micronaut-projects/micronaut-sql/pull/1106) and [starter](https://github.com/micronaut-projects/micronaut-starter/pull/2064)