### PR TITLE
Add a server idle timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.2.1-SNAPSHOT
+projectVersion=2.3.0-SNAPSHOT
 projectGroup=io.micronaut.testresources
 
 title=Micronaut Test Resources

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerSettings.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerSettings.java
@@ -25,11 +25,18 @@ public final class ServerSettings {
     private final int port;
     private final String accessToken;
     private final Integer clientTimeout;
+    private final Integer idleTimeoutMinutes;
 
+    @Deprecated
     public ServerSettings(int port, String accessToken, Integer clientTimeout) {
+        this(port, accessToken, clientTimeout, null);
+    }
+
+    public ServerSettings(int port, String accessToken, Integer clientTimeout, Integer idleTimeoutMinutes) {
         this.port = port;
         this.accessToken = accessToken;
         this.clientTimeout = clientTimeout;
+        this.idleTimeoutMinutes = idleTimeoutMinutes;
     }
 
     public int getPort() {
@@ -42,6 +49,10 @@ public final class ServerSettings {
 
     public Optional<Integer> getClientTimeout() {
         return Optional.ofNullable(clientTimeout);
+    }
+
+    public Optional<Integer> getIdleTimeoutMinutes() {
+        return Optional.ofNullable(idleTimeoutMinutes);
     }
 
     @Override
@@ -61,7 +72,10 @@ public final class ServerSettings {
         if (!Objects.equals(accessToken, that.accessToken)) {
             return false;
         }
-        return Objects.equals(clientTimeout, that.clientTimeout);
+        if (!Objects.equals(clientTimeout, that.clientTimeout)) {
+            return false;
+        }
+        return Objects.equals(idleTimeoutMinutes, that.idleTimeoutMinutes);
     }
 
     @Override
@@ -69,6 +83,7 @@ public final class ServerSettings {
         int result = port;
         result = 31 * result + (accessToken != null ? accessToken.hashCode() : 0);
         result = 31 * result + (clientTimeout != null ? clientTimeout.hashCode() : 0);
+        result = 31 * result + (idleTimeoutMinutes != null ? idleTimeoutMinutes.hashCode() : 0);
         return result;
     }
 }

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -49,7 +49,7 @@ class ServerUtilsTest extends Specification {
         embeddedServer.start()
 
         when:
-        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, token, classpath, timeout, factory)
+        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, token, classpath, timeout, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -98,17 +98,17 @@ class ServerUtilsTest extends Specification {
         def applicationContext = ApplicationContext.builder().start()
         def embeddedServer = applicationContext.getBean(EmbeddedServer)
         embeddedServer.start()
-        ServerUtils.writeServerSettings(settingsDir, new ServerSettings(embeddedServer.port, null, null))
+        ServerUtils.writeServerSettings(settingsDir, new ServerSettings(embeddedServer.port, null, null, null))
 
         when: "no explicit port"
-        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, factory)
+        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, null, factory)
 
         then:
         0 * factory.startServer(_)
         0 * factory.waitFor(_)
 
         when: "explicit port"
-        ServerUtils.startOrConnectToExistingServer(embeddedServer.port, portFile, settingsDir, null, [], null, factory)
+        ServerUtils.startOrConnectToExistingServer(embeddedServer.port, portFile, settingsDir, null, [], null, null, factory)
 
         then:
         0 * factory.startServer(_)
@@ -137,7 +137,7 @@ class ServerUtilsTest extends Specification {
         embeddedServer.start()
 
         when: "first call with CDS support enabled"
-        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, factory)
+        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -154,7 +154,7 @@ class ServerUtilsTest extends Specification {
         settingsDir.toFile().deleteDir()
 
         when: "second call dumps CDS then starts server"
-        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, factory)
+        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -177,7 +177,7 @@ class ServerUtilsTest extends Specification {
         settingsDir.toFile().deleteDir()
 
         when: "third call starts server with CDS"
-        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, factory)
+        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [cdsClasspathDir.toFile()], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -193,7 +193,7 @@ class ServerUtilsTest extends Specification {
         settingsDir.toFile().deleteDir()
 
         when: "removes CDS files if classpath changes"
-        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [], null, factory)
+        ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, cdsDir, [], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -220,7 +220,7 @@ class ServerUtilsTest extends Specification {
         embeddedServer.start()
 
         when:
-        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, factory)
+        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -247,7 +247,7 @@ class ServerUtilsTest extends Specification {
         embeddedServer.start()
 
         when:
-        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, factory)
+        def settings = ServerUtils.startOrConnectToExistingServer(null, portFile, settingsDir, null, [], null, null, factory)
 
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
@@ -58,10 +58,16 @@ public interface TestResourcesClient extends TestResourcesResolver {
 
     /**
      * Closes all test resources.
+     * @return true if the operation was successful
      */
     @Get("/close/all")
     boolean closeAll();
 
+    /**
+     * Closes a test resource scope
+     * @param id the scope id
+     * @return true if the operation was successful
+     */
     @Get("/close/{id}")
     boolean closeScope(@Nullable String id);
 }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesKeepAlive.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesKeepAlive.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.client;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+
+/**
+ * An application component which sends periodic keep alive requests to the server.
+ */
+@Singleton
+public class TestResourcesKeepAlive {
+    /**
+     * Sends periodic keep alive requests to the server.
+     * @param applicationContext the application context
+     */
+    @Scheduled(fixedRate = "1m")
+    public void keepAlive(ApplicationContext applicationContext) {
+        var client = TestResourcesClientFactory.extractFrom(applicationContext);
+        if (client != null) {
+            // Call any method to keep the service alive
+            client.getResolvableProperties();
+        }
+    }
+}

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/ExpiryManager.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/ExpiryManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.server;
+
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The expiry manager will handle pings from the client to keep the server alive.
+ */
+@Singleton
+@InterceptorBean(Ping.class)
+public final class ExpiryManager implements MethodInterceptor<Object, Object> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExpiryManager.class);
+
+    private static final long MS_IN_ONE_MINUTE = 60_000;
+    private final long timeoutMs;
+
+    private long lastAccess;
+
+    public ExpiryManager(@Value("${server.idle.timeout.minutes:60}") int keepAliveMinutes) {
+        this.timeoutMs = keepAliveMinutes * MS_IN_ONE_MINUTE;
+        ping();
+        LOGGER.info("Test resources server will automatically be shutdown if it doesn't receive requests for {} minutes", keepAliveMinutes);
+    }
+
+    private void ping() {
+        this.lastAccess = System.currentTimeMillis();
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() - lastAccess > timeoutMs;
+    }
+
+    @Override
+    public @Nullable Object intercept(MethodInvocationContext<Object, Object> context) {
+        ping();
+        return context.proceed();
+    }
+}

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/Ping.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/Ping.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.server;
+
+import io.micronaut.aop.Around;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation for controllers which participate to keeping the server alive.
+ */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@Around
+public @interface Ping {
+}

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/PropertyResolutionListener.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/PropertyResolutionListener.java
@@ -19,9 +19,13 @@ import io.micronaut.testresources.core.TestResourcesResolver;
 
 import java.util.Map;
 
+/**
+ * A test resources property resolution listener will be notified
+ * whenever a property is resolved by a {@link TestResourcesResolver}.
+ */
 public interface PropertyResolutionListener {
     /**
-     * Records that a property was resolved by a particular resolver
+     * Records that a property was resolved by a particular resolver.
      * @param property the property which was resolved
      * @param resolvedValue the result of the resolution
      * @param resolver the resolver which resolved the property

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.ContextConfigurer;
 import io.micronaut.context.env.Environment;
 import io.micronaut.runtime.Micronaut;
 import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,19 @@ public class TestResourcesService {
         long dur = System.nanoTime() - sd;
         LOGGER.info("A Micronaut Test Resources server is listening on port {}, started in {}ms",
             context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
+    }
+
+    /**
+     * Periodically checks if the server is expired and if so, shuts it down.
+     * @param server the server
+     * @param manager the expiry manager
+     */
+    @Scheduled(fixedRate = "1m")
+    public void checkTimeout(EmbeddedServer server, ExpiryManager manager) {
+        if (manager.isExpired()) {
+            LOGGER.info("Shutting down server due to inactivity");
+            server.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
This commit introduces a server idle timeout. By default, after one hour without receiving requests, the server will shut down. Configuring the idle timeout will require updates to the build plugin integrations.

The client will send one request per minute to the server in order to keep it alive.

Fixes #443