### PR TITLE
Record resolution errors for control panel

### DIFF
--- a/test-resources-control-panel/src/main/java/io/micronaut/testresources/controlpanel/TestResourcesControlPanel.java
+++ b/test-resources-control-panel/src/main/java/io/micronaut/testresources/controlpanel/TestResourcesControlPanel.java
@@ -18,15 +18,13 @@ package io.micronaut.testresources.controlpanel;
 import io.micronaut.controlpanel.core.AbstractControlPanel;
 import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 
-import java.util.List;
-
 /**
  * A control panel for test resource resolvers.
  * Each resolver will result in the creation of a separate control panel.
  * The control panel is responsible for showing the properties resolved
  * by this particular test resources resolver.
  */
-public class TestResourcesControlPanel extends AbstractControlPanel<List<ControlPanelPropertyResolutionListener.Resolution>> {
+public class TestResourcesControlPanel extends AbstractControlPanel<TestResourcesControlPanelBody> {
     private final ControlPanelPropertyResolutionListener resolutionListener;
     private final String id;
 
@@ -45,9 +43,16 @@ public class TestResourcesControlPanel extends AbstractControlPanel<List<Control
         );
     }
 
+    public int getErrorCount() {
+        return resolutionListener.findErrorsById(id).size();
+    }
+
     @Override
-    public List<ControlPanelPropertyResolutionListener.Resolution> getBody() {
-        return resolutionListener.findById(id);
+    public TestResourcesControlPanelBody getBody() {
+        return new TestResourcesControlPanelBody(
+            resolutionListener.findById(id),
+            resolutionListener.findErrorsById(id)
+        );
     }
 
     @Override

--- a/test-resources-control-panel/src/main/java/io/micronaut/testresources/controlpanel/TestResourcesControlPanelBody.java
+++ b/test-resources-control-panel/src/main/java/io/micronaut/testresources/controlpanel/TestResourcesControlPanelBody.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.controlpanel;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.List;
+
+@Introspected
+public record TestResourcesControlPanelBody(
+    List<ControlPanelPropertyResolutionListener.Resolution> resolvedProperties,
+    List<ControlPanelPropertyResolutionListener.ResolutionError> errors
+) {
+}

--- a/test-resources-control-panel/src/main/resources/views/test-resources/body.hbs
+++ b/test-resources-control-panel/src/main/resources/views/test-resources/body.hbs
@@ -9,5 +9,14 @@
             Resolved {{badge}} properties.
         {{/eq}}
     {{/eq}}
+    {{#neq errorCount 0 }}
+        <div class="card bg-danger">
+            {{#eq errorCount 1}}
+                1 resolution failure
+            {{else}}
+                {{errorCount}} resolution failures
+            {{/eq}}
+        </div>
+    {{/neq}}
 
 {{/with}}

--- a/test-resources-control-panel/src/main/resources/views/test-resources/detail.hbs
+++ b/test-resources-control-panel/src/main/resources/views/test-resources/detail.hbs
@@ -1,9 +1,9 @@
 <div class="card card-light">
-    {{#neq controlPanel.body.size 0}}
-        <div class="card-header">
-            <h3 class="card-title"><code>{{@key}}</code></h3>
-        </div>
-        <div class="card-body">
+    <div class="card-header">
+        <h3 class="card-title"><code>{{@key}}</code></h3>
+    </div>
+    <div class="card-body">
+        {{#neq controlPanel.body.resolvedProperties.size 0}}
             <p>
                 The following table contains the properties which were resolved by this test resources provider.
             </p>
@@ -17,7 +17,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                {{#each controlPanel.body as |resolution|}}
+                {{#each controlPanel.body.resolvedProperties as |resolution|}}
                     <tr>
                         <td><code>{{resolution.property}}</code></td>
                         <td><code>{{resolution.resolvedValue}}</code></td>
@@ -28,8 +28,28 @@
                 {{/each}}
                 </tbody>
             </table>
-        </div>
-    {{else}}
-        This test resources provider hasn't resolved any property yet.
-    {{/neq}}
+        {{else}}
+            This test resources provider hasn't resolved any property yet.
+        {{/neq}}
+        {{#neq controlPanel.body.errors.size 0}}
+            <p>There were errors during resolution of properties.</p>
+            <table class="table">
+                <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Error</th>
+                </tr>
+                </thead>
+                <tbody>
+                {{#each controlPanel.body.errors as |error|}}
+                    <tr>
+                        <td><code>{{error.property}}</code></td>
+                        <td><code>{{error.stackTrace}}</code></td>
+                    </tr>
+                {{/each}}
+                </tbody>
+            </table>
+        {{/neq}}
+    </div>
+
 </div>

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesResolutionException.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesResolutionException.java
@@ -31,4 +31,19 @@ public class TestResourcesResolutionException extends RuntimeException {
     public TestResourcesResolutionException(String message) {
         super(message);
     }
+
+    /**
+     * Returns a TestResourcesResolutionException from an exception. If
+     * the type of the exception is already TestResourcesResolutionException
+     * then the same instance is returned, otherwise the exception is
+     * wrapped into TestResourcesResolutionException.
+     * @param ex the exception
+     * @return a TestResourcesResolutionException
+     */
+    public static TestResourcesResolutionException wrap(Exception ex) {
+        if (ex instanceof TestResourcesResolutionException trre) {
+            return trre;
+        }
+        return new TestResourcesResolutionException(ex);
+    }
 }

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/PropertyResolutionListener.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/PropertyResolutionListener.java
@@ -37,4 +37,15 @@ public interface PropertyResolutionListener {
                   TestResourcesResolver resolver,
                   Map<String, Object> properties,
                   Map<String, Object> testResourcesConfig);
+
+    /**
+     * Records an error which happened during property resolution,
+     * for example if a container fails to start.
+     * @param property the property which we attempted to resolve
+     * @param resolver the resolver which failed
+     * @param error the error which happened
+     */
+    void errored(String property,
+                 TestResourcesResolver resolver,
+                 Throwable error);
 }


### PR DESCRIPTION
With this change, the control panel will now remember resolution errors. This can be particularly useful when resolution fails on the client side, and that the user doesn't really understand why.

By going to the control panel, the errors will be recorded per resolver.

Here's a screenshot of the control panel main page for a resolver with an error:

![image](https://github.com/micronaut-projects/micronaut-test-resources/assets/316357/b8d712c9-baaf-4b23-9de7-2b66ebcb8db3)

Then on the details page:


![image](https://github.com/micronaut-projects/micronaut-test-resources/assets/316357/34220e93-1255-4da7-8b78-ef3a774577da)

