### PR TITLE
Fix server not shutting down

### DIFF
--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.testresources.server;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.testresources.core.TestResourcesResolutionException;
@@ -44,13 +46,20 @@ import java.util.Optional;
 @Ping
 public class TestResourcesController implements TestResourcesResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestResourcesController.class);
+    private static final int MAX_STOP_TIMEOUT = 5000;
 
     private final TestResourcesResolverLoader loader = TestResourcesResolverLoader.getInstance();
 
     private final List<PropertyResolutionListener> propertyResolutionListeners;
+    private final EmbeddedServer embeddedServer;
+    private final ApplicationContext applicationContext;
 
-    public TestResourcesController(List<PropertyResolutionListener> propertyResolutionListeners) {
+    public TestResourcesController(List<PropertyResolutionListener> propertyResolutionListeners,
+                                   EmbeddedServer embeddedServer,
+                                   ApplicationContext applicationContext) {
         this.propertyResolutionListeners = propertyResolutionListeners;
+        this.embeddedServer = embeddedServer;
+        this.applicationContext = applicationContext;
     }
 
     /**
@@ -212,6 +221,26 @@ public class TestResourcesController implements TestResourcesResolver {
                     entry.getKey().toString())
                 ))
             .toList();
+    }
+
+    /**
+     * Requests a test resources service shutdown.
+     */
+    @Post("/stop")
+    public void stopService() {
+        var makeSureServerIsStopped = new Thread(() -> {
+            try {
+                embeddedServer.stop();
+                applicationContext.close();
+                Thread.sleep(MAX_STOP_TIMEOUT);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                System.exit(0);
+            }
+        });
+        makeSureServerIsStopped.setDaemon(true);
+        makeSureServerIsStopped.start();
     }
 
     private static boolean isEnabled(TestResourcesResolver resolver,

--- a/test-resources-server/src/main/resources/application.properties
+++ b/test-resources-server/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 micronaut.application.name=Test resources server
 micronaut.server.port=-1
-endpoints.stop.enabled=true
-endpoints.stop.sensitive=false
 # This will enable the control panel if the test-resources-control-panel module is on classpath
 micronaut.control-panel.enabled=true
 micronaut.control-panel.panels.routes.enabled=false


### PR DESCRIPTION
It seems that in some cases, even if the default stop endpoint is called, the server is not shutdown properly. This seems to happen if some containers are started, but not in all cases. With this change, we switch from using the `/stop` endpoint from management to a custom one which times out after 5s, making sure the server is killed.