### PR TITLE
Remove accidental dependency on kotlin stdlib

### DIFF
--- a/test-resources-extensions/test-resources-extensions-junit-platform/gradle.properties
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This is because we use Kotlin in tests, but not in production code.