### PR TITLE
Enhancements to the MySQL support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.4.0-SNAPSHOT
+projectVersion=2.5.0-SNAPSHOT
 projectGroup=io.micronaut.testresources
 
 title=Micronaut Test Resources

--- a/settings.gradle
+++ b/settings.gradle
@@ -111,7 +111,6 @@ micronautBuild {
     importMicronautCatalog("micronaut-elasticsearch")
     importMicronautCatalog("micronaut-email")
     importMicronautCatalog("micronaut-kafka")
-    importMicronautCatalog("micronaut-logging")
     importMicronautCatalog("micronaut-mongodb")
     importMicronautCatalog("micronaut-mqtt")
     importMicronautCatalog("micronaut-neo4j")

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -5,6 +5,9 @@ The following properties will automatically be set when using a JDBC database:
 - `datasources.*.password`
 - `datasources.*.dialect`
 
+Additionally, the MySQL resolver will automatically set the property `datasources.*.x-protocol-url` to be used with the
+https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html[MySQL X DevAPI].
+
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
 - `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgres`)

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -6,11 +6,11 @@ Micronaut Test Resources provides support for the following databases:
 |===
 |Database | JDBC | R2DBC | Database identifier | Default image
 
-| https://mariadb.org/[MariaDB] | Yes | Yes | mariadb | mariadb
-| https://www.mysql.com/[MySQL] | Yes | Yes | mysql | mysql
-| https://www.oracle.com/database/[Oracle Database] | Yes | Yes | oracle | gvenzl/oracle-xe:slim-faststart
-| https://www.postgresql.org/[PostgreSQL] | Yes | Yes | postgres | postgres
-| https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | mssql | mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04
+| https://mariadb.org/[MariaDB] | Yes | Yes | `mariadb` | `mariadb`
+| https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `container-registry.oracle.com/mysql/community-server`
+| https://www.oracle.com/database/[Oracle Database] | Yes | Yes | `oracle` | `gvenzl/oracle-xe:slim-faststart`
+| https://www.postgresql.org/[PostgreSQL] | Yes | Yes | `postgres` | `postgres`
+| https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | `mssql` | `mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04`
 
 |===
 

--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -34,7 +34,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     public static final String SIMPLE_NAME = "elasticsearch";
     public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
     public static final String DEFAULT_TAG = "8.4.3";
-    public static final String DISPLAY_NAME = "kafka";
+    public static final String DISPLAY_NAME = "Elasticsearch";
 
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -18,14 +18,12 @@ package io.micronaut.testresources.jdbc;
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/build.gradle
@@ -9,5 +9,5 @@ Provides support for launching a MySQL test container.
 dependencies {
     implementation(libs.managed.testcontainers.mysql)
 
-    testRuntimeOnly(mnSql.mysql.connector.java)
+    testImplementation(mnSql.mysql.connector.java)
 }

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A test resource provider which will spawn a MySQL test container.

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -26,6 +26,8 @@ import java.util.Map;
  */
 public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MySQLContainer<?>> {
     public static final String DISPLAY_NAME = "MySQL";
+    public static final String MYSQL_OFFICIAL_IMAGE = "container-registry.oracle.com/mysql/community-server";
+    public static final String DOCKER_OFFICIAL_IMAGE = "mysql";
 
     @Override
     public String getDisplayName() {
@@ -39,11 +41,15 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
 
     @Override
     protected String getDefaultImageName() {
-        return "mysql";
+        return MYSQL_OFFICIAL_IMAGE;
     }
 
     @Override
     protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        // Testcontainers uses by default the Docker Hub official image, so the MySQL official image needs to be set as compatible substitute
+        if (imageName.asCanonicalNameString().startsWith(MYSQL_OFFICIAL_IMAGE)) {
+            imageName = imageName.asCompatibleSubstituteFor(DOCKER_OFFICIAL_IMAGE);
+        }
         return new MySQLContainer<>(imageName);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/StartMySQLTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/StartMySQLTest.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.testresources.jdbc.mysql
 
+import com.mysql.cj.xdevapi.SessionFactory
+import io.micronaut.context.env.Environment
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.jdbc.AbstractJDBCSpec
 import io.micronaut.testresources.jdbc.Book
@@ -8,10 +10,15 @@ import jakarta.inject.Inject
 
 @MicronautTest
 class StartMySQLTest extends AbstractJDBCSpec {
+
     @Inject
     MySQLBookRepository repository
 
-    def "starts a MySQL container"() {
+    @Inject
+    Environment environment
+
+    void "starts a MySQL container"() {
+        given:
         def book = new Book(title: "Micronaut for Spring developers")
         repository.save(book)
 
@@ -20,6 +27,20 @@ class StartMySQLTest extends AbstractJDBCSpec {
 
         then:
         books.size() == 1
+    }
+
+    void "resolves the X Protocol URL"() {
+        given:
+        def xProtocolUrl = environment.getRequiredProperty("datasources.default.x-protocol-url", String)
+
+        when:
+        def session = new SessionFactory().getSession(xProtocolUrl)
+
+        then:
+        session.isOpen()
+
+        cleanup:
+        session.close()
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/StartMySQLTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/StartMySQLTest.groovy
@@ -3,6 +3,7 @@ package io.micronaut.testresources.jdbc.mysql
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.jdbc.AbstractJDBCSpec
 import io.micronaut.testresources.jdbc.Book
+import io.micronaut.testresources.mysql.MySQLTestResourceProvider
 import jakarta.inject.Inject
 
 @MicronautTest
@@ -23,6 +24,6 @@ class StartMySQLTest extends AbstractJDBCSpec {
 
     @Override
     String getImageName() {
-        "mysql"
+        MySQLTestResourceProvider.MYSQL_OFFICIAL_IMAGE
     }
 }


### PR DESCRIPTION
This PR:

- Uses [the real official MySQL image](https://blogs.oracle.com/mysql/post/where-to-find-official-mysql-container-images).
- Resolves a new property to allow using [MySQL Document Store](https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html).