### PR TITLE
Add Oracle Free module, to be used as the main Oracle Database

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ managed-testcontainers-mssql = { module = "org.testcontainers:mssqlserver", vers
 managed-testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "managed-testcontainers" }
 managed-testcontainers-neo4j = { module = "org.testcontainers:neo4j", version.ref = "managed-testcontainers" }
 managed-testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "managed-testcontainers" }
+managed-testcontainers-oracle-free = { module = "org.testcontainers:oracle-free", version.ref = "managed-testcontainers" }
 managed-testcontainers-postgres = { module = "org.testcontainers:postgresql", version.ref = "managed-testcontainers" }
 managed-testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq", version.ref = "managed-testcontainers" }
 managed-testcontainers-redis = { module = "com.redis.testcontainers:testcontainers-redis", version.ref = "managed-testcontainers-redis" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,8 @@ def hibernateReactiveModules = [
         'mssql',
         'mysql',
         'postgresql',
-        'oracle-xe'
+        'oracle-xe',
+        'oracle-free'
 ]
 
 def localstackModules = [

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ def r2dbcModules = [
         'mariadb',
         'mysql',
         'oracle-xe',
+        'oracle-free',
         'postgresql',
         'mssql',
         'pool'

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ def jdbcModules = [
         'mysql',
         'mariadb',
         'oracle-xe',
+        'oracle-free',
         'postgresql',
         'mssql'
 ]

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -10,6 +10,6 @@ https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html[MySQL X 
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgres`)
+- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
 - `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)

--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -8,13 +8,13 @@ The following properties will automatically be set when using a JDBC database:
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `r2dbc.datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgresql`)
+- `r2dbc.datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgresql`)
 - `r2dbc.datasources.*.driverClassName`: the class name of the driver (fallback)
 - `r2dbc.datasources.*.dialect`: the dialect to use for the database (fallback)
 
 In addition, R2DBC databases can be configured simply by reading the traditional JDBC properties:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `postgresql`)
+- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgresql`)
 - `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 - `datasources.*.db-name`: overrides the default test database name

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -8,7 +8,7 @@ Micronaut Test Resources provides support for the following databases:
 
 | https://mariadb.org/[MariaDB] | Yes | Yes | `mariadb` | `mariadb`
 | https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `container-registry.oracle.com/mysql/community-server`
-| https://www.oracle.com/database/[Oracle Database] | Yes | Yes | `oracle-xe` | `gvenzl/oracle-xe:slim-faststart`
+| https://www.oracle.com/database/technologies/appdev/xe.html[Oracle Database XE] | Yes | Yes | `oracle-xe` | `gvenzl/oracle-xe:slim-faststart`
 | https://www.oracle.com/database/free/[Oracle Database Free] | Yes | Yes | `oracle` | `gvenzl/oracle-free:slim-faststart`
 | https://www.postgresql.org/[PostgreSQL] | Yes | Yes | `postgres` | `postgres`
 | https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | `mssql` | `mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04`

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -8,7 +8,8 @@ Micronaut Test Resources provides support for the following databases:
 
 | https://mariadb.org/[MariaDB] | Yes | Yes | `mariadb` | `mariadb`
 | https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `container-registry.oracle.com/mysql/community-server`
-| https://www.oracle.com/database/[Oracle Database] | Yes | Yes | `oracle` | `gvenzl/oracle-xe:slim-faststart`
+| https://www.oracle.com/database/[Oracle Database] | Yes | Yes | `oracle-xe` | `gvenzl/oracle-xe:slim-faststart`
+| https://www.oracle.com/database/free/[Oracle Database Free] | Yes | Yes | `oracle` | `gvenzl/oracle-free:slim-faststart`
 | https://www.postgresql.org/[PostgreSQL] | Yes | Yes | `postgres` | `postgres`
 | https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | `mssql` | `mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04`
 

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -89,9 +89,9 @@ public final class TestResourcesClasspath implements KnownModules {
     private static final String MYSQL_MODULE = "jdbc-mysql";
     private static final String REACTIVE_MYSQL_MODULE = "r2dbc-mysql";
     private static final String NEO4J_MODULE = "neo4j";
-    private static final String ORACLE_XE_MODULE = "jdbc-oracle-xe";
+    private static final String ORACLE_FREE_MODULE = "jdbc-oracle-free";
     private static final String RABBITMQ_MODULE = "rabbitmq";
-    private static final String REACTIVE_ORACLE_XE_MODULE = "r2dbc-oracle-xe";
+    private static final String REACTIVE_ORACLE_FREE_MODULE = "r2dbc-oracle-free";
     private static final String POSTGRESQL_MODULE = "jdbc-postgresql";
     private static final String REACTIVE_POSTGRESQL_MODULE = "r2dbc-postgresql";
     private static final String MARIADB_MODULE = "jdbc-mariadb";
@@ -152,11 +152,11 @@ public final class TestResourcesClasspath implements KnownModules {
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(POSTGRESQL_DRIVER)), POSTGRESQL_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(MARIADB_JAVA_CLIENT)), MARIADB_MODULE);
             m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(moduleEquals(MSSQL_DRIVER)), MSSQL_MODULE);
-            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(d -> ORACLE_DRIVERS.contains(d.getModule())), ORACLE_XE_MODULE);
+            m.onArtifact(name -> name.startsWith(MICRONAUT_DATA_PREFIX), deps -> deps.anyMatch(d -> ORACLE_DRIVERS.contains(d.getModule())), ORACLE_FREE_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(d -> REACTIVE_MYSQL_DRIVERS.contains(d.getModule())), REACTIVE_MYSQL_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_MARIADB_DRIVER)), REACTIVE_MARIADB_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_POSTGRESQL_DRIVER)), REACTIVE_POSTGRESQL_MODULE);
-            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_ORACLE_DRIVER)), REACTIVE_ORACLE_XE_MODULE);
+            m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_ORACLE_DRIVER)), REACTIVE_ORACLE_FREE_MODULE);
             m.onArtifact(name -> name.equals(MICRONAUT_DATA_R2DBC), deps -> deps.anyMatch(moduleEquals(REACTIVE_MSSQL_DRIVER)), REACTIVE_MSSQL_MODULE);
             m.passthroughModules(
                 MYSQL_MYSQL_CONNECTOR_JAVA, MYSQL_MYSQL_CONNECTOR_J,

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/TestResourcesClasspathTest.groovy
@@ -91,7 +91,7 @@ class TestResourcesClasspathTest extends Specification {
         'com.mysql:mysql-connector-j'          | 'mysql'
         'org.postgresql:postgresql'            | 'postgresql'
         'org.mariadb.jdbc:mariadb-java-client' | 'mariadb'
-        'com.oracle.database.jdbc:ojdbc8'      | 'oracle-xe'
+        'com.oracle.database.jdbc:ojdbc8'      | 'oracle-free'
         'com.microsoft.sqlserver:mssql-jdbc'   | 'mssql'
     }
 
@@ -138,7 +138,7 @@ class TestResourcesClasspathTest extends Specification {
         'io.asyncer:r2dbc-mysql'                 | 'mysql'
         'org.mariadb:r2dbc-mariadb'              | 'mariadb'
         'org.postgresql:r2dbc-postgresql'        | 'postgresql'
-        'com.oracle.database.r2dbc:oracle-r2dbc' | 'oracle-xe'
+        'com.oracle.database.r2dbc:oracle-r2dbc' | 'oracle-free'
         'io.r2dbc:r2dbc-mssql'                   | 'mssql'
         'io.r2dbc:r2dbc-pool'                    | 'pool'
     }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/build.gradle
@@ -12,3 +12,9 @@ dependencies {
 
     testRuntimeOnly(libs.vertx.oracle)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = version != '2.5.0-SNAPSHOT'
+    }
+}

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'io.micronaut.build.internal.hibernate-reactive-module'
+}
+
+description = """
+Provides support for launching an Oracle Free test container for Hibernate Reactive.
+"""
+
+dependencies {
+    implementation(libs.managed.testcontainers.oracle.free)
+    runtimeOnly(projects.micronautTestResourcesJdbcOracleFree)
+
+    testRuntimeOnly(libs.vertx.oracle)
+}

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleFreeTestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleFreeTestResourceProvider.java
@@ -16,18 +16,15 @@
 package io.micronaut.testresources.hibernate.reactive.oracle;
 
 import io.micronaut.testresources.hibernate.reactive.core.AbstractHibernateReactiveTestResourceProvider;
-import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 
 /**
- * A test resource provider which will spawn an Oracle XE test container.
- *
- * @deprecated Use <code>oracle-free</code> instead.
+ * A test resource provider which will spawn an Oracle Free test container.
  */
-@Deprecated(since = "2.4.0", forRemoval = true)
-public class HibernateReactiveOracleXETestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<OracleContainer> {
+public class HibernateReactiveOracleFreeTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<OracleContainer> {
     public static final String DISPLAY_NAME = "Oracle Database (Hibernate Reactive)";
 
     @Override
@@ -37,12 +34,12 @@ public class HibernateReactiveOracleXETestResourceProvider extends AbstractHiber
 
     @Override
     protected String getSimpleName() {
-        return "oracle-xe";
+        return "oracle";
     }
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe:slim-faststart";
+        return "gvenzl/oracle-free:slim-faststart";
     }
 
     @Override

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.hibernate.reactive.oracle.HibernateReactiveOracleFreeTestResourceProvider

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/groovy/io/micronaut/testresources/hibernate/reactive/oracle/StandaloneStartOracleFreeDBTest.groovy
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/groovy/io/micronaut/testresources/hibernate/reactive/oracle/StandaloneStartOracleFreeDBTest.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.testresources.hibernate.reactive.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.hibernate.reactive.core.Book
+import io.micronaut.testresources.hibernate.reactive.core.BookRepository
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+import jakarta.inject.Inject
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+@MicronautTest(transactional = false, environments = "standalone")
+class StandaloneStartOracleFreeDBTest extends AbstractTestContainersSpec {
+    private static final Duration TEST_TIMEOUT = Duration.of(10, ChronoUnit.SECONDS)
+
+    @Inject
+    BookRepository repository
+
+    def "starts a Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block(TEST_TIMEOUT)
+
+        when:
+        def books = repository.findAll().collectList().block(TEST_TIMEOUT)
+
+        then:
+        books.size() == 1
+
+        and:
+        listContainers().size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/groovy/io/micronaut/testresources/hibernate/reactive/oracle/WithJdbcStartOracleFreeDBTest.groovy
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/groovy/io/micronaut/testresources/hibernate/reactive/oracle/WithJdbcStartOracleFreeDBTest.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.testresources.hibernate.reactive.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.hibernate.reactive.core.Book
+import io.micronaut.testresources.hibernate.reactive.core.BookRepository
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+import jakarta.inject.Inject
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+@MicronautTest(transactional = false, environments = "jdbc")
+class WithJdbcStartOracleFreeDBTest extends AbstractTestContainersSpec {
+    private static final Duration TEST_TIMEOUT = Duration.of(10, ChronoUnit.SECONDS)
+
+    @Inject
+    BookRepository repository
+
+    def "starts a Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block(TEST_TIMEOUT)
+
+        when:
+        def books = repository.findAll().collectList().block(TEST_TIMEOUT)
+
+        then:
+        books.size() == 1
+
+        and:
+        listContainers().size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/application-jdbc.yml
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/application-jdbc.yml
@@ -1,0 +1,14 @@
+datasources:
+  default:
+    db-type: oracle
+    schema-generate: CREATE_DROP
+    dialect: ORACLE
+jpa:
+  default:
+    reactive: true
+    entity-scan:
+      packages: io.micronaut.testresources.hibernate.reactive.core
+    properties:
+      hibernate:
+        hbm2ddl:
+          auto: update

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/application-standalone.yml
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/application-standalone.yml
@@ -1,0 +1,11 @@
+jpa:
+  default:
+    reactive: true
+    entity-scan:
+      packages: io.micronaut.testresources.hibernate.reactive.core
+    properties:
+      hibernate:
+        connection:
+          db-type: oracle
+        hbm2ddl:
+          auto: update

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/logback.xml
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-free/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/build.gradle
@@ -8,7 +8,7 @@ Provides support for launching an Oracle XE test container for Hibernate Reactiv
 
 dependencies {
     implementation(libs.managed.testcontainers.oracle.xe)
-    runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
+    runtimeOnly(projects.micronautTestResourcesJdbcOracleXe)
 
     testRuntimeOnly(libs.vertx.oracle)
 }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleXETestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/main/java/io/micronaut/testresources/hibernate/reactive/oracle/HibernateReactiveOracleXETestResourceProvider.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn an Oracle XE test container.
  *
- * @deprecated Use <code>oracle-free</code> instead.
+ * @deprecated Use <code>oracle</code> instead.
  */
 @Deprecated(since = "2.4.0", forRemoval = true)
 public class HibernateReactiveOracleXETestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<OracleContainer> {

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/test/resources/application-jdbc.yml
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/test/resources/application-jdbc.yml
@@ -1,6 +1,6 @@
 datasources:
   default:
-    db-type: oracle
+    db-type: oracle-xe
     schema-generate: CREATE_DROP
     dialect: ORACLE
 jpa:

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/test/resources/application-standalone.yml
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-oracle-xe/src/test/resources/application-standalone.yml
@@ -6,6 +6,6 @@ jpa:
     properties:
       hibernate:
         connection:
-          db-type: oracle
+          db-type: oracle-xe
         hbm2ddl:
           auto: update

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'io.micronaut.build.internal.jdbc-module'
+}
+
+description = """
+Provides support for launching a Oracle Free test container.
+"""
+
+dependencies {
+    implementation(libs.managed.testcontainers.oracle.free)
+
+    testRuntimeOnly(mnSql.ojdbc8)
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/build.gradle
@@ -11,3 +11,9 @@ dependencies {
 
     testRuntimeOnly(mnSql.ojdbc8)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = version != '2.5.0-SNAPSHOT'
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/java/io/micronaut/testresources/oracle/free/OracleFreeTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/java/io/micronaut/testresources/oracle/free/OracleFreeTestResourceProvider.java
@@ -13,25 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.testresources.oracle.xe;
+package io.micronaut.testresources.oracle.free;
 
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
-import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A test resource provider which will spawn an Oracle XE test container.
+ * A test resource provider which will spawn an Oracle Free test container.
  *
- * @deprecated Use <code>oracle-free</code> instead.
+ * @since 2.4.0
  */
-@Deprecated(since = "2.4.0", forRemoval = true)
-public class OracleXETestResourceProvider extends AbstractJdbcTestResourceProvider<OracleContainer> {
+public class OracleFreeTestResourceProvider extends AbstractJdbcTestResourceProvider<OracleContainer> {
     private static final String OCID = "ocid";
     public static final String DISPLAY_NAME = "Oracle Database";
 
@@ -70,12 +68,12 @@ public class OracleXETestResourceProvider extends AbstractJdbcTestResourceProvid
 
     @Override
     protected String getSimpleName() {
-        return "oracle-xe";
+        return "oracle";
     }
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe:slim-faststart";
+        return "gvenzl/oracle-free:slim-faststart";
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/java/io/micronaut/testresources/oracle/free/OracleFreeTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/java/io/micronaut/testresources/oracle/free/OracleFreeTestResourceProvider.java
@@ -30,8 +30,8 @@ import java.util.stream.Stream;
  * @since 2.4.0
  */
 public class OracleFreeTestResourceProvider extends AbstractJdbcTestResourceProvider<OracleContainer> {
-    private static final String OCID = "ocid";
     public static final String DISPLAY_NAME = "Oracle Database";
+    private static final String OCID = "ocid";
 
     @Override
     public String getDisplayName() {

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.oracle.free.OracleFreeTestResourceProvider

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/OracleATPTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/OracleATPTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.jdbc.free
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import spock.lang.Issue
+
+class OracleATPTest extends AbstractJDBCSpec {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-test-resources/issues/104")
+    def "an Oracle container isn't started if ATP prod environment is detected"() {
+        // because we test a production environment, ideally this should actually spawn a
+        // mock for Oracle ATP, but for now we will just check that the properties are
+        // not resolved by the test resources provider
+        when:
+        ApplicationContext.builder("test", "prod")
+            .packages("io.micronaut.testresources.jdbc.free")
+            .start()
+
+        then:
+        BeanInstantiationException ex = thrown()
+        ex.message.contains("Test resources doesn't support resolving expression 'datasources.default.password'")
+    }
+
+    @Override
+    String getImageName() {
+        "oracle-free"
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/OracleFreeBookRepository.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/OracleFreeBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.jdbc.free
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import io.micronaut.testresources.jdbc.Book
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface OracleFreeBookRepository extends CrudRepository<Book, Long> {
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/StartOracleFreeTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/groovy/io/micronaut/testresources/jdbc/free/StartOracleFreeTest.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.jdbc.free
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+@MicronautTest
+class StartOracleFreeTest extends AbstractJDBCSpec {
+    @Inject
+    OracleFreeBookRepository repository
+
+    def "starts an Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book)
+
+        when:
+        def books = repository.findAll()
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle-free"
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/application-prod.yml
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/application-prod.yml
@@ -1,0 +1,3 @@
+datasources:
+  default:
+    ocid: SOME_ID

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/application-test.yml
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+datasources:
+  default:
+    driverClassName: oracle.jdbc.OracleDriver
+    schema-generate: CREATE_DROP
+    dialect: ORACLE

--- a/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/logback.xml
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-free/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/main/java/io/micronaut/testresources/oracle/xe/OracleXETestResourceProvider.java
@@ -22,18 +22,17 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * A test resource provider which will spawn an Oracle XE test container.
  *
- * @deprecated Use <code>oracle-free</code> instead.
+ * @deprecated Use <code>oracle</code> instead.
  */
 @Deprecated(since = "2.4.0", forRemoval = true)
 public class OracleXETestResourceProvider extends AbstractJdbcTestResourceProvider<OracleContainer> {
-    private static final String OCID = "ocid";
     public static final String DISPLAY_NAME = "Oracle Database";
+    private static final String OCID = "ocid";
 
     @Override
     public String getDisplayName() {

--- a/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/resources/application-test.yml
+++ b/test-resources-jdbc/test-resources-jdbc-oracle-xe/src/test/resources/application-test.yml
@@ -1,5 +1,6 @@
 datasources:
   default:
+    db-type: oracle-xe
     driverClassName: oracle.jdbc.OracleDriver
     schema-generate: CREATE_DROP
     dialect: ORACLE

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/build.gradle
@@ -12,3 +12,9 @@ dependencies {
 
     testRuntimeOnly(mnR2dbc.r2dbc.oracle)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = version != '2.5.0-SNAPSHOT'
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'io.micronaut.build.internal.r2dbc-module'
+}
+
+description = """
+Provides support for Oracle Free R2DBC test resources.
+"""
+
+dependencies {
+    implementation(libs.managed.testcontainers.oracle.free)
+    runtimeOnly(projects.micronautTestResourcesJdbcOracleFree)
+
+    testRuntimeOnly(mnR2dbc.r2dbc.oracle)
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleFreeTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleFreeTestResourceProvider.java
@@ -25,7 +25,6 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.testresources.r2dbc.core.R2dbcSupport.datasourceNameFrom;

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleFreeTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/java/io/micronaut/testresources/r2dbc/oracle/R2DBCOracleFreeTestResourceProvider.java
@@ -19,7 +19,7 @@ import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.micronaut.testresources.r2dbc.core.R2dbcSupport;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
@@ -32,16 +32,13 @@ import static io.micronaut.testresources.r2dbc.core.R2dbcSupport.datasourceNameF
 import static io.micronaut.testresources.r2dbc.core.R2dbcSupport.r2dbDatasourceExpressionOf;
 
 /**
- * A test resource provider which will spawn an Oracle XE reactive test container.
- *
- * @deprecated Use <code>oracle</code> instead.
+ * A test resource provider which will spawn an Oracle Free reactive test container.
  */
-@Deprecated(since = "2.4.0", forRemoval = true)
-public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResourceProvider<OracleContainer> {
+public class R2DBCOracleFreeTestResourceProvider extends AbstractR2DBCTestResourceProvider<OracleContainer> {
 
+    public static final String DISPLAY_NAME = "Oracle Database (R2DBC)";
     private static final String R2DBC_ORACLE_DRIVER = "oracle";
     private static final String OCID = "ocid";
-    public static final String DISPLAY_NAME = "Oracle Database (R2DBC)";
 
     @Override
     public List<String> getRequiredProperties(String expression) {
@@ -51,7 +48,7 @@ public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResource
         return Stream.concat(
             requiredProperties.stream(),
             Stream.of(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, OCID))
-        ).collect(Collectors.toList());
+        ).toList();
     }
 
     @Override
@@ -82,13 +79,12 @@ public class R2DBCOracleXETestResourceProvider extends AbstractR2DBCTestResource
 
     @Override
     protected String getDefaultImageName() {
-        return "gvenzl/oracle-xe:slim-faststart";
+        return "gvenzl/oracle-free:slim-faststart";
     }
 
     @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
-        if (container instanceof OracleContainer) {
-            OracleContainer oracle = (OracleContainer) container;
+        if (container instanceof OracleContainer oracle) {
             ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
                 .option(ConnectionFactoryOptions.USER, oracle.getUsername())
                 .option(ConnectionFactoryOptions.PASSWORD, oracle.getPassword())

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.r2dbc.oracle.R2DBCOracleFreeTestResourceProvider

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/OracleATPReactiveTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/OracleATPReactiveTest.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import spock.lang.Issue
+
+class OracleATPReactiveTest extends AbstractJDBCSpec {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-test-resources/issues/104")
+    def "an Oracle container isn't started if ATP prod environment is detected"() {
+        // because we test a production environment, ideally this should actually spawn a
+        // mock for Oracle ATP, but for now we will just check that the properties are
+        // not resolved by the test resources provider
+        when:
+        ApplicationContext.builder(environments as String[])
+                .packages("io.micronaut.testresources.jdbc.free")
+                .start()
+
+        then:
+        BeanInstantiationException ex = thrown()
+        ex.message.contains("Test resources doesn't support resolving expression '$expression")
+
+        where:
+        environments                             | expression
+        ["test", "jdbc", "prod"]                 | "datasources.default"
+        ["test", "standalone", "standaloneprod"] | "r2dbc.datasources.default"
+
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/ReactiveBookRepository.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/ReactiveBookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorPageableRepository
+import io.micronaut.testresources.jdbc.Book
+
+@R2dbcRepository(dialect = Dialect.ORACLE)
+interface ReactiveBookRepository extends ReactorPageableRepository<Book, Long> {
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/StandaloneStartOracleTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/StandaloneStartOracleTest.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+import spock.lang.IgnoreIf
+
+@MicronautTest(environments = ["standalone"], transactional = false )
+@IgnoreIf({ !jvm.java11Compatible })
+class StandaloneStartOracleTest extends AbstractJDBCSpec {
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/WithJdbcStartOracleTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/groovy/io/micronaut/testresources/r2dbc/oracle/WithJdbcStartOracleTest.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.testresources.r2dbc.oracle
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.AbstractJDBCSpec
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+import spock.lang.IgnoreIf
+
+@MicronautTest(environments = ["jdbc"], transactional = false )
+@IgnoreIf({ !jvm.java11Compatible })
+class WithJdbcStartOracleTest extends AbstractJDBCSpec {
+
+    @Inject
+    ReactiveBookRepository repository
+
+    def "starts a reactive Oracle container"() {
+        def book = new Book(title: "Micronaut for Spring developers")
+        repository.save(book).block()
+
+        when:
+        def books = repository.findAll().toIterable() as List<Book>
+
+        then:
+        books.size() == 1
+    }
+
+    @Override
+    String getImageName() {
+        "oracle"
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-jdbc.yml
@@ -1,0 +1,10 @@
+datasources:
+  default:
+    driverClassName: oracle.jdbc.OracleDriver
+    schema-generate: CREATE_DROP
+    dialect: ORACLE
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: ORACLE

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-prod.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-prod.yml
@@ -1,0 +1,3 @@
+datasources:
+  default:
+    ocid: SOME_ID

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-standalone.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-standalone.yml
@@ -1,0 +1,5 @@
+r2dbc:
+  datasources:
+    default:
+      schema-generate: CREATE_DROP
+      dialect: ORACLE

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-standaloneprod.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/application-standaloneprod.yml
@@ -1,0 +1,4 @@
+r2dbc:
+  datasources:
+    default:
+      ocid: SOME_ID

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/logback.xml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-free/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+
+</configuration>

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/build.gradle
@@ -8,7 +8,7 @@ Provides support for Oracle XE R2DBC test resources.
 
 dependencies {
     implementation(libs.managed.testcontainers.oracle.xe)
-    runtimeOnly(project(":micronaut-test-resources-jdbc-oracle-xe"))
+    runtimeOnly(projects.micronautTestResourcesJdbcOracleXe)
 
     testRuntimeOnly(mnR2dbc.r2dbc.oracle)
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-jdbc.yml
+++ b/test-resources-r2dbc/test-resources-r2dbc-oracle-xe/src/test/resources/application-jdbc.yml
@@ -1,5 +1,6 @@
 datasources:
   default:
+    db-type: oracle-xe
     driverClassName: oracle.jdbc.OracleDriver
     schema-generate: CREATE_DROP
     dialect: ORACLE


### PR DESCRIPTION
Oracle Database Express Edition (XE) is considered deprecated, and it supports only versions up to 21.

From https://blogs.oracle.com/database/post/database-23c-free-ga"

> Oracle Database Free is the successor of Oracle Database Express Edition (XE). It is released under the same [Free Use Terms and Conditions](https://www.oracle.com/downloads/licenses/oracle-free-license.html), resource limits, and community support as its predecessor. Users of Oracle Database Express Edition are advised to upgrade to Oracle Database 23c Free now to take advantage of the latest and greatest features of Oracle Database.