### PR TITLE
Add params for redis cluster provider

### DIFF
--- a/src/main/docs/guide/modules-redis.adoc
+++ b/src/main/docs/guide/modules-redis.adoc
@@ -1,9 +1,16 @@
 Redis support will automatically start a https://redis.io/[Redis container] and provide the value of the `redis.uri` property.
+This provider can be configured with a variety of parameters:
 
-Alternatively, test resources can spawn a redis cluster, in which case you will need to set the `test-resources.containers.redis.cluster-mode` to `true` and the `redis.uris` property will be provided instead of `redis.uri`.
+* The default image can be overwritten by setting the `test-resources.containers.redis.image-name` property.
 
-The default image can be overwritten by setting the `test-resources.containers.redis.image-name` property.
+* Have Test Resources spawn a Redis cluster by setting `test-resources.containers.redis.cluster-mode` to `true`. With this setting, the property `redis.uris` will be defined instead of `redis.uri`, and some cluster-specific parameters may be provided under `test-resources.containers.redis.cluster`:
 
-The number of nodes in cluster mode can be controlled by the `test-resources.containers.redis.masters` property.
+** The number of master nodes can be controlled by the `masters` property.
 
-The number of slaves per master can be controller by the `test-resources.containers.redis.slaves-per-master` property.
+** The number of slaves per master can be controlled by the `slaves-per-master` property.
+
+** The starting port number can be set with property `initial-port`. For a port argument of `n`, each cluster node numbered 0 to `x` will have port number `n + x`, respectively. The default is 7000.
+
+** The cluster IP can be set with property `ip` (may be necessary for cluster discovery on Mac computers).
+
+** https://redis.io/docs/latest/develop/use/keyspace-notifications[Keyspace notifications] can be enabled by providing a string value to `notify-keyspace-events`. If provided, the value will be set on the `notify-keyspace-events` parameter in the redis.conf file for each node.

--- a/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisClusterTestResourceProvider.java
+++ b/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisClusterTestResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static io.micronaut.testresources.redis.RedisConfigurationSupport.*;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.findInitialPort;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.findIp;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.findMasterCount;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.findNotifyKeyspaceEvents;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.findSlavesPerMasterCount;
+import static io.micronaut.testresources.redis.RedisConfigurationSupport.isClusterMode;
 
 /**
  * A test resource provider which will spawn a Redis cluster test container.

--- a/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisConfigurationSupport.java
+++ b/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisConfigurationSupport.java
+++ b/test-resources-redis/src/main/java/io/micronaut/testresources/redis/RedisConfigurationSupport.java
@@ -18,6 +18,7 @@ package io.micronaut.testresources.redis;
 import com.redis.testcontainers.RedisClusterContainer;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Internal class to deal with the test resources
@@ -27,6 +28,9 @@ abstract class RedisConfigurationSupport {
     public static final String CONFIG_REDIS_CLUSTER_MODE = "containers.redis.cluster-mode";
     public static final String CONFIG_REDIS_CLUSTER_MASTERS = "containers.redis.cluster.masters";
     public static final String CONFIG_REDIS_CLUSTER_SLAVES = "containers.redis.cluster.slaves-per-master";
+    public static final String CONFIG_REDIS_CLUSTER_INITIAL_PORT = "containers.redis.cluster.initial-port";
+    public static final String CONFIG_REDIS_CLUSTER_IP = "containers.redis.cluster.ip";
+    public static final String CONFIG_REDIS_CLUSTER_NOTIFY_KEYSPACE_EVENTS = "containers.redis.cluster.notify-keyspace-events";
 
     private RedisConfigurationSupport() {
 
@@ -37,11 +41,24 @@ abstract class RedisConfigurationSupport {
         return Boolean.TRUE.equals(clusterMode);
     }
 
-    static int findMasterCound(Map<String, Object> testResourcesConfig) {
+    static int findMasterCount(Map<String, Object> testResourcesConfig) {
         return (Integer) testResourcesConfig.getOrDefault(CONFIG_REDIS_CLUSTER_MASTERS, RedisClusterContainer.DEFAULT_MASTERS);
     }
 
     static int findSlavesPerMasterCount(Map<String, Object> testResourcesConfig) {
         return (Integer) testResourcesConfig.getOrDefault(CONFIG_REDIS_CLUSTER_SLAVES, RedisClusterContainer.DEFAULT_SLAVES_PER_MASTER);
+    }
+
+    static int findInitialPort(Map<String, Object> testResourcesConfig) {
+        return (Integer) testResourcesConfig.getOrDefault(CONFIG_REDIS_CLUSTER_INITIAL_PORT, RedisClusterContainer.DEFAULT_INITIAL_PORT);
+    }
+
+    static String findIp(Map<String, Object> testResourcesConfig) {
+        return (String) testResourcesConfig.getOrDefault(CONFIG_REDIS_CLUSTER_IP, RedisClusterContainer.DEFAULT_IP);
+    }
+
+    static Optional<String> findNotifyKeyspaceEvents(Map<String, Object> testResourcesConfig) {
+        String notifyKeyspaceEvents = (String) testResourcesConfig.getOrDefault(CONFIG_REDIS_CLUSTER_NOTIFY_KEYSPACE_EVENTS, null);
+        return Optional.ofNullable(notifyKeyspaceEvents);
     }
 }

--- a/test-resources-redis/src/test/groovy/io/micronaut/testresources/redis/RedisClusterStartedTest.groovy
+++ b/test-resources-redis/src/test/groovy/io/micronaut/testresources/redis/RedisClusterStartedTest.groovy
@@ -22,7 +22,10 @@ class RedisClusterStartedTest extends AbstractRedisSpec {
 
         then:
         value == 'bar'
-        listContainers().size() == 1
+        def containers = listContainers()
+        containers.size() == 1
+        containers[0].ports.collect { it.publicPort }
+                .containsAll([7015, 7016, 7017])
     }
 
 }

--- a/test-resources-redis/src/test/resources/application-cluster.yml
+++ b/test-resources-redis/src/test/resources/application-cluster.yml
@@ -2,3 +2,7 @@ test-resources:
   containers:
     redis:
       cluster-mode: true
+      cluster:
+        masters: 3
+        initial-port: 7015
+        notify-keyspace-events: Ex


### PR DESCRIPTION
This augments the Redis cluster provider to allow setting all the parameters supported by the backing RedisClusterContainer.

The only thing I don't use from the testcontainers definition is the setting of withKeyspaceNotifications because it uses a Docker image that doesn't seem to exist. The method in this PR seems better anyway because it allows the consumer to specify notification types.