### PR TITLE
Add OpenSearch docs

### DIFF
--- a/src/main/docs/guide/modules-opensearch.adoc
+++ b/src/main/docs/guide/modules-opensearch.adoc
@@ -1,0 +1,3 @@
+OpenSearch support will automatically start an https://opensearch.org/[OpenSearch] container and provide the value of the `micronaut.opensearch.rest-client.http-hosts` or `micronaut.opensearch.httpclient5.http-hosts` properties.
+
+The default image (`opensearchproject/opensearch:latest`) can be overwritten by setting the `test-resources.containers.opensearch.image-name` property.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -13,6 +13,8 @@ modules:
       title: R2DBC
   modules-elasticsearch:
     title: Elasticsearch
+  modules-opensearch:
+    title: OpenSearch
   modules-kafka:
     title: Kafka
   modules-localstack:


### PR DESCRIPTION
Closes #596 

I think 2.5.x is the correct branch for Micronaut 4.5.0...  But we also have a 2.6.x branch, which has confused me