### PR TITLE
Passthrough docker.check.timeout.seconds system property or env

### DIFF
--- a/src/main/docs/guide/architecture-configuration.adoc
+++ b/src/main/docs/guide/architecture-configuration.adoc
@@ -1,0 +1,6 @@
+=== Docker Client creation timeout
+
+The test-resources server communicates with Docker via a docker client.
+By default, creation of this client is expected to take less than 10 seconds.
+However, under certain circumstances (limited resources, docker in docker, etc.), this may take longer.
+To configure the timeout, you can pass a system property `docker.check.timeout.seconds` or an environment variable `TEST_RESOURCES_DOCKER_CHECK_TIMEOUT_SECONDS` with the number of seconds you require.

--- a/src/main/docs/guide/architecture-server.adoc
+++ b/src/main/docs/guide/architecture-server.adoc
@@ -5,3 +5,4 @@ For example, a MySQL database may need to be started when the tests start, and s
 For this purpose, the test resource server must be started before the application under test starts, and shutdown after test resources are no longer needed.
 
 It means, for example, that with https://docs.gradle.org/current/userguide/userguide_single.html#sec:continuous_build[Gradle continuous builds], the test resources server would outlive a single build, making it possible to develop your application while not paying the price of starting a container on each build.
+

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -51,6 +51,8 @@ architecture:
       title: The test resources server
       architecture-shared-server:
         title: Sharing containers between independent builds
+      architecture-configuration:
+        title: Configuring the server
     architecture-client:
       title: The test resources client
     architecture-embedded:

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -80,6 +80,9 @@ public class ServerUtils {
     private static final String CDS_CLASS_LST = "cds.classlist";
     private static final String FLAT_JAR = "flat.jar";
 
+    // See io.micronaut.testresources.testcontainers.DockerSupport.TIMEOUT
+    private static final String DOCKER_CHECK_TIMEOUT_SECONDS = "docker.check.timeout.seconds";
+
     /**
      * Writes the server settings in an output directory.
      *
@@ -461,6 +464,10 @@ public class ServerUtils {
         public Map<String, String> getSystemProperties() {
             Map<String, String> systemProperties = new HashMap<>();
             systemProperties.put(JMX_SYSTEM_PROPERTY, null);
+            String dockerCheckTimeout = System.getProperty(DOCKER_CHECK_TIMEOUT_SECONDS);
+            if (dockerCheckTimeout != null) {
+                systemProperties.put(DOCKER_CHECK_TIMEOUT_SECONDS, dockerCheckTimeout);
+            }
             if (explicitPort != null) {
                 systemProperties.put(MICRONAUT_SERVER_PORT, String.valueOf(explicitPort));
             }

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -81,7 +81,8 @@ public class ServerUtils {
     private static final String FLAT_JAR = "flat.jar";
 
     // See io.micronaut.testresources.testcontainers.DockerSupport.TIMEOUT
-    private static final String DOCKER_CHECK_TIMEOUT_SECONDS = "docker.check.timeout.seconds";
+    private static final String DOCKER_CHECK_TIMEOUT_SECONDS_ENV = "TEST_RESOURCES_DOCKER_CHECK_TIMEOUT_SECONDS";
+    private static final String DOCKER_CHECK_TIMEOUT_SECONDS_PROPERTY = "docker.check.timeout.seconds";
 
     /**
      * Writes the server settings in an output directory.
@@ -464,9 +465,12 @@ public class ServerUtils {
         public Map<String, String> getSystemProperties() {
             Map<String, String> systemProperties = new HashMap<>();
             systemProperties.put(JMX_SYSTEM_PROPERTY, null);
-            String dockerCheckTimeout = System.getProperty(DOCKER_CHECK_TIMEOUT_SECONDS);
+            String dockerCheckTimeout = System.getProperty(DOCKER_CHECK_TIMEOUT_SECONDS_PROPERTY);
+            if (dockerCheckTimeout == null) {
+                dockerCheckTimeout = System.getenv(DOCKER_CHECK_TIMEOUT_SECONDS_ENV);
+            }
             if (dockerCheckTimeout != null) {
-                systemProperties.put(DOCKER_CHECK_TIMEOUT_SECONDS, dockerCheckTimeout);
+                systemProperties.put(DOCKER_CHECK_TIMEOUT_SECONDS_PROPERTY, dockerCheckTimeout);
             }
             if (explicitPort != null) {
                 systemProperties.put(MICRONAUT_SERVER_PORT, String.valueOf(explicitPort));

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -95,6 +95,23 @@ class ServerUtilsTest extends Specification {
     }
 
     @RestoreSystemProperties
+    def "can set the docker check timeout"() {
+        def portFile = tmpDir.resolve("port-file")
+        def settingsDir = tmpDir.resolve("settings")
+        def factory = Mock(ServerFactory)
+        System.setProperty('docker.check.timeout.seconds', "100")
+
+        when:
+        ServerUtils.startOrConnectToExistingServer(9999, portFile, settingsDir, null, null, null, null, factory)
+
+        then:
+        1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
+            assert params.mainClass == 'io.micronaut.testresources.server.TestResourcesService'
+            assert params.systemProperties['docker.check.timeout.seconds'] == '100'
+        }
+    }
+
+    @RestoreSystemProperties
     def "waits for the server to be available when using an explicit port"() {
         def portFile = tmpDir.resolve("port-file")
         def settingsDir = tmpDir.resolve("settings")


### PR DESCRIPTION
When starting the test-resources server, passthrough the `docker.check.timeout.seconds` system property if it is set, or use the env var `TEST_RESOURCES_DOCKER_CHECK_TIMEOUT_SECONDS` if that is set

The env var has precidence