### PR TITLE
Fix compatibility with Micronaut 4.4.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "4.4.1"
-micronaut-platform = "4.3.7"
+micronaut = "4.4.2"
+micronaut-platform = "4.4.2"
 micronaut-aot = "2.4.0"
 micronaut-aws = "4.5.0"
 micronaut-control-panel = "1.3.0"


### PR DESCRIPTION
This commit fixes compatibility with Micronaut 4.4.x, in particular, it fixes the test resources control panel which didn't load anymore (see https://github.com/micronaut-projects/micronaut-control-panel/issues/150).

Note that this change makes test resources incompatible with previous Micronaut 3.x releases. I don't understand why, we're not supposed to have incompatibilities in minors, but if we're trying to run it with a previous Micronaut release it would fail with:

Caused by: java.lang.IllegalAccessException: symbolic reference class is not accessible: class io.micronaut.views.$DefaultViewsResolver$Definition, from public Lookup
        at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:894)

Fixes https://github.com/micronaut-projects/micronaut-control-panel/issues/150