### PR TITLE
Fix test resources property factory when properties have requirements

### DIFF
--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
@@ -30,18 +30,18 @@ import java.util.function.Supplier;
  */
 @Internal
 public final class TestResourcesClientHolder {
-    private static TestResourcesClient CLIENT;
+    private static TestResourcesClient client;
 
     private TestResourcesClientHolder() {
 
     }
 
     public static void set(TestResourcesClient client) {
-        CLIENT = client;
+        TestResourcesClientHolder.client = client;
     }
 
     public static TestResourcesClient get() {
-        return CLIENT;
+        return client;
     }
 
     public static TestResourcesClient lazy() {
@@ -51,7 +51,7 @@ public final class TestResourcesClientHolder {
     private static class LazyTestResourcesClient implements TestResourcesClient {
 
         private static <T> T nullSafe(Supplier<T> value) {
-            if (CLIENT == null) {
+            if (client == null) {
                 return null;
             }
             return value.get();
@@ -59,37 +59,37 @@ public final class TestResourcesClientHolder {
 
         @Override
         public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-            return nullSafe(CLIENT::getResolvableProperties);
+            return nullSafe(client::getResolvableProperties);
         }
 
         @Override
         public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-            return nullSafe(() -> CLIENT.resolve(name, properties, testResourcesConfig));
+            return nullSafe(() -> client.resolve(name, properties, testResourcesConfig));
         }
 
         @Override
         public List<String> getRequiredProperties(String expression) {
-            return nullSafe(() -> CLIENT.getRequiredProperties(expression));
+            return nullSafe(() -> client.getRequiredProperties(expression));
         }
 
         @Override
         public List<String> getRequiredPropertyEntries() {
-            return nullSafe(CLIENT::getRequiredPropertyEntries);
+            return nullSafe(client::getRequiredPropertyEntries);
         }
 
         @Override
         public boolean closeAll() {
-            return nullSafe(CLIENT::closeAll);
+            return nullSafe(client::closeAll);
         }
 
         @Override
         public boolean closeScope(String id) {
-            return nullSafe(() -> CLIENT.closeScope(id));
+            return nullSafe(() -> client.closeScope(id));
         }
 
         @Override
         public List<String> getResolvableProperties() {
-            return nullSafe(CLIENT::getResolvableProperties);
+            return nullSafe(client::getResolvableProperties);
         }
 
     }

--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
@@ -92,7 +92,7 @@ public class TestResourcesPropertiesFactory implements TestPropertyProviderFacto
                                 private final Object value = properties.get(e);
                             })
                             .filter(o -> o.value != null)
-                            .collect(Collectors.toMap(e -> e.key, e-> e.value));
+                            .collect(Collectors.toMap(e -> e.key, e -> e.value));
                         return client.resolve(v, props, testResourcesConfig).orElse(null);
                     }
                 })

--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
@@ -82,7 +82,19 @@ public class TestResourcesPropertiesFactory implements TestPropertyProviderFacto
             Map<String, String> resolvedProperties = Stream.of(requestedProperties)
                 .map(v -> new Object() {
                     private final String key = v;
-                    private final String value = client.resolve(v, Map.of(), testResourcesConfig).orElse(null);
+                    private final String value = resolveProperty();
+
+                    private String resolveProperty() {
+                        var props = client.getRequiredProperties(v)
+                            .stream()
+                            .map(e -> new Object() {
+                                private final String key = e;
+                                private final Object value = properties.get(e);
+                            })
+                            .filter(o -> o.value != null)
+                            .collect(Collectors.toMap(e -> e.key, e-> e.value));
+                        return client.resolve(v, props, testResourcesConfig).orElse(null);
+                    }
                 })
                 .filter(o -> o.value != null)
                 .collect(Collectors.toMap(e -> e.key, e -> e.value));

--- a/test-resources-extensions/test-resources-extensions-core/src/test/java/io/micronaut/test/extensions/testresources/TestResourcesPropertyProvidersWithRequirementsTest.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/test/java/io/micronaut/test/extensions/testresources/TestResourcesPropertyProvidersWithRequirementsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.extensions.testresources;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.extensions.testresources.annotation.TestResourcesProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+@TestResourcesProperties(
+    value = "property-with-requirements",
+    providers = TestResourcesPropertyProvidersWithRequirementsTest.MyProvider.class
+)
+public class TestResourcesPropertyProvidersWithRequirementsTest {
+
+    @Value("${some-other-property}")
+    String derivedFromTestResources;
+
+    @Test
+    @DisplayName("properties can be computed from test resources when they have requirements")
+    public void canDerivePropertiesFromTestResources() {
+        assertEquals("supplied by test resources with requirements: 42 and transformed", derivedFromTestResources);
+    }
+
+    public static class MyProvider implements TestResourcesPropertyProvider {
+        @Override
+        public Map<String, String> provide(Map<String, Object> testProperties) {
+            String str = (String) testProperties.get("property-with-requirements");
+            return Map.of(
+                "some-other-property", str + " and transformed"
+            );
+        }
+    }
+
+}

--- a/test-resources-extensions/test-resources-extensions-core/src/test/resources/application-test.yml
+++ b/test-resources-extensions/test-resources-extensions-core/src/test/resources/application-test.yml
@@ -10,3 +10,4 @@ test-resources:
         log:
           regex: ".*Server is ready.*"
 toto: 40
+required-property: 42

--- a/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
@@ -26,7 +26,8 @@ public class FakeTestResourcesClient implements TestResourcesClient {
     private static final Map<String, String> MOCK_PROPERTIES = Map.of(
             "first-property", "first supplied by test resources",
             "second-property", "second supplied by test resources",
-            "some-property", "supplied by test resources"
+            "some-property", "supplied by test resources",
+            "property-with-requirements", "supplied by test resources with requirements"
     );
 
     @Override
@@ -36,11 +37,22 @@ public class FakeTestResourcesClient implements TestResourcesClient {
 
     @Override
     public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-        return Optional.ofNullable(MOCK_PROPERTIES.get(name));
+        var value = MOCK_PROPERTIES.get(name);
+        if ("property-with-requirements".equals(name)) {
+            if (!properties.containsKey("required-property")) {
+                return Optional.empty();
+            } else {
+                value += ": " + properties.get("required-property");
+            }
+        }
+        return Optional.ofNullable(value);
     }
 
     @Override
     public List<String> getRequiredProperties(String expression) {
+        if ("property-with-requirements".equals(expression)) {
+            return List.of("required-property");
+        }
         return List.of();
     }
 


### PR DESCRIPTION
If a type was annotated with `@TestResourcesProperties` and requested a value like `datasources.default.url`, which itself requires other properties to be resolved (e.g `datasources.default.db-type`), then the required properties were not passed to the resolver, which led to the inability to read these values from test resources.

Fixes #552