### PR TITLE
Update description for jdbc settings

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -11,5 +11,6 @@ https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html[MySQL X 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
 - `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
-- `datasources.*.driverClassName`: the class name of the driver (fallback)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
+
+`datasources.*.driverClassName` should be empty because JDBC driver from testcontainers has to be used for working with URI like 'jdcb:tc:postgres:14///db'


### PR DESCRIPTION
Having `driverClassName` set causes error `Message: Driver org.postgresql.Driver claims to not accept jdbcUrl, jdbc:tc:postgresql:14:///postgres`

For example this config has worked before in 4.1.0:
```
datasources:
  default:
    driverClassName: 'org.postgresql.Driver'
    db-type: "postgresql"
```
And now this doesn't work in 4.4.2 because of specified driver className. Removing this property fixes error.