### PR TITLE
Fix NPE when client is on classpath but not configured

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/NoOpClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/NoOpClient.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.client;
+
+import io.micronaut.core.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class NoOpClient implements TestResourcesClient {
+    static final TestResourcesClient INSTANCE = new NoOpClient();
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries,
+                                                Map<String, Object> testResourcesConfig) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<String> resolve(String name, Map<String, Object> properties,
+                                    Map<String, Object> testResourcesConfig) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> getRequiredProperties(String expression) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean closeAll() {
+        return true;
+    }
+
+    @Override
+    public boolean closeScope(@Nullable String id) {
+        return true;
+    }
+}

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClient.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  * server.
  */
 public interface TestResourcesClient extends TestResourcesResolver {
+    String ENABLED = "enabled";
     String SERVER_URI = "server.uri";
     String ACCESS_TOKEN = "server.access.token";
     String CLIENT_READ_TIMEOUT = "server.client.read.timeout";

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -92,6 +92,10 @@ public final class TestResourcesClientFactory {
             } catch (IOException e) {
                 throw new TestResourcesException(e);
             }
+            String enabled = props.getProperty(TestResourcesClient.ENABLED);
+            if (enabled != null && !Boolean.parseBoolean(enabled)) {
+                return Optional.of(NoOpClient.INSTANCE);
+            }
             String serverUri = props.getProperty(TestResourcesClient.SERVER_URI);
             String accessToken = props.getProperty(TestResourcesClient.ACCESS_TOKEN);
             int clientReadTimeout = Integer.parseInt(props.getProperty(TestResourcesClient.CLIENT_READ_TIMEOUT, DEFAULT_TIMEOUT_SECONDS));
@@ -109,6 +113,11 @@ public final class TestResourcesClientFactory {
         var client = cachedClient != null ? cachedClient.get() : null;
         if (client != null) {
             return Optional.of(client);
+        }
+        boolean enabled = Boolean.parseBoolean(System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.ENABLED), "true"));
+        if (!enabled) {
+            System.err.println("Test resources are disabled");
+            return Optional.of(NoOpClient.INSTANCE);
         }
         String serverUri = System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.SERVER_URI));
         if (serverUri != null) {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -17,7 +17,6 @@ package io.micronaut.testresources.client;
 
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertyExpressionResolver;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.testresources.core.LazyTestResourcesExpressionResolver;
@@ -25,9 +24,6 @@ import io.micronaut.testresources.core.TestResourcesResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,40 +44,6 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
 
     private static TestResourcesClient createClient(Environment env) {
         return TestResourcesClientFactory.findByConvention().orElse(NoOpClient.INSTANCE);
-    }
-
-    private static class NoOpClient implements TestResourcesClient {
-        static final TestResourcesClient INSTANCE = new NoOpClient();
-
-        @Override
-        public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<String> getRequiredProperties(String expression) {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public List<String> getRequiredPropertyEntries() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public boolean closeAll() {
-            return true;
-        }
-
-        @Override
-        public boolean closeScope(@Nullable String id) {
-            return true;
-        }
     }
 
     private static class DelegateResolver implements PropertyExpressionResolver, AutoCloseable {

--- a/test-resources-extensions/test-resources-extensions-core/build.gradle
+++ b/test-resources-extensions/test-resources-extensions-core/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(mn.micronaut.context)
     testRuntimeOnly(mn.snakeyaml)
+    testRuntimeOnly(mnSerde.micronaut.serde.jackson)
 }

--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesClientHolder.java
@@ -50,46 +50,46 @@ public final class TestResourcesClientHolder {
 
     private static class LazyTestResourcesClient implements TestResourcesClient {
 
-        private static <T> T nullSafe(Supplier<T> value) {
+        private static <T> T nullSafe(Supplier<T> value, T defaultValue) {
             if (client == null) {
-                return null;
+                return defaultValue;
             }
             return value.get();
         }
 
         @Override
         public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-            return nullSafe(client::getResolvableProperties);
+            return nullSafe(client::getResolvableProperties, List.of());
         }
 
         @Override
         public Optional<String> resolve(String name, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
-            return nullSafe(() -> client.resolve(name, properties, testResourcesConfig));
+            return nullSafe(() -> client.resolve(name, properties, testResourcesConfig), Optional.empty());
         }
 
         @Override
         public List<String> getRequiredProperties(String expression) {
-            return nullSafe(() -> client.getRequiredProperties(expression));
+            return nullSafe(() -> client.getRequiredProperties(expression), List.of());
         }
 
         @Override
         public List<String> getRequiredPropertyEntries() {
-            return nullSafe(client::getRequiredPropertyEntries);
+            return nullSafe(client::getRequiredPropertyEntries, List.of());
         }
 
         @Override
         public boolean closeAll() {
-            return nullSafe(client::closeAll);
+            return nullSafe(client::closeAll, true);
         }
 
         @Override
         public boolean closeScope(String id) {
-            return nullSafe(() -> client.closeScope(id));
+            return nullSafe(() -> client.closeScope(id), true);
         }
 
         @Override
         public List<String> getResolvableProperties() {
-            return nullSafe(client::getResolvableProperties);
+            return nullSafe(client::getResolvableProperties, List.of());
         }
 
     }

--- a/test-resources-extensions/test-resources-extensions-junit-platform/build.gradle
+++ b/test-resources-extensions/test-resources-extensions-junit-platform/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(mn.micronaut.context)
     testRuntimeOnly(mn.snakeyaml)
+    testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     kspKoTest(mn.micronaut.inject.kotlin)
 }
 


### PR DESCRIPTION
Because of user errors (for example explicitly adding the test resources client even if disabled) or simply because the test resources extensions have the client as a transitive dependency, it is possible to have the test resources client present on classpath even if test resources are disabled. In that case, the client wouldn't be configurable.

This commit fixes what the client returns in case there's no test resources service configured, by returning reasonable defaults instead of null.

Fixes #651