### PR TITLE
Fix test resources properties factory

### DIFF
--- a/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/main/java/io/micronaut/test/extensions/testresources/TestResourcesPropertiesFactory.java
@@ -78,7 +78,7 @@ public class TestResourcesPropertiesFactory implements TestPropertyProviderFacto
             var testResourcesConfig = properties.entrySet()
                 .stream()
                 .filter(e -> e.getKey().startsWith(TEST_RESOURCES_PROPERTY_PREFIX))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(e -> e.getKey().substring(TEST_RESOURCES_PROPERTY_PREFIX.length()), Map.Entry::getValue));
             Map<String, String> resolvedProperties = Stream.of(requestedProperties)
                 .map(v -> new Object() {
                     private final String key = v;

--- a/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
+++ b/test-resources-extensions/test-resources-extensions-core/src/testFixtures/java/io/micronaut/test/extensions/testresources/FakeTestResourcesClient.java
@@ -45,6 +45,13 @@ public class FakeTestResourcesClient implements TestResourcesClient {
                 value += ": " + properties.get("required-property");
             }
         }
+        testResourcesConfig.
+            keySet()
+            .forEach(k -> {
+                if (k.startsWith("test-resources.")) {
+                    throw new AssertionError("Test resources properties must be passed without the prefix \"test-resources.\"");
+                }
+            });
         return Optional.ofNullable(value);
     }
 


### PR DESCRIPTION
This commit fixes the `TestResourcesPropertiesFactory`, which incorrectly passed the `testResourcesConfig` map. Instead of removing the `test-resources.` prefix, like the client expects, it was passing the full property name which led to resolvers being unable to resolve properties.

While this commit fixes the problem at the source, in the properties factory, a sanity cleanup has been introduced in the controller, in order to cleanup such entries in case they show up. This could be useful if a program uses the client directly but forgets to do the same (in the "normal" use case, the properties are passed "naturally" without the prefix because that's how the config API works).

Fixes #663

(Note to the reviewer: this only concerns users of the test resources JUnit extensions)