### PR TITLE
Fix integration with Micronaut Control Panel

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.server-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.server-module.gradle
@@ -58,6 +58,22 @@ afterEvaluate {
     }
 }
 
+def writeDependenciesList = tasks.register("writeDependenciesList", io.micronaut.internal.GenerateModuleList) {
+    dependencies = configurations.runtimeClasspath.incoming.artifacts.resolvedArtifacts.map {
+        it.id
+    }
+    outputDirectory = layout.buildDirectory.file("dependencies")
+    fileName = "dependency-list.txt"
+}
+
+configurations {
+    embeddedDependencies {
+        canBeResolved = false
+        canBeConsumed = true
+        outgoing.artifact(writeDependenciesList)
+    }
+}
+
 static void prepareAttributesForPublication(Configuration src, Configuration dest) {
     dest.attributes { attrs ->
         src.attributes.keySet().each { k ->

--- a/buildSrc/src/main/groovy/io/micronaut/internal/GenerateModuleList.java
+++ b/buildSrc/src/main/groovy/io/micronaut/internal/GenerateModuleList.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.internal;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+@CacheableTask
+public abstract class GenerateModuleList extends DefaultTask {
+    @Input
+    public abstract SetProperty<ComponentArtifactIdentifier> getDependencies();
+
+    @Input
+    public abstract Property<String> getFileName();
+
+    @OutputDirectory
+    public abstract RegularFileProperty getOutputDirectory();
+
+    @TaskAction
+    public void writeDependencyList() throws IOException {
+        try (var writer = Files.newBufferedWriter(getOutputDirectory().get().getAsFile().toPath().resolve(getFileName().get()))) {
+            var ids = getDependencies()
+                .get()
+                .stream()
+                .map(ComponentArtifactIdentifier::getComponentIdentifier)
+                .filter(ModuleComponentIdentifier.class::isInstance)
+                .map(mi -> ((ModuleComponentIdentifier) mi).getModuleIdentifier().toString())
+                .sorted()
+                .toList();
+            for (String mi : ids) {
+                writer.write(mi);
+                writer.newLine();
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 
 [versions]
 micronaut = "4.6.5"
-micronaut-platform = "4.5.1"
+micronaut-platform = "4.6.2"
 micronaut-aot = "2.5.0"
 micronaut-aws = "4.7.1"
 micronaut-control-panel = "1.5.0"

--- a/test-resources-build-tools/build.gradle
+++ b/test-resources-build-tools/build.gradle
@@ -54,6 +54,13 @@ def writeModuleList = tasks.register("writeModuleList", WriteModuleList) {
 
 sourceSets.main.java.srcDirs(writeVersion, writeModuleList)
 
+configurations {
+    embeddedDependencies {
+        canBeResolved = true
+        canBeConsumed = false
+    }
+}
+
 dependencies {
     implementation(mnLogging.slf4j.api)
     testImplementation(platform(mn.micronaut.core.bom))
@@ -61,4 +68,7 @@ dependencies {
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(libs.spock)
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
+    embeddedDependencies(project(path: ":micronaut-test-resources-server", configuration: "embeddedDependencies"))
 }
+
+sourceSets.main.resources.srcDir(configurations.embeddedDependencies)

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ModuleIdentifier.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ModuleIdentifier.java
@@ -1,0 +1,12 @@
+package io.micronaut.testresources.buildtools;
+
+/**
+ * Represents a Maven artifact, without version.
+ * @param groupId the group id of the artifact
+ * @param artifactId the artifact id of the artifact
+ */
+public record ModuleIdentifier(
+    String groupId,
+    String artifactId
+) {
+}

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ModuleIdentifier.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ModuleIdentifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.testresources.buildtools;
 
 /**

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -48,7 +48,7 @@ micronaut {
     aot {
         version = libs.versions.micronaut.aot.get()
         cacheEnvironment.set(true)
-        optimizeServiceLoading.set(true)
+        optimizeServiceLoading.set(false)
         optimizeClassLoading.set(true)
         convertYamlToJava.set(false)
         precomputeOperations.set(true)


### PR DESCRIPTION
This commit provides a fix for the control panel not being loaded when using Micronaut 4.6. It turns out that this highlighted a deeper issue with classloading in test resources. In particular, there are a couple of problems:

1. the server module uses Micronaut AOT to optimize the binary. However, once the server is optimized, this prevents additional beans to be registered when using Micronaut 4.6+. Since the control panel module is an additional module, this wasn't loaded anymore, which is the root issue of this bug.
2. however, once the service loading optimization is disabled, another hidden issue surfaced: because the server uses a shaded jar in order to be able to use the Micronaut BOM independently in user applications, once the control panel module is added, we ended up with duplicate Micronaut classes on classpath.

Fixing 2 isn't trivial, since we need a single dependency graph on the server side. In order to avoid breaking changes, and to make sure that the solution works both for Maven and Gradle, this commit introduces a new utility in the `TestResourcesClasspath` class from the `build-tools` module, so that the Maven and Gradle plugins can filter out dependencies which are already packaged into the jar (e.g Micronaut Core, Micronaut Context, ...).
This fixes the loading of the control panel module, in a backwards compatible way. In addition, it should fix the issue for user-written custom modules too. However, this will not prevent modules which are written for an
incompatible version of Micronaut to break when loaded in the server.

Fixes #705

**Important** : the complete fix will require changes in both the Gradle and Maven plugins to use that new method for filtering the classpath.