### PR TITLE
Use lenient docker checks

### DIFF
--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/DockerSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/DockerSupport.java
@@ -77,7 +77,8 @@ public final class DockerSupport {
         LOCK.lock();
         try {
             available = AVAILABLE.get();
-            if (available != null) {
+            // Allow re-checking later in time
+            if (Boolean.TRUE.equals(available)) {
                 return available;
             }
             available = performDockerCheck();

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
@@ -126,7 +126,8 @@ public final class TestContainers {
                             LOGGER.info("Starting test container {}", name);
                             container.start();
                         } else {
-                            throw new TestResourcesResolutionException("Cannot start container " + name + " as Docker doesn't seem to be available");
+                            LOGGER.info("Trying to start container {} but it is likely to fail as Docker doesn't seem to be available", name);
+                            container.start();
                         }
                     } finally {
                         notifyEndOperation(STARTING, dockerImageName);


### PR DESCRIPTION
This commit changes how docker checks are done, so that if the docker environment is detected, then nothing changes, but if it is not, then we would still try to start a container, because it seems that in some cases, the docker environment is present but not properly detected, or detected too late. In this case, we will now display a warning, and let the docker check re-execute for the next container.