### PR TITLE
Prepare for 2.10.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           echo $GPG_FILE | base64 -d > secring.gpg
           # Publish both locally and to Sonatype.
           # The artifacts stored locally will be used to generate the SLSA provenance.
-          ./gradlew publishAllPublicationsToBuildRepository publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToMavenCentral --publishing-type=AUTOMATIC
           # Read the current version from gradle.properties.
           VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
           # Read the project group from gradle.properties.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.docs"
-    id "io.micronaut.build.internal.quality-reporting"
+    id "io.micronaut.build.internal.parent"
 }
 
 pluginManager.apply(io.micronaut.build.catalogs.MicronautVersionCatalogUpdatePlugin)

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.5.0'
+    id 'io.micronaut.build.shared.settings' version '7.6.2'
 }
 rootProject.name = 'testresources-parent'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.6.2'
+    id 'io.micronaut.build.shared.settings' version '7.6.3'
 }
 rootProject.name = 'testresources-parent'
 


### PR DESCRIPTION
This manually patches the workflow, as an experiment to use the new task available in build plugins 7.6.0 before we put it in the template.