### PR TITLE
Update Elasticsearch default tag to 9.2.1

### DIFF
--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -33,7 +33,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     public static final String ELASTICSEARCH_HOSTS = "elasticsearch.http-hosts";
     public static final String SIMPLE_NAME = "elasticsearch";
     public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
-    public static final String DEFAULT_TAG = "8.4.3";
+    public static final String DEFAULT_TAG = "9.2.1";
     public static final String DISPLAY_NAME = "Elasticsearch";
 
     @Override


### PR DESCRIPTION
Following: https://github.com/micronaut-projects/micronaut-elasticsearch/pull/665