### PR TITLE
Migrate off deprecated Testcontainer APIs (mostly)

### DIFF
--- a/src/main/docs/guide/modules-mongodb.adoc
+++ b/src/main/docs/guide/modules-mongodb.adoc
@@ -1,5 +1,7 @@
 MongoDB support will automatically start a https://www.mongodb.com[MongoDB container] and provide the value of the `mongodb.uri` property.
 
+The container is configured with replica set functionality enabled.
+
 The default image can be overwritten by setting the `test-resources.containers.mongodb.image-name` property.
 
 The default database name can be overwritten by setting the `test-resources.containers.mongodb.db-name` property.

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/src/main/java/io/micronaut/testresources/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mariadb/src/main/java/io/micronaut/testresources/hibernate/reactive/mariadb/HibernateReactiveMariaDBTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.hibernate.reactive.mariadb;
 
 import io.micronaut.testresources.hibernate.reactive.core.AbstractHibernateReactiveTestResourceProvider;
-import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.mariadb.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MariaDB test container.
  */
-public class HibernateReactiveMariaDBTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MariaDBContainer<?>> {
+public class HibernateReactiveMariaDBTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MariaDBContainer> {
     public static final String DISPLAY_NAME = "MariaDB (Hibernate reactive)";
 
     @Override
@@ -43,8 +43,8 @@ public class HibernateReactiveMariaDBTestResourceProvider extends AbstractHibern
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MariaDBContainer<>(imageName);
+    protected MariaDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new MariaDBContainer(imageName);
     }
 
 }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/src/main/java/io/micronaut/testresources/hibernate/reactive/mssql/HibernateReactiveMSSQLTestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mssql/src/main/java/io/micronaut/testresources/hibernate/reactive/mssql/HibernateReactiveMSSQLTestResourceProvider.java
@@ -17,7 +17,7 @@ package io.micronaut.testresources.hibernate.reactive.mssql;
 
 import io.micronaut.testresources.hibernate.reactive.core.AbstractHibernateReactiveTestResourceProvider;
 import io.micronaut.testresources.mssql.MSSQLTestResourceProvider;
-import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -27,7 +27,7 @@ import static io.micronaut.testresources.mssql.MSSQLTestResourceProvider.createM
 /**
  * A test resource provider which will spawn a MSSQL test container.
  */
-public class HibernateReactiveMSSQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MSSQLServerContainer<?>> {
+public class HibernateReactiveMSSQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MSSQLServerContainer> {
     public static final String DISPLAY_NAME = "MSSQL (Hibernate reactive)";
 
     @Override
@@ -46,7 +46,7 @@ public class HibernateReactiveMSSQLTestResourceProvider extends AbstractHibernat
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+    protected MSSQLServerContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return createMSSQLContainer(imageName, getSimpleName(), testResourcesConfig);
     }
 

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/src/main/java/io/micronaut/testresources/hibernate/reactive/mysql/HibernateReactiveMySQLTestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-mysql/src/main/java/io/micronaut/testresources/hibernate/reactive/mysql/HibernateReactiveMySQLTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.hibernate.reactive.mysql;
 
 import io.micronaut.testresources.hibernate.reactive.core.AbstractHibernateReactiveTestResourceProvider;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MySQL test container.
  */
-public class HibernateReactiveMySQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MySQLContainer<?>> {
+public class HibernateReactiveMySQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<MySQLContainer> {
     public static final String DISPLAY_NAME = "MySQL (Hibernate reactive)";
 
     @Override
@@ -43,8 +43,8 @@ public class HibernateReactiveMySQLTestResourceProvider extends AbstractHibernat
     }
 
     @Override
-    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MySQLContainer<>(imageName);
+    protected MySQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new MySQLContainer(imageName);
     }
 
 }

--- a/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/src/main/java/io/micronaut/testresources/hibernate/reactive/postgresql/HibernateReactivePostgreSQLTestResourceProvider.java
+++ b/test-resources-hibernate-reactive/test-resources-hibernate-reactive-postgresql/src/main/java/io/micronaut/testresources/hibernate/reactive/postgresql/HibernateReactivePostgreSQLTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.hibernate.reactive.postgresql;
 
 import io.micronaut.testresources.hibernate.reactive.core.AbstractHibernateReactiveTestResourceProvider;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a PostgreSQL test container.
  */
-public class HibernateReactivePostgreSQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<PostgreSQLContainer<?>> {
+public class HibernateReactivePostgreSQLTestResourceProvider extends AbstractHibernateReactiveTestResourceProvider<PostgreSQLContainer> {
     public static final String DISPLAY_NAME = "PostgreSQL (Hibernate reactive)";
 
     @Override
@@ -43,8 +43,8 @@ public class HibernateReactivePostgreSQLTestResourceProvider extends AbstractHib
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new PostgreSQLContainer<>(imageName);
+    protected PostgreSQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new PostgreSQLContainer(imageName);
     }
 
 }

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.mariadb;
 
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
-import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.mariadb.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MariaDB test container.
  */
-public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvider<MariaDBContainer<?>> {
+public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvider<MariaDBContainer> {
     public static final String DISPLAY_NAME = "MariaDB";
 
     @Override
@@ -43,8 +43,8 @@ public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvide
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MariaDBContainer<>(imageName);
+    protected MariaDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new MariaDBContainer(imageName);
     }
 
 }

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/main/java/io/micronaut/testresources/mssql/MSSQLTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.mssql;
 
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
-import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LicenseAcceptance;
 
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MS SQL test container.
  */
-public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MSSQLServerContainer<?>> {
+public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MSSQLServerContainer> {
 
     public static final String DEFAULT_IMAGE_NAME = "mcr.microsoft.com/mssql/server:2022-latest";
     public static final String DISPLAY_NAME = "MSSQL";
@@ -46,12 +46,12 @@ public class MSSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+    protected MSSQLServerContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return createMSSQLContainer(imageName, getSimpleName(), testResourcesConfig);
     }
 
-    public static MSSQLServerContainer<?> createMSSQLContainer(DockerImageName imageName, String simpleName, Map<String, Object> testResourcesConfig) {
-        MSSQLServerContainer<?> container = new MSSQLServerContainer<>(imageName);
+    public static MSSQLServerContainer createMSSQLContainer(DockerImageName imageName, String simpleName, Map<String, Object> testResourcesConfig) {
+        MSSQLServerContainer container = new MSSQLServerContainer(imageName);
         String licenseKey = "containers." + simpleName + ".accept-license";
         if (shouldAcceptLicense(licenseKey, testResourcesConfig)) {
             container.acceptLicense();

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -17,7 +17,7 @@ package io.micronaut.testresources.mysql;
 
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MySQL test container.
  */
-public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MySQLContainer<?>> {
+public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<MySQLContainer> {
     public static final String DISPLAY_NAME = "MySQL";
     public static final String MYSQL_OFFICIAL_IMAGE = "container-registry.oracle.com/mysql/community-server";
     public static final String DOCKER_OFFICIAL_IMAGE = "mysql";
@@ -53,16 +53,16 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
-    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+    protected MySQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         // Testcontainers uses by default the Docker Hub official image, so the MySQL official image needs to be set as compatible substitute
         if (imageName.asCanonicalNameString().startsWith(MYSQL_OFFICIAL_IMAGE)) {
             imageName = imageName.asCompatibleSubstituteFor(DOCKER_OFFICIAL_IMAGE);
         }
-        return new MySQLContainer<>(imageName);
+        return new MySQLContainer(imageName);
     }
 
     @Override
-    protected void configureContainer(MySQLContainer<?> container, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+    protected void configureContainer(MySQLContainer container, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
         container.withExposedPorts(MySQLContainer.MYSQL_PORT, DEFAULT_X_PROTOCOL_PORT);
     }
 

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.postgres;
 
 import io.micronaut.testresources.jdbc.AbstractJdbcTestResourceProvider;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Arrays;
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * A test resource provider which will spawn a MySQL test container.
  */
-public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<PostgreSQLContainer<?>> {
+public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProvider<PostgreSQLContainer> {
     private static final List<String> SUPPORTED_DB_TYPES = Collections.unmodifiableList(
         Arrays.asList("postgresql", "postgres", "pg")
     );
@@ -54,8 +54,8 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new PostgreSQLContainer<>(imageName);
+    protected PostgreSQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new PostgreSQLContainer(imageName);
     }
 
 }

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -75,7 +75,7 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
         if (configuredDbName != null) {
             this.dbName = configuredDbName.toString();
         }
-        return new MongoDBContainer(imageName);
+        return new MongoDBContainer(imageName).withReplicaSet();
     }
 
     @Override

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.mongodb;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
-import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.mongodb.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collection;

--- a/test-resources-neo4j/src/main/java/io/micronaut/testresources/neo4j/Neo4jTestResourceProvider.java
+++ b/test-resources-neo4j/src/main/java/io/micronaut/testresources/neo4j/Neo4jTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.neo4j;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
-import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.neo4j.Neo4jContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collection;
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * A test resource provider which will spawn a MongoDB test container.
  */
-public class Neo4jTestResourceProvider extends AbstractTestContainersProvider<Neo4jContainer<?>> {
+public class Neo4jTestResourceProvider extends AbstractTestContainersProvider<Neo4jContainer> {
 
     public static final String NEO4J_SERVER_URI = "neo4j.uri";
     public static final String DEFAULT_IMAGE = "neo4j";
@@ -65,14 +65,14 @@ public class Neo4jTestResourceProvider extends AbstractTestContainersProvider<Ne
     }
 
     @Override
-    protected Neo4jContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        Neo4jContainer<?> container = new Neo4jContainer<>(imageName);
+    protected Neo4jContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        Neo4jContainer container = new Neo4jContainer(imageName);
         container.withoutAuthentication();
         return container;
     }
 
     @Override
-    protected Optional<String> resolveProperty(String propertyName, Neo4jContainer<?> container) {
+    protected Optional<String> resolveProperty(String propertyName, Neo4jContainer container) {
         if (NEO4J_SERVER_URI.equals(propertyName)) {
             return Optional.of(container.getBoltUrl());
         }

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
@@ -18,8 +18,8 @@ package io.micronaut.testresources.r2dbc.mariadb;
 import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MariaDBContainer;
-import org.testcontainers.containers.MariaDBR2DBCDatabaseContainer;
+import org.testcontainers.mariadb.MariaDBContainer;
+import org.testcontainers.mariadb.MariaDBR2DBCDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * A test resource provider for reactive MariaDB.
  */
-public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceProvider<MariaDBContainer<?>> {
+public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceProvider<MariaDBContainer> {
     public static final String DISPLAY_NAME = "MariaDB (R2DBC)";
 
     @Override
@@ -49,14 +49,14 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
     @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof MariaDBContainer) {
-            return Optional.of(MariaDBR2DBCDatabaseContainer.getOptions((MariaDBContainer<?>) container));
+            return Optional.of(MariaDBR2DBCDatabaseContainer.getOptions((MariaDBContainer) container));
         }
         return Optional.empty();
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MariaDBContainer<>(imageName);
+    protected MariaDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new MariaDBContainer(imageName);
     }
 
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/main/java/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProvider.java
@@ -19,8 +19,8 @@ import io.micronaut.testresources.mssql.MSSQLTestResourceProvider;
 import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MSSQLR2DBCDatabaseContainer;
-import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.mssqlserver.MSSQLR2DBCDatabaseContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -29,7 +29,7 @@ import java.util.Optional;
 /**
  * A test resource provider for reactive PostgreSQL.
  */
-public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<MSSQLServerContainer<?>> {
+public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<MSSQLServerContainer> {
 
     public static final String DISPLAY_NAME = "MSSQL (R2DBC)";
 
@@ -51,14 +51,14 @@ public class R2DBCMSSQLTestResourceProvider extends AbstractR2DBCTestResourcePro
     @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof MSSQLServerContainer) {
-            MSSQLServerContainer<?> mssql = (MSSQLServerContainer<?>) container;
+            MSSQLServerContainer mssql = (MSSQLServerContainer) container;
             return Optional.of(MSSQLR2DBCDatabaseContainer.getOptions(mssql));
         }
         return Optional.empty();
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+    protected MSSQLServerContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return MSSQLTestResourceProvider.createMSSQLContainer(imageName, getSimpleName(), testResourcesConfig);
     }
 

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
@@ -18,8 +18,8 @@ package io.micronaut.testresources.r2dbc.mysql;
 import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.containers.MySQLR2DBCDatabaseContainer;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.mysql.MySQLR2DBCDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * A test resource provider for reactive MySQL.
  */
-public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<MySQLContainer<?>> {
+public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<MySQLContainer> {
     public static final String DISPLAY_NAME = "MySQL (R2DBC)";
 
     @Override
@@ -49,14 +49,14 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
     @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof MySQLContainer) {
-            return Optional.of(MySQLR2DBCDatabaseContainer.getOptions((MySQLContainer<?>) container));
+            return Optional.of(MySQLR2DBCDatabaseContainer.getOptions((MySQLContainer) container));
         }
         return Optional.empty();
     }
 
     @Override
-    protected MySQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MySQLContainer<>(imageName);
+    protected MySQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new MySQLContainer(imageName);
     }
 
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -18,8 +18,8 @@ package io.micronaut.testresources.r2dbc.postgres;
 import io.micronaut.testresources.r2dbc.core.AbstractR2DBCTestResourceProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLR2DBCDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Arrays;
@@ -31,7 +31,7 @@ import java.util.Optional;
 /**
  * A test resource provider for reactive PostgreSQL.
  */
-public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<PostgreSQLContainer<?>> {
+public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResourceProvider<PostgreSQLContainer> {
     private static final List<String> SUPPORTED_DB_TYPES = Collections.unmodifiableList(
         Arrays.asList("postgresql", "postgres", "pg")
     );
@@ -60,14 +60,14 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
     @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof PostgreSQLContainer) {
-            return Optional.of(PostgreSQLR2DBCDatabaseContainer.getOptions((PostgreSQLContainer<?>) container));
+            return Optional.of(PostgreSQLR2DBCDatabaseContainer.getOptions((PostgreSQLContainer) container));
         }
         return Optional.empty();
     }
 
     @Override
-    protected PostgreSQLContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new PostgreSQLContainer<>(imageName);
+    protected PostgreSQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new PostgreSQLContainer(imageName);
     }
 
 }

--- a/test-resources-rabbitmq/src/main/java/io/micronaut/testresources/rabbitmq/RabbitMQTestResourceProvider.java
+++ b/test-resources-rabbitmq/src/main/java/io/micronaut/testresources/rabbitmq/RabbitMQTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.rabbitmq;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
-import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Arrays;

--- a/test-resources-solr/src/main/java/io/micronaut/testresources/solr/SolrTestResourceProvider.java
+++ b/test-resources-solr/src/main/java/io/micronaut/testresources/solr/SolrTestResourceProvider.java
@@ -16,7 +16,7 @@
 package io.micronaut.testresources.solr;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
-import org.testcontainers.containers.SolrContainer;
+import org.testcontainers.solr.SolrContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 


### PR DESCRIPTION
These APIs became deprecated with Testcontainers 2.0. The LocalStack resources were not migrated as part of this commit because they make use of an enum that is inside a deprecated class, and so the migration is non-trivial.