### PR TITLE
feat: add hazelcast test resources module

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -83,6 +83,7 @@ include 'test-resources-testcontainers'
 include 'test-resources-hashicorp-vault'
 include 'test-resources-hashicorp-consul'
 include 'test-resources-infinispan'
+include 'test-resources-hazelcast'
 
 extensionModules.each {
     String projectName = "test-resources-extensions-$it"

--- a/src/main/docs/guide/modules-hazelcast.adoc
+++ b/src/main/docs/guide/modules-hazelcast.adoc
@@ -1,0 +1,11 @@
+Hazelcast support
+
+Hazelcast support will automatically start a Hazelcast container and provide the values of the `hazelcast.client.network.addresses` property.
+
+The default image can be overwritten by setting the `test-resources.containers.hazelcast.image-name` property.
+The default version can be overwritten by setting the `test-resources.containers.hazelcast.image-tag` property.
+
+Resolved properties:
+
+[[hazelcast-client-network-addresses]]
+`hazelcast.client.network.addresses`:: The list of Hazelcast client addresses (host:port) to connect to.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -29,6 +29,8 @@ modules:
     title: RabbitMQ
   modules-redis:
     title: Redis
+  modules-hazelcast:
+    title: Hazelcast
   modules-hashicorp-vault:
     title: Hashicorp Vault
   modules-testcontainers:

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/TestResourcesClasspath.java
@@ -163,6 +163,7 @@ public final class TestResourcesClasspath implements KnownModules {
      * Tells if a dependency should be added to the server classpath. This is used
      * to avoid dependency conflicts between what is embedded in the server and what
      * additional modules can bring.
+     * @param id the module to test
      * @return the filtered dependencies
      */
     public static boolean isDependencyAllowedOnServerClasspath(ModuleIdentifier id) {

--- a/test-resources-hazelcast/build.gradle
+++ b/test-resources-hazelcast/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+}
+
+description = """
+Provides support for launching a Hazelcast test container.
+"""
+
+dependencies {
+    api(projects.micronautTestResourcesCore)
+    api(projects.micronautTestResourcesTestcontainers)
+
+    testImplementation(projects.micronautTestResourcesEmbedded)
+    testImplementation(testFixtures(projects.micronautTestResourcesTestcontainers))
+    testImplementation(mnCache.micronaut.cache.hazelcast)
+}

--- a/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
+++ b/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
@@ -25,6 +25,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Provides a TestContainers-based resource provider for Hazelcast, allowing integration tests
+ * to use Hazelcast instances within isolated environments.
+ *
+ * This class extends the AbstractTestContainersProvider, leveraging the capabilities of
+ * TestContainers to create and manage Hazelcast Docker containers. It resolves Hazelcast-related
+ * properties required by the application's integration tests.
+ */
 public class HazelcastTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
 
     public static final String HAZELCAST_ADDRESSES = "hazelcast.client.network.addresses";
@@ -65,7 +73,7 @@ public class HazelcastTestResourceProvider extends AbstractTestContainersProvide
     @Override
     protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
         if (HAZELCAST_ADDRESSES.equals(propertyName)) {
-            String address = "%s:%d".formatted(container.getHost(), container.getMappedPort(DEFAULT_PORT));
+            String address = container.getHost() + ":" + container.getMappedPort(DEFAULT_PORT));
             return Optional.of(address);
         }
         return Optional.empty();

--- a/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
+++ b/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
@@ -73,7 +73,7 @@ public class HazelcastTestResourceProvider extends AbstractTestContainersProvide
     @Override
     protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
         if (HAZELCAST_ADDRESSES.equals(propertyName)) {
-            String address = container.getHost() + ":" + container.getMappedPort(DEFAULT_PORT));
+            String address = container.getHost() + ":" + container.getMappedPort(DEFAULT_PORT);
             return Optional.of(address);
         }
         return Optional.empty();

--- a/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
+++ b/test-resources-hazelcast/src/main/java/io/micronaut/testresources/hazelcast/HazelcastTestResourceProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.hazelcast;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class HazelcastTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+
+    public static final String HAZELCAST_ADDRESSES = "hazelcast.client.network.addresses";
+    public static final String DEFAULT_IMAGE = "hazelcast/hazelcast:latest-slim";
+    public static final String DISPLAY_NAME = "Hazelcast";
+    public static final String SIMPLE_NAME = "hazelcast";
+    private static final int DEFAULT_PORT = 5701;
+
+    private static final List<String> SUPPORTED_PROPERTIES_LIST = List.of(HAZELCAST_ADDRESSES);
+    private static final Set<String> SUPPORTED_PROPERTIES = Set.of(HAZELCAST_ADDRESSES);
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return SUPPORTED_PROPERTIES_LIST;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return SIMPLE_NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new GenericContainer<>(imageName)
+            .withExposedPorts(DEFAULT_PORT);
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
+        if (HAZELCAST_ADDRESSES.equals(propertyName)) {
+            String address = "%s:%d".formatted(container.getHost(), container.getMappedPort(DEFAULT_PORT));
+            return Optional.of(address);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return SUPPORTED_PROPERTIES.contains(propertyName);
+    }
+}

--- a/test-resources-hazelcast/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-hazelcast/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.hazelcast.HazelcastTestResourceProvider

--- a/test-resources-hazelcast/src/test/groovy/io/micronaut/testresources/hazelcast/AbstractHazelcastSpec.groovy
+++ b/test-resources-hazelcast/src/test/groovy/io/micronaut/testresources/hazelcast/AbstractHazelcastSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testresources.hazelcast
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+
+abstract class AbstractHazelcastSpec extends AbstractTestContainersSpec {
+
+    @Override
+    String getScopeName() {
+        'hazelcast'
+    }
+}

--- a/test-resources-hazelcast/src/test/groovy/io/micronaut/testresources/hazelcast/HazelcastStartedTest.groovy
+++ b/test-resources-hazelcast/src/test/groovy/io/micronaut/testresources/hazelcast/HazelcastStartedTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.testresources.hazelcast
+
+import io.micronaut.cache.CacheManager
+import io.micronaut.context.annotation.Value
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+
+@MicronautTest
+class HazelcastStartedTest extends AbstractHazelcastSpec {
+
+    @Value('${hazelcast.client.network.addresses}')
+    List<String> addresses
+
+    @Inject
+    CacheManager<?> cacheManager
+
+    def "test hazelcast starts"() {
+        expect:
+        addresses != null
+        !addresses.isEmpty()
+        addresses[0].contains(':')
+
+        when:
+        cacheManager.getCache("my-cache").put("foo", "bar")
+
+        then:
+        cacheManager.getCache("my-cache").get("foo", String).get() == "bar"
+    }
+}

--- a/test-resources-hazelcast/src/test/resources/application-hazelcast.yml
+++ b/test-resources-hazelcast/src/test/resources/application-hazelcast.yml
@@ -1,0 +1,2 @@
+hazelcast:
+  client: {}

--- a/test-resources-hazelcast/src/test/resources/logback.xml
+++ b/test-resources-hazelcast/src/test/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="io.micronaut.testresources" level="debug" />
+    <logger name="com.hazelcast" level="debug" />
+
+</configuration>


### PR DESCRIPTION
## Summary
- add Hazelcast test resources module and resolver for hazelcast client addresses
- add Hazelcast module documentation
- fix a missing Javadoc param in build tools

## Testing
- ./gradlew -q :micronaut-test-resources-hazelcast:compileTestJava :micronaut-test-resources-hazelcast:compileTestGroovy
- ./gradlew :micronaut-test-resources-hazelcast:test --tests 'io.micronaut.testresources.hazelcast.HazelcastStartedTest'
- ./gradlew :micronaut-test-resources-hazelcast:test
- ./gradlew -q cM
- ./gradlew -q spotlessCheck
- ./gradlew -q :micronaut-test-resources-hazelcast:build