### PR TITLE
Change MongoDB to use the latest image.

### DIFF
--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,0 +1,2 @@
+=== Version 3.0.0
+MongoDB now defaults to using the latest image. Previously it used MongoDB 5.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,6 +1,7 @@
 introduction:
   title: Introduction
 releaseHistory: Release History
+breaks: Breaking Changes
 quickStart:
   title: Quick Start
 modules:

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -32,7 +32,7 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
 
     public static final String MONGODB_SERVERS = "mongodb.servers";
     public static final String MONGODB_SERVER_URI = "mongodb.uri";
-    public static final String DEFAULT_IMAGE = "mongo:5";
+    public static final String DEFAULT_IMAGE = "mongo:latest";
     public static final String SIMPLE_NAME = "mongodb";
     public static final String DB_NAME = "containers." + SIMPLE_NAME + ".db-name";
     public static final String DISPLAY_NAME = "MongoDB";


### PR DESCRIPTION
Previously it was using MongoDB 5, which is EOL. This more closely matches the behavior of other containers, which generally use a floating version.