### PR TITLE
Add H2 JDBC test resources support

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ def extensionModules = [
 
 def jdbcModules = [
         'core',
+        'h2',
         'mysql',
         'mariadb',
         'oracle-xe',

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -3,17 +3,21 @@ The following properties will automatically be set when using a JDBC database:
 - `datasources.*.url`
 - `datasources.*.username`
 - `datasources.*.password`
-- `datasources.*.dialect`
+- `datasources.*.driver-class-name`
 
 Additionally, the MySQL resolver will automatically set the property `datasources.*.x-protocol-url` to be used with the
 https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html[MySQL X DevAPI].
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
+- `datasources.*.db-type`: the kind of database (preferred, one of `h2`, `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 
-`datasources.*.driverClassName` should be empty because JDBC driver from testcontainers has to be used for working with URI like 'jdcb:tc:postgres:14///db'
+Most JDBC databases are started via Testcontainers, so `datasources.*.driver-class-name` should usually be left empty because the JDBC driver from Testcontainers has to be used for URIs like `jdbc:tc:postgres:14:///db`.
+H2 is the exception: it is supported in JDBC mode only, starts a containerless loopback-only in-memory TCP server, and automatically resolves `org.h2.Driver`.
+Shared or remote H2 test resources are not supported at this time, so the H2 resolver stays disabled when `micronaut.test.resources.server.uri` is configured.
+
+H2 support in this module is currently limited to JDBC test resources. R2DBC and Hibernate Reactive H2 support are out of scope for this feature.
 
 Micronaut Test Resources can also generate an IntelliJ IDEA/DataGrip datasource export file for resolved JDBC datasources.
 The export is opt-in and disabled by default.

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -6,6 +6,7 @@ Micronaut Test Resources provides support for the following databases:
 |===
 |Database | JDBC | R2DBC | Database identifier | Default image
 
+| https://www.h2database.com/html/main.html[H2] | Yes | No | `h2` | n/a
 | https://mariadb.org/[MariaDB] | Yes | Yes | `mariadb` | `mariadb`
 | https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `container-registry.oracle.com/mysql/community-server`
 | https://www.oracle.com/database/technologies/appdev/xe.html[Oracle Database XE] | Yes | Yes | `oracle-xe` | `gvenzl/oracle-xe:slim-faststart`
@@ -15,7 +16,9 @@ Micronaut Test Resources provides support for the following databases:
 
 |===
 
-Databases are supplied via a https://www.testcontainers.com/[Testcontainers] container.
+Most databases are supplied via a https://www.testcontainers.com/[Testcontainers] container.
+H2 is containerless and starts a loopback-only in-memory TCP server for the lifetime of the test-resources process.
+Shared or remote H2 test resources are not supported at this time, so the H2 resolver stays disabled when `micronaut.test.resources.server.uri` is configured.
 It is possible to override the default image of the container by setting the following property in your application configuration:
 
 - `test-resources.containers.[db-type].image-name`

--- a/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'io.micronaut.build.internal.test-resources-module'
+    id 'io.micronaut.build.internal.database-testing'
+}
+
+description = """
+Provides support for H2 JDBC test resources.
+"""
+
+dependencies {
+    api(project(':micronaut-test-resources-core'))
+
+    implementation(mnSql.h2)
+
+    testCompileOnly(mnData.micronaut.data.processor)
+    testImplementation(project(":micronaut-test-resources-embedded"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-jdbc-core")))
+    testRuntimeOnly(mnSql.micronaut.jdbc.hikari)
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
@@ -17,3 +17,7 @@ dependencies {
     testImplementation(testFixtures(project(":micronaut-test-resources-jdbc-core")))
     testRuntimeOnly(mnSql.micronaut.jdbc.hikari)
 }
+
+extensions.configure(org.sonatype.gradle.plugins.scan.ossindex.OssIndexPluginExtension) { extension ->
+    extension.excludeVulnerabilityIds = ["CVE-2018-14335"] as Set
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
+++ b/test-resources-jdbc/test-resources-jdbc-h2/build.gradle
@@ -19,5 +19,7 @@ dependencies {
 }
 
 extensions.configure(org.sonatype.gradle.plugins.scan.ossindex.OssIndexPluginExtension) { extension ->
+    // OSS Index still reports this CVE for H2, but the current dependency resolves to 2.4.240
+    // and the published vulnerable range only covers older releases.
     extension.excludeVulnerabilityIds = ["CVE-2018-14335"] as Set
 }

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
@@ -22,14 +22,17 @@ import org.h2.tools.Server;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.BindException;
 import java.net.ServerSocket;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -52,9 +55,12 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
     private static final String DEFAULT_PASSWORD = "";
     private static final String DEFAULT_DRIVER = "org.h2.Driver";
     private static final String JDBC_OPTIONS = "DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE";
+    private static final int MAX_START_ATTEMPTS = 10;
     private static final List<String> SUPPORTED_PROPERTIES = List.of(URL, USERNAME, PASSWORD, DRIVER);
 
-    private final Map<Key, H2Server> servers = new ConcurrentHashMap<>();
+    private final Object lifecycleMonitor = new Object();
+    private final Map<Scope, H2Server> servers = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     @Override
     public String getDisplayName() {
@@ -99,7 +105,7 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
         }
         String datasource = datasourceNameFrom(propertyName);
         return Optional.ofNullable(switch (datasourcePropertyFrom(propertyName)) {
-            case URL -> server(properties, datasource).getJdbcUrl();
+            case URL -> server(properties).getJdbcUrl(datasource);
             case USERNAME -> DEFAULT_USERNAME;
             case PASSWORD -> DEFAULT_PASSWORD;
             case DRIVER -> DEFAULT_DRIVER;
@@ -109,8 +115,16 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
 
     @Override
     public void close() throws IOException {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        List<H2Server> activeServers;
+        synchronized (lifecycleMonitor) {
+            activeServers = List.copyOf(servers.values());
+            servers.clear();
+        }
         IOException failure = null;
-        for (H2Server server : servers.values()) {
+        for (H2Server server : activeServers) {
             try {
                 server.close();
             } catch (IOException e) {
@@ -121,7 +135,6 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
                 }
             }
         }
-        servers.clear();
         if (failure != null) {
             throw failure;
         }
@@ -129,13 +142,6 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
 
     int serverCount() {
         return servers.size();
-    }
-
-    private H2Server server(Map<String, Object> properties, String datasource) {
-        return servers.computeIfAbsent(
-            new Key(Scope.from(properties), datasource),
-            key -> H2Server.start(datasource)
-        );
     }
 
     private static boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties) {
@@ -184,34 +190,43 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
         return PREFIX + "." + datasource + "." + property;
     }
 
-    private record Key(Scope scope, String datasource) {
+    private H2Server server(Map<String, Object> properties) {
+        synchronized (lifecycleMonitor) {
+            if (closed.get()) {
+                throw new IllegalStateException("H2 test resource provider is closed");
+            }
+            return servers.computeIfAbsent(
+                Scope.from(properties),
+                ignored -> H2Server.start()
+            );
+        }
     }
 
     private static final class H2Server implements Closeable {
-        private final String databaseName;
         private final Server server;
+        private final Map<String, String> databaseNames = new ConcurrentHashMap<>();
 
-        private H2Server(String databaseName, Server server) {
-            this.databaseName = databaseName;
+        private H2Server(Server server) {
             this.server = server;
         }
 
-        private static H2Server start(String datasource) {
-            String databaseName = datasource + "_" + UUID.randomUUID().toString().replace("-", "");
-            int port = findAvailablePort();
-            try {
-                Server server = Server.createTcpServer(
-                    "-tcp",
-                    "-tcpPort", Integer.toString(port),
-                    "-ifNotExists"
-                ).start();
-                return new H2Server(databaseName, server);
-            } catch (SQLException e) {
-                throw new IllegalStateException("Unable to start H2 TCP server", e);
+        private static H2Server start() {
+            SQLException failure = null;
+            for (int attempt = 0; attempt < MAX_START_ATTEMPTS; attempt++) {
+                try {
+                    return new H2Server(startServer());
+                } catch (SQLException e) {
+                    if (!isBindFailure(e) || attempt == MAX_START_ATTEMPTS - 1) {
+                        throw new IllegalStateException("Unable to start H2 TCP server", e);
+                    }
+                    failure = e;
+                }
             }
+            throw new IllegalStateException("Unable to start H2 TCP server", failure);
         }
 
-        private String getJdbcUrl() {
+        private String getJdbcUrl(String datasource) {
+            String databaseName = databaseNames.computeIfAbsent(datasource, H2Server::newDatabaseName);
             return "jdbc:h2:tcp://%s:%d/mem:%s;%s".formatted(DEFAULT_HOST, server.getPort(), databaseName, JDBC_OPTIONS);
         }
 
@@ -222,6 +237,31 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
             } catch (RuntimeException e) {
                 throw new IOException("Unable to stop H2 TCP server", e);
             }
+        }
+
+        private static Server startServer() throws SQLException {
+            int port = findAvailablePort();
+            return Server.createTcpServer(
+                "-tcp",
+                "-tcpPort", Integer.toString(port),
+                "-ifNotExists"
+            ).start();
+        }
+
+        private static boolean isBindFailure(SQLException e) {
+            Throwable current = e;
+            while (current != null) {
+                if (current instanceof BindException) {
+                    return true;
+                }
+                current = current.getCause();
+            }
+            String message = e.getMessage();
+            return message != null && message.toLowerCase(Locale.ROOT).contains("already in use");
+        }
+
+        private static String newDatabaseName(String datasource) {
+            return datasource + "_" + UUID.randomUUID().toString().replace("-", "");
         }
 
         private static int findAvailablePort() {

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
@@ -17,12 +17,14 @@ package io.micronaut.testresources.h2;
 
 import io.micronaut.testresources.core.Scope;
 import io.micronaut.testresources.core.ToggableTestResourcesResolver;
+import org.h2.engine.SysProperties;
 import org.h2.tools.Server;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.BindException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -55,8 +57,11 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
     private static final String DEFAULT_PASSWORD = "";
     private static final String DEFAULT_DRIVER = "org.h2.Driver";
     private static final String JDBC_OPTIONS = "DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE";
+    private static final String BIND_ADDRESS_PROPERTY = "h2.bindAddress";
+    private static final String LOOPBACK_HOST = InetAddress.getLoopbackAddress().getHostAddress();
     private static final int MAX_START_ATTEMPTS = 10;
     private static final List<String> SUPPORTED_PROPERTIES = List.of(URL, USERNAME, PASSWORD, DRIVER);
+    private static final Object H2_SYSTEM_PROPERTIES_MONITOR = new Object();
 
     private final Object lifecycleMonitor = new Object();
     private final Map<Scope, H2Server> servers = new ConcurrentHashMap<>();
@@ -241,11 +246,20 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
 
         private static Server startServer() throws SQLException {
             int port = findAvailablePort();
-            return Server.createTcpServer(
-                "-tcp",
-                "-tcpPort", Integer.toString(port),
-                "-ifNotExists"
-            ).start();
+            synchronized (H2_SYSTEM_PROPERTIES_MONITOR) {
+                String previousBindAddress = System.getProperty(BIND_ADDRESS_PROPERTY);
+                System.setProperty(BIND_ADDRESS_PROPERTY, LOOPBACK_HOST);
+                try {
+                    verifyLoopbackBinding();
+                    return Server.createTcpServer(
+                        "-tcp",
+                        "-tcpPort", Integer.toString(port),
+                        "-ifNotExists"
+                    ).start();
+                } finally {
+                    restoreBindAddress(previousBindAddress);
+                }
+            }
         }
 
         private static boolean isBindFailure(SQLException e) {
@@ -262,6 +276,28 @@ public final class H2TestResourceProvider implements ToggableTestResourcesResolv
 
         private static String newDatabaseName(String datasource) {
             return datasource + "_" + UUID.randomUUID().toString().replace("-", "");
+        }
+
+        private static void verifyLoopbackBinding() throws SQLException {
+            String bindAddress = SysProperties.BIND_ADDRESS;
+            if (bindAddress == null || bindAddress.isBlank()) {
+                throw new SQLException("Unable to enforce a loopback-only H2 bind address");
+            }
+            try {
+                if (!InetAddress.getByName(bindAddress).isLoopbackAddress()) {
+                    throw new SQLException("Unable to enforce a loopback-only H2 bind address");
+                }
+            } catch (IOException e) {
+                throw new SQLException("Unable to enforce a loopback-only H2 bind address", e);
+            }
+        }
+
+        private static void restoreBindAddress(String previousBindAddress) {
+            if (previousBindAddress == null) {
+                System.clearProperty(BIND_ADDRESS_PROPERTY);
+            } else {
+                System.setProperty(BIND_ADDRESS_PROPERTY, previousBindAddress);
+            }
         }
 
         private static int findAvailablePort() {

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/main/java/io/micronaut/testresources/h2/H2TestResourceProvider.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.h2;
+
+import io.micronaut.testresources.core.Scope;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
+import org.h2.tools.Server;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * A test resource provider which starts a containerless H2 TCP server.
+ */
+public final class H2TestResourceProvider implements ToggableTestResourcesResolver, Closeable {
+    public static final String DISPLAY_NAME = "H2";
+    public static final String PREFIX = "datasources";
+
+    private static final String URL = "url";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String DIALECT = "dialect";
+    private static final String DRIVER = "driver-class-name";
+    private static final String TYPE = "db-type";
+    private static final String SERVER_URI = "micronaut.test.resources.server.uri";
+    private static final String DEFAULT_HOST = "localhost";
+    private static final String DEFAULT_USERNAME = "sa";
+    private static final String DEFAULT_PASSWORD = "";
+    private static final String DEFAULT_DRIVER = "org.h2.Driver";
+    private static final String JDBC_OPTIONS = "DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE";
+    private static final List<String> SUPPORTED_PROPERTIES = List.of(URL, USERNAME, PASSWORD, DRIVER);
+
+    private final Map<Key, H2Server> servers = new ConcurrentHashMap<>();
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    public String getName() {
+        return "h2";
+    }
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Collections.singletonList(PREFIX);
+    }
+
+    @Override
+    public List<String> getRequiredProperties(String expression) {
+        if (!isDatasourceExpression(expression)) {
+            return Collections.emptyList();
+        }
+        String datasource = datasourceNameFrom(expression);
+        return Stream.of(
+            datasourceExpressionOf(datasource, TYPE),
+            datasourceExpressionOf(datasource, DIALECT),
+            SERVER_URI
+        ).toList();
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        Collection<String> datasources = propertyEntries.getOrDefault(PREFIX, Collections.emptyList());
+        return datasources.stream()
+            .flatMap(datasource -> SUPPORTED_PROPERTIES.stream().map(property -> datasourceExpressionOf(datasource, property)))
+            .toList();
+    }
+
+    @Override
+    public Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        if (!shouldAnswer(propertyName, properties)) {
+            return Optional.empty();
+        }
+        String datasource = datasourceNameFrom(propertyName);
+        return Optional.ofNullable(switch (datasourcePropertyFrom(propertyName)) {
+            case URL -> server(properties, datasource).getJdbcUrl();
+            case USERNAME -> DEFAULT_USERNAME;
+            case PASSWORD -> DEFAULT_PASSWORD;
+            case DRIVER -> DEFAULT_DRIVER;
+            default -> null;
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOException failure = null;
+        for (H2Server server : servers.values()) {
+            try {
+                server.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        servers.clear();
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    int serverCount() {
+        return servers.size();
+    }
+
+    private H2Server server(Map<String, Object> properties, String datasource) {
+        return servers.computeIfAbsent(
+            new Key(Scope.from(properties), datasource),
+            key -> H2Server.start(datasource)
+        );
+    }
+
+    private static boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties) {
+        if (!isDatasourceExpression(propertyName)) {
+            return false;
+        }
+        String datasource = datasourceNameFrom(propertyName);
+        if (isExternalServerConfigured(requestedProperties)) {
+            return false;
+        }
+        String type = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, TYPE)));
+        if (type != null) {
+            return "h2".equalsIgnoreCase(type);
+        }
+        String dialect = stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, DIALECT)));
+        return dialect != null && "h2".equalsIgnoreCase(dialect);
+    }
+
+    private static boolean isExternalServerConfigured(Map<String, Object> requestedProperties) {
+        String serverUri = stringOrNull(requestedProperties.get(SERVER_URI));
+        return serverUri != null && !serverUri.isBlank();
+    }
+
+    private static String stringOrNull(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return String.valueOf(value);
+    }
+
+    private static boolean isDatasourceExpression(String expression) {
+        return expression.startsWith(PREFIX + ".");
+    }
+
+    private static String datasourceNameFrom(String expression) {
+        String remainder = expression.substring(1 + expression.indexOf('.'));
+        return remainder.substring(0, remainder.indexOf('.'));
+    }
+
+    private static String datasourcePropertyFrom(String expression) {
+        String remainder = expression.substring(1 + expression.indexOf('.'));
+        return remainder.substring(1 + remainder.indexOf('.'));
+    }
+
+    private static String datasourceExpressionOf(String datasource, String property) {
+        return PREFIX + "." + datasource + "." + property;
+    }
+
+    private record Key(Scope scope, String datasource) {
+    }
+
+    private static final class H2Server implements Closeable {
+        private final String databaseName;
+        private final Server server;
+
+        private H2Server(String databaseName, Server server) {
+            this.databaseName = databaseName;
+            this.server = server;
+        }
+
+        private static H2Server start(String datasource) {
+            String databaseName = datasource + "_" + UUID.randomUUID().toString().replace("-", "");
+            int port = findAvailablePort();
+            try {
+                Server server = Server.createTcpServer(
+                    "-tcp",
+                    "-tcpPort", Integer.toString(port),
+                    "-ifNotExists"
+                ).start();
+                return new H2Server(databaseName, server);
+            } catch (SQLException e) {
+                throw new IllegalStateException("Unable to start H2 TCP server", e);
+            }
+        }
+
+        private String getJdbcUrl() {
+            return "jdbc:h2:tcp://%s:%d/mem:%s;%s".formatted(DEFAULT_HOST, server.getPort(), databaseName, JDBC_OPTIONS);
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                server.stop();
+            } catch (RuntimeException e) {
+                throw new IOException("Unable to stop H2 TCP server", e);
+            }
+        }
+
+        private static int findAvailablePort() {
+            try (ServerSocket socket = new ServerSocket(0)) {
+                socket.setReuseAddress(true);
+                return socket.getLocalPort();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to allocate a TCP port for H2", e);
+            }
+        }
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.h2.H2TestResourceProvider

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
@@ -3,6 +3,15 @@ package io.micronaut.testresources.h2
 import io.micronaut.testresources.core.Scope
 import spock.lang.Specification
 
+import java.net.ConnectException
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.NoRouteToHostException
+import java.net.Socket
+import java.net.SocketTimeoutException
+
 class H2TestResourceProviderSpec extends Specification {
     private final H2TestResourceProvider provider = new H2TestResourceProvider()
 
@@ -92,6 +101,33 @@ class H2TestResourceProviderSpec extends Specification {
         provider.serverCount() == 1
     }
 
+    void "binds the H2 TCP listener to loopback only"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'loopback',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        String url = provider.resolve('datasources.default.url', properties, [:]).orElseThrow()
+        InetAddress nonLoopbackAddress = findNonLoopbackAddress()
+        if (nonLoopbackAddress == null) {
+            return
+        }
+        int port = tcpPortOf(url)
+        Socket socket = new Socket()
+        try {
+            socket.connect(new InetSocketAddress(nonLoopbackAddress, port), 500)
+        } finally {
+            socket.close()
+        }
+
+        then:
+        IOException e = thrown()
+        e instanceof ConnectException || e instanceof NoRouteToHostException || e instanceof SocketTimeoutException
+        provider.serverCount() == 1
+    }
+
     void "matches the H2 dialect fallback"() {
         given:
         Map<String, Object> properties = [
@@ -170,5 +206,29 @@ class H2TestResourceProviderSpec extends Specification {
         IllegalStateException e = thrown()
         e.message == 'H2 test resource provider is closed'
         provider.serverCount() == 0
+    }
+
+    private static int tcpPortOf(String url) {
+        def matcher = url =~ /jdbc:h2:tcp:\/\/localhost:(\d+)\/mem:.+/
+        assert matcher.matches()
+        matcher.group(1) as int
+    }
+
+    private static InetAddress findNonLoopbackAddress() {
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces()
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement()
+            if (!networkInterface.isUp() || networkInterface.isLoopback() || networkInterface.isVirtual()) {
+                continue
+            }
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses()
+            while (addresses.hasMoreElements()) {
+                InetAddress address = addresses.nextElement()
+                if (address instanceof Inet4Address && !address.isLoopbackAddress() && !address.isLinkLocalAddress() && !address.isAnyLocalAddress()) {
+                    return address
+                }
+            }
+        }
+        null
     }
 }

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
@@ -1,0 +1,135 @@
+package io.micronaut.testresources.h2
+
+import io.micronaut.testresources.core.Scope
+import spock.lang.Specification
+
+class H2TestResourceProviderSpec extends Specification {
+    private final H2TestResourceProvider provider = new H2TestResourceProvider()
+
+    void cleanup() {
+        provider.close()
+    }
+
+    void "resolves JDBC properties when db type is h2"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'test',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        String url = provider.resolve('datasources.default.url', properties, [:]).orElse(null)
+        String username = provider.resolve('datasources.default.username', properties, [:]).orElse(null)
+        String password = provider.resolve('datasources.default.password', properties, [:]).orElse(null)
+        String driver = provider.resolve('datasources.default.driver-class-name', properties, [:]).orElse(null)
+
+        then:
+        url.startsWith('jdbc:h2:tcp://localhost:')
+        url.contains('/mem:default_')
+        username == 'sa'
+        password == ''
+        driver == 'org.h2.Driver'
+        provider.serverCount() == 1
+    }
+
+    void "reuses the same server inside a scope"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'shared',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        String first = provider.resolve('datasources.default.url', properties, [:]).orElseThrow()
+        String second = provider.resolve('datasources.default.url', properties, [:]).orElseThrow()
+        String username = provider.resolve('datasources.default.username', properties, [:]).orElseThrow()
+
+        then:
+        first == second
+        username == 'sa'
+        provider.serverCount() == 1
+    }
+
+    void "creates a different server for another scope"() {
+        given:
+        Map<String, Object> left = [
+            (Scope.PROPERTY_KEY)           : 'left',
+            'datasources.default.db-type'  : 'h2'
+        ]
+        Map<String, Object> right = [
+            (Scope.PROPERTY_KEY)           : 'right',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        String leftUrl = provider.resolve('datasources.default.url', left, [:]).orElseThrow()
+        String rightUrl = provider.resolve('datasources.default.url', right, [:]).orElseThrow()
+
+        then:
+        leftUrl != rightUrl
+        provider.serverCount() == 2
+    }
+
+    void "matches the H2 dialect fallback"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)            : 'dialect',
+            'datasources.default.dialect'   : 'H2'
+        ]
+
+        expect:
+        provider.resolve('datasources.default.url', properties, [:]).present
+    }
+
+    void "does not answer other database types"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'other',
+            'datasources.default.db-type'  : 'postgres'
+        ]
+
+        expect:
+        provider.resolve('datasources.default.url', properties, [:]).empty
+        provider.serverCount() == 0
+    }
+
+    void "requires H2 datasource hints and the external server flag"() {
+        expect:
+        provider.getRequiredProperties('datasources.default.url') == [
+            'datasources.default.db-type',
+            'datasources.default.dialect',
+            'micronaut.test.resources.server.uri'
+        ]
+    }
+
+    void "does not answer when using an external test resources server"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'remote-host',
+            'datasources.default.db-type'  : 'h2',
+            'micronaut.test.resources.server.uri': 'http://localhost:8080'
+        ]
+
+        expect:
+        provider.resolve('datasources.default.url', properties, [:]).empty
+        provider.resolve('datasources.default.username', properties, [:]).empty
+        provider.resolve('datasources.default.password', properties, [:]).empty
+        provider.resolve('datasources.default.driver-class-name', properties, [:]).empty
+        provider.serverCount() == 0
+    }
+
+    void "closes active servers"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'closing',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        provider.resolve('datasources.default.url', properties, [:]).orElseThrow()
+        provider.close()
+
+        then:
+        provider.serverCount() == 0
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/h2/H2TestResourceProviderSpec.groovy
@@ -70,6 +70,28 @@ class H2TestResourceProviderSpec extends Specification {
         provider.serverCount() == 2
     }
 
+    void "reuses the same server for multiple datasource names in the same scope"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)         : 'shared',
+            'datasources.alpha.db-type'  : 'h2',
+            'datasources.beta.db-type'   : 'h2'
+        ]
+
+        when:
+        String alphaUrl = provider.resolve('datasources.alpha.url', properties, [:]).orElseThrow()
+        String betaUrl = provider.resolve('datasources.beta.url', properties, [:]).orElseThrow()
+
+        then:
+        alphaUrl.startsWith('jdbc:h2:tcp://localhost:')
+        betaUrl.startsWith('jdbc:h2:tcp://localhost:')
+        alphaUrl.contains('/mem:alpha_')
+        betaUrl.contains('/mem:beta_')
+        alphaUrl != betaUrl
+        alphaUrl.substring(0, alphaUrl.indexOf('/mem:')) == betaUrl.substring(0, betaUrl.indexOf('/mem:'))
+        provider.serverCount() == 1
+    }
+
     void "matches the H2 dialect fallback"() {
         given:
         Map<String, Object> properties = [
@@ -130,6 +152,23 @@ class H2TestResourceProviderSpec extends Specification {
         provider.close()
 
         then:
+        provider.serverCount() == 0
+    }
+
+    void "does not create new servers after close"() {
+        given:
+        Map<String, Object> properties = [
+            (Scope.PROPERTY_KEY)           : 'closed',
+            'datasources.default.db-type'  : 'h2'
+        ]
+
+        when:
+        provider.close()
+        provider.resolve('datasources.default.url', properties, [:])
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'H2 test resource provider is closed'
         provider.serverCount() == 0
     }
 }

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/jdbc/h2/H2BookRepository.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/jdbc/h2/H2BookRepository.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.testresources.jdbc.h2
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import io.micronaut.testresources.jdbc.Book
+
+@JdbcRepository(dialect = Dialect.H2)
+interface H2BookRepository extends CrudRepository<Book, Long> {
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/jdbc/h2/StartH2Test.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/groovy/io/micronaut/testresources/jdbc/h2/StartH2Test.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.testresources.jdbc.h2
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.jdbc.Book
+import jakarta.inject.Inject
+
+import javax.sql.DataSource
+
+@MicronautTest
+class StartH2Test extends spock.lang.Specification {
+    @Inject
+    H2BookRepository repository
+
+    @Inject
+    DataSource dataSource
+
+    def "starts a containerless H2 server"() {
+        given:
+        def book = new Book(title: "Micronaut Test Resources")
+        repository.save(book)
+
+        when:
+        def books = repository.findAll()
+        def connection = dataSource.connection
+
+        then:
+        books.size() == 1
+        connection.metaData.URL.startsWith('jdbc:h2:tcp://localhost:')
+
+        cleanup:
+        connection?.close()
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/resources/application-test.yml
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/resources/application-test.yml
@@ -1,0 +1,4 @@
+datasources:
+  default:
+    db-type: h2
+    schema-generate: CREATE_DROP

--- a/test-resources-jdbc/test-resources-jdbc-h2/src/test/resources/logback.xml
+++ b/test-resources-jdbc/test-resources-jdbc-h2/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary
- add a new `test-resources-jdbc-h2` module for JDBC-only, containerless H2 test resources
- implement an H2 resolver that provides JDBC URL, username, password, and driver class while reusing one loopback-only TCP server per scope
- document the H2 support boundary as JDBC-only and local-only, with shared or remote H2 test resources currently unsupported

## Verification
- `./gradlew :micronaut-test-resources-jdbc-h2:check`

Closes #77

---
###### ✨ This message was AI-generated using gpt-5