### PR TITLE
Add IntelliJ IDEA datasource export support

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -14,3 +14,24 @@ In order for the database to be properly detected, _one of_ the following proper
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 
 `datasources.*.driverClassName` should be empty because JDBC driver from testcontainers has to be used for working with URI like 'jdcb:tc:postgres:14///db'
+
+Micronaut Test Resources can also generate an IntelliJ IDEA/DataGrip datasource export file for resolved JDBC datasources.
+The export is opt-in and disabled by default.
+
+Enable it with:
+
+[configuration]
+----
+test-resources:
+  intellij-idea:
+    enabled: true
+----
+
+By default, the generated export is written to `.micronaut/test-resources/intellij-idea-datasources.xml`.
+You can override that location with `test-resources.intellij-idea.output-path`.
+
+The export is generated from resolved `datasources.*.url`, `datasources.*.username`, `datasources.*.password`, and `datasources.*.driver-class-name` values, and supports multiple named JDBC datasources in the same run.
+The file uses IntelliJ IDEA's datasource export format so you can import or paste it into IntelliJ IDEA or DataGrip without rebuilding the connection details by hand.
+
+WARNING: The generated export contains local test usernames and passwords.
+Do not commit it, and do not point the output path at `.idea/` files in this first iteration.

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -70,6 +70,7 @@ public class ServerUtils {
     private static final String SERVER_ACCESS_TOKEN_MICRONAUT_PROPERTY = "server.access-token";
     private static final String SERVER_ACCESS_TOKEN = "server.access.token";
     private static final String SERVER_CLIENT_READ_TIMEOUT = "server.client.read.timeout";
+    private static final String CLIENT_PROJECT_PATH_URI = "micronaut.test.resources.project-path-uri";
     private static final String SERVER_IDLE_TIMEOUT_MINUTES = "server.idle.timeout.minutes";
     private static final String SERVER_ENTRY_POINT =
         "io.micronaut.testresources.server.TestResourcesService";
@@ -103,6 +104,8 @@ public class ServerUtils {
                 .ifPresent(token -> prn.println(SERVER_ACCESS_TOKEN + "=" + token));
             settings.getClientTimeout()
                 .ifPresent(timeout -> prn.println(SERVER_CLIENT_READ_TIMEOUT + "=" + timeout));
+            inferProjectDirectory(destinationDirectory)
+                .ifPresent(projectDirectory -> prn.println(CLIENT_PROJECT_PATH_URI + "=" + projectDirectory.toUri()));
         }
     }
 
@@ -314,6 +317,20 @@ public class ServerUtils {
     public static Path getDefaultSharedSettingsPath(String namespace) {
         String ns = namespace == null ? "test-resources" : "test-resources-" + namespace;
         return Paths.get(System.getProperty("user.home"), ".micronaut/" + ns);
+    }
+
+    private static Optional<Path> inferProjectDirectory(Path settingsDirectory) {
+        Path current = settingsDirectory.toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.exists(current.resolve("settings.gradle"))
+                || Files.exists(current.resolve("settings.gradle.kts"))
+                || Files.exists(current.resolve("gradlew"))
+                || Files.exists(current.resolve("gradlew.bat"))) {
+                return Optional.of(current);
+            }
+            current = current.getParent();
+        }
+        return Optional.empty();
     }
 
     private static void startAndWait(ServerFactory serverFactory,

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -12,6 +12,7 @@ import spock.util.environment.RestoreSystemProperties
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.Properties
 
 class ServerUtilsTest extends Specification {
     @TempDir
@@ -41,6 +42,23 @@ class ServerUtilsTest extends Specification {
         'abc' | null
         null  | 60
         'abc' | 98
+    }
+
+    def "writes the current project path uri into server settings when available"() {
+        given:
+        def projectDir = tmpDir.resolve("sample-project")
+        Files.createDirectories(projectDir.resolve("build/test-resources-server-config"))
+        Files.createFile(projectDir.resolve("settings.gradle"))
+        def settingsDir = projectDir.resolve("build/test-resources-server-config")
+        def settings = new ServerSettings(1234, null, null, null)
+
+        when:
+        ServerUtils.writeServerSettings(settingsDir, settings)
+        def props = new Properties()
+        Files.newInputStream(settingsDir.resolve(ServerUtils.PROPERTIES_FILE_NAME)).withCloseable(props.&load)
+
+        then:
+        props.getProperty("micronaut.test.resources.project-path-uri") == projectDir.toUri().toString()
     }
 
     def "requires new server"() {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
@@ -62,8 +62,16 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
 
     private final String accessToken;
     private final Duration clientTimeout;
+    private final IntellijIdeaDatasourceExporter intellijIdeaDatasourceExporter;
 
     public DefaultTestResourcesClient(String baseUri, String accessToken, int clientReadTimeout) {
+        this(baseUri, accessToken, clientReadTimeout, new IntellijIdeaDatasourceExporter());
+    }
+
+    DefaultTestResourcesClient(String baseUri,
+                               String accessToken,
+                               int clientReadTimeout,
+                               IntellijIdeaDatasourceExporter intellijIdeaDatasourceExporter) {
         this.baseUri = baseUri;
         clientTimeout = Duration.ofSeconds(clientReadTimeout);
         this.client = HttpClient.newBuilder()
@@ -71,6 +79,7 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
             .build();
         this.accessToken = accessToken;
         this.jsonMapper = JsonMapper.createDefault();
+        this.intellijIdeaDatasourceExporter = intellijIdeaDatasourceExporter;
     }
 
     @Override
@@ -87,11 +96,20 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
     @Override
     public Optional<String> resolve(String name, Map<String, Object> properties,
                                     Map<String, Object> testResourcesConfig) {
+        return resolve(name, properties, testResourcesConfig, "default");
+    }
+
+    Optional<String> resolve(String name,
+                             Map<String, Object> properties,
+                             Map<String, Object> testResourcesConfig,
+                             String exporterSessionId) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", name);
         params.put("properties", properties);
         params.put("testResourcesConfig", testResourcesConfig);
-        return Optional.ofNullable(request(RESOLVE_URI, STRING, r -> POST(r, params)));
+        Optional<String> resolved = Optional.ofNullable(request(RESOLVE_URI, STRING, r -> POST(r, params)));
+        resolved.ifPresent(value -> intellijIdeaDatasourceExporter.export(name, value, testResourcesConfig, exporterSessionId));
+        return resolved;
     }
 
     @Override
@@ -112,6 +130,10 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
     @Override
     public boolean closeScope(@Nullable String id) {
         return request(CLOSE_URI + "/" + id, BOOLEAN, this::GET);
+    }
+
+    void clearIntellijIdeaDatasourceExport(String exporterSessionId) {
+        intellijIdeaDatasourceExporter.clearSession(exporterSessionId);
     }
 
     @SuppressWarnings({"java:S100", "checkstyle:MethodName"})

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
  */
 @SuppressWarnings("unchecked")
 @Internal
-public class DefaultTestResourcesClient implements TestResourcesClient {
+public final class DefaultTestResourcesClient implements TestResourcesClient {
     public static final String ACCESS_TOKEN = "Access-Token";
 
     private static final String RESOLVABLE_PROPERTIES_URI = "/list";
@@ -54,7 +54,7 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
     private static final Argument<String> STRING = Argument.STRING;
     private static final Argument<Boolean> BOOLEAN = Argument.BOOLEAN;
     private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
-    private static final String INTERNAL_SERVER_ERROR_PREFIX = INTERNAL_SERVER_ERROR + ": ";    
+    private static final String INTERNAL_SERVER_ERROR_PREFIX = INTERNAL_SERVER_ERROR + ": ";
 
     private final JsonMapper jsonMapper;
     private final String baseUri;

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import java.util.UUID;
 final class IntellijIdeaDatasourceExporter {
     static final String ENABLED = "intellij-idea.enabled";
     static final String OUTPUT_PATH = "intellij-idea.output-path";
+    static final String PROJECT_PATH_URI = "project-path-uri";
     static final String DEFAULT_OUTPUT_PATH = ".micronaut/test-resources/intellij-idea-datasources.xml";
 
     private static final String DATASOURCES_PREFIX = "datasources.";
@@ -194,11 +196,26 @@ final class IntellijIdeaDatasourceExporter {
     private record ExportConfiguration(boolean enabled, Path outputPath) {
         private static ExportConfiguration from(Map<String, Object> testResourcesConfig, Path projectDirectory) {
             boolean enabled = booleanValue(testResourcesConfig, ENABLED, false);
+            Path activeProjectDirectory = projectDirectory(testResourcesConfig, projectDirectory);
             Path outputPath = stringValue(testResourcesConfig, OUTPUT_PATH)
                 .map(Path::of)
-                .map(path -> path.isAbsolute() ? path : projectDirectory.resolve(path).normalize())
-                .orElse(projectDirectory.resolve(DEFAULT_OUTPUT_PATH).normalize());
+                .map(path -> path.isAbsolute() ? path : activeProjectDirectory.resolve(path).normalize())
+                .orElse(activeProjectDirectory.resolve(DEFAULT_OUTPUT_PATH).normalize());
             return new ExportConfiguration(enabled, outputPath);
+        }
+
+        private static Path projectDirectory(Map<String, Object> testResourcesConfig, Path defaultProjectDirectory) {
+            return stringValue(testResourcesConfig, PROJECT_PATH_URI)
+                .map(ExportConfiguration::pathFromUri)
+                .orElse(defaultProjectDirectory);
+        }
+
+        private static Path pathFromUri(String projectPathUri) {
+            try {
+                return Path.of(URI.create(projectPathUri)).toAbsolutePath().normalize();
+            } catch (IllegalArgumentException e) {
+                throw new TestResourcesException("Invalid IntelliJ IDEA project path URI '" + projectPathUri + "'", e);
+            }
         }
 
         private static boolean booleanValue(Map<String, Object> testResourcesConfig, String key, boolean defaultValue) {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
@@ -63,23 +63,40 @@ final class IntellijIdeaDatasourceExporter {
         JdbcDatasourceProperty.parse(propertyName)
             .ifPresent(property -> {
                 var sessionState = sessions.computeIfAbsent(sessionId, unused -> new ExportSessionState(config.outputPath()));
+                var previousOutputPath = sessionState.outputPath;
                 sessionState.outputPath = config.outputPath();
                 var state = sessionState.datasources.computeIfAbsent(property.datasourceName(), JdbcDatasourceState::new);
                 state.record(property.propertyName(), value);
-                writeExport(sessionState.outputPath, completeDatasources(sessionState.datasources));
+                if (previousOutputPath != null && !previousOutputPath.equals(sessionState.outputPath)) {
+                    rewriteExport(previousOutputPath);
+                }
+                rewriteExport(sessionState.outputPath);
             });
     }
 
     synchronized void clearSession(String sessionId) {
-        sessions.remove(sessionId);
+        var sessionState = sessions.remove(sessionId);
+        if (sessionState != null) {
+            rewriteExport(sessionState.outputPath);
+        }
     }
 
-    private List<JdbcDatasourceState> completeDatasources(Map<String, JdbcDatasourceState> datasources) {
+    private List<JdbcDatasourceState> completeDatasources(Path outputPath) {
+        var datasources = new LinkedHashMap<String, JdbcDatasourceState>();
+        for (ExportSessionState sessionState : sessions.values()) {
+            if (outputPath.equals(sessionState.outputPath)) {
+                sessionState.datasources.forEach(datasources::put);
+            }
+        }
         return datasources.values()
             .stream()
             .filter(JdbcDatasourceState::isComplete)
             .sorted(Comparator.comparing(JdbcDatasourceState::name))
             .toList();
+    }
+
+    private void rewriteExport(Path outputPath) {
+        writeExport(outputPath, completeDatasources(outputPath));
     }
 
     private void writeExport(Path outputPath, List<JdbcDatasourceState> completeDatasources) {

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.client;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Internal
+final class IntellijIdeaDatasourceExporter {
+    static final String ENABLED = "intellij-idea.enabled";
+    static final String OUTPUT_PATH = "intellij-idea.output-path";
+    static final String DEFAULT_OUTPUT_PATH = ".micronaut/test-resources/intellij-idea-datasources.xml";
+
+    private static final String DATASOURCES_PREFIX = "datasources.";
+    private static final String URL = "url";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String DRIVER_CLASS_NAME = "driver-class-name";
+
+    private final Path projectDirectory;
+    private final Map<String, ExportSessionState> sessions = new LinkedHashMap<>();
+
+    IntellijIdeaDatasourceExporter() {
+        this(Path.of("").toAbsolutePath().normalize());
+    }
+
+    IntellijIdeaDatasourceExporter(Path projectDirectory) {
+        this.projectDirectory = projectDirectory.toAbsolutePath().normalize();
+    }
+
+    synchronized void export(String propertyName, String value, Map<String, Object> testResourcesConfig) {
+        export(propertyName, value, testResourcesConfig, "default");
+    }
+
+    synchronized void export(String propertyName, String value, Map<String, Object> testResourcesConfig, String sessionId) {
+        var config = ExportConfiguration.from(testResourcesConfig, projectDirectory);
+        if (!config.enabled()) {
+            return;
+        }
+        JdbcDatasourceProperty.parse(propertyName)
+            .ifPresent(property -> {
+                var sessionState = sessions.computeIfAbsent(sessionId, unused -> new ExportSessionState(config.outputPath()));
+                sessionState.outputPath = config.outputPath();
+                var state = sessionState.datasources.computeIfAbsent(property.datasourceName(), JdbcDatasourceState::new);
+                state.record(property.propertyName(), value);
+                writeExport(sessionState.outputPath, completeDatasources(sessionState.datasources));
+            });
+    }
+
+    synchronized void clearSession(String sessionId) {
+        sessions.remove(sessionId);
+    }
+
+    private List<JdbcDatasourceState> completeDatasources(Map<String, JdbcDatasourceState> datasources) {
+        return datasources.values()
+            .stream()
+            .filter(JdbcDatasourceState::isComplete)
+            .sorted(Comparator.comparing(JdbcDatasourceState::name))
+            .toList();
+    }
+
+    private void writeExport(Path outputPath, List<JdbcDatasourceState> completeDatasources) {
+        try {
+            if (completeDatasources.isEmpty()) {
+                Files.deleteIfExists(outputPath);
+                return;
+            }
+            var parent = outputPath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.writeString(outputPath, render(completeDatasources), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new TestResourcesException("Failed to write IntelliJ IDEA datasource export to " + outputPath, e);
+        }
+    }
+
+    private String render(List<JdbcDatasourceState> completeDatasources) {
+        var sb = new StringBuilder("#DataSourceSettings#\n");
+        for (JdbcDatasourceState datasource : completeDatasources) {
+            var driverMetadata = DriverMetadata.from(datasource.url, datasource.driverClassName);
+            sb.append("#LocalDataSource: ").append(datasource.name).append('\n');
+            sb.append("#BEGIN#\n");
+            sb.append("<data-source source=\"LOCAL\" name=\"")
+                .append(escape(datasource.name))
+                .append("\" uuid=\"")
+                .append(datasource.uuid())
+                .append("\">");
+            driverMetadata.dbms()
+                .ifPresent(dbms -> sb.append("<database-info product=\"\" version=\"\" jdbc-version=\"\" driver-name=\"\" driver-version=\"\" dbms=\"")
+                    .append(escape(dbms))
+                    .append("\"/>"));
+            sb.append("<driver-ref>")
+                .append(escape(driverMetadata.driverRef()))
+                .append("</driver-ref>")
+                .append("<synchronize>true</synchronize>")
+                .append("<jdbc-driver>")
+                .append(escape(datasource.driverClassName))
+                .append("</jdbc-driver>")
+                .append("<jdbc-url>")
+                .append(escape(datasource.url))
+                .append("</jdbc-url>")
+                .append("<user-name>")
+                .append(escape(datasource.username))
+                .append("</user-name>")
+                .append("<password>")
+                .append(escape(datasource.password))
+                .append("</password>")
+                .append("<working-dir>$ProjectFileDir$</working-dir>")
+                .append("</data-source>\n")
+                .append("#END#\n");
+        }
+        return sb.toString();
+    }
+
+    private static String escape(String value) {
+        return value
+            .replace("&", "&amp;")
+            .replace("\"", "&quot;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;");
+    }
+
+    private static final class ExportSessionState {
+        private Path outputPath;
+        private final Map<String, JdbcDatasourceState> datasources = new LinkedHashMap<>();
+
+        private ExportSessionState(Path outputPath) {
+            this.outputPath = outputPath;
+        }
+    }
+
+    private record ExportConfiguration(boolean enabled, Path outputPath) {
+        private static ExportConfiguration from(Map<String, Object> testResourcesConfig, Path projectDirectory) {
+            boolean enabled = booleanValue(testResourcesConfig, ENABLED, false);
+            Path outputPath = stringValue(testResourcesConfig, OUTPUT_PATH)
+                .map(Path::of)
+                .map(path -> path.isAbsolute() ? path : projectDirectory.resolve(path).normalize())
+                .orElse(projectDirectory.resolve(DEFAULT_OUTPUT_PATH).normalize());
+            return new ExportConfiguration(enabled, outputPath);
+        }
+
+        private static boolean booleanValue(Map<String, Object> testResourcesConfig, String key, boolean defaultValue) {
+            Object value = testResourcesConfig.get(key);
+            if (value == null) {
+                value = System.getProperty(ConfigFinder.systemPropertyNameOf(key));
+            }
+            if (value == null) {
+                return defaultValue;
+            }
+            if (value instanceof Boolean bool) {
+                return bool;
+            }
+            return Boolean.parseBoolean(String.valueOf(value));
+        }
+
+        private static Optional<String> stringValue(Map<String, Object> testResourcesConfig, String key) {
+            Object value = testResourcesConfig.get(key);
+            if (value == null) {
+                value = System.getProperty(ConfigFinder.systemPropertyNameOf(key));
+            }
+            if (value == null) {
+                return Optional.empty();
+            }
+            return Optional.of(String.valueOf(value));
+        }
+    }
+
+    private record JdbcDatasourceProperty(String datasourceName, String propertyName) {
+        private static Optional<JdbcDatasourceProperty> parse(String propertyName) {
+            if (!propertyName.startsWith(DATASOURCES_PREFIX)) {
+                return Optional.empty();
+            }
+            String remainder = propertyName.substring(DATASOURCES_PREFIX.length());
+            int separator = remainder.indexOf('.');
+            if (separator < 0) {
+                return Optional.empty();
+            }
+            String datasourceName = remainder.substring(0, separator);
+            String datasourceProperty = remainder.substring(separator + 1);
+            if (URL.equals(datasourceProperty)
+                || USERNAME.equals(datasourceProperty)
+                || PASSWORD.equals(datasourceProperty)
+                || DRIVER_CLASS_NAME.equals(datasourceProperty)) {
+                return Optional.of(new JdbcDatasourceProperty(datasourceName, datasourceProperty));
+            }
+            return Optional.empty();
+        }
+    }
+
+    private static final class JdbcDatasourceState {
+        private final String name;
+        private String url;
+        private String username;
+        private String password;
+        private String driverClassName;
+
+        private JdbcDatasourceState(String name) {
+            this.name = name;
+        }
+
+        private void record(String propertyName, String value) {
+            switch (propertyName) {
+                case URL -> this.url = value;
+                case USERNAME -> this.username = value;
+                case PASSWORD -> this.password = value;
+                case DRIVER_CLASS_NAME -> this.driverClassName = value;
+                default -> {
+                }
+            }
+        }
+
+        private boolean isComplete() {
+            return url != null && username != null && password != null && driverClassName != null;
+        }
+
+        private String name() {
+            return name;
+        }
+
+        private String uuid() {
+            return UUID.nameUUIDFromBytes(("intellij-idea-datasource:" + name).getBytes(StandardCharsets.UTF_8)).toString();
+        }
+    }
+
+    private record DriverMetadata(String driverRef, Optional<String> dbms) {
+        private static DriverMetadata from(String jdbcUrl, String driverClassName) {
+            String lowerDriver = driverClassName.toLowerCase();
+            String lowerUrl = jdbcUrl.toLowerCase();
+            if (lowerDriver.contains("postgresql") || lowerUrl.startsWith("jdbc:postgresql:")) {
+                return new DriverMetadata("postgresql", Optional.of("POSTGRES"));
+            }
+            if (lowerDriver.contains("mariadb") || lowerUrl.startsWith("jdbc:mariadb:")) {
+                return new DriverMetadata("mariadb", Optional.of("MARIADB"));
+            }
+            if (lowerDriver.contains("mysql") || lowerUrl.startsWith("jdbc:mysql:")) {
+                return new DriverMetadata("mysql", Optional.of("MYSQL"));
+            }
+            if (lowerDriver.contains("oracle") || lowerUrl.startsWith("jdbc:oracle:")) {
+                return new DriverMetadata("oracle", Optional.of("ORACLE"));
+            }
+            if (lowerDriver.contains("sqlserver") || lowerUrl.startsWith("jdbc:sqlserver:")) {
+                return new DriverMetadata("sqlserver", Optional.of("MSSQL"));
+            }
+            return new DriverMetadata(driverClassName, Optional.empty());
+        }
+    }
+}

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,17 +83,25 @@ final class IntellijIdeaDatasourceExporter {
         }
     }
 
-    private List<JdbcDatasourceState> completeDatasources(Path outputPath) {
-        var datasources = new LinkedHashMap<String, JdbcDatasourceState>();
-        for (ExportSessionState sessionState : sessions.values()) {
+    private List<RenderedDatasource> completeDatasources(Path outputPath) {
+        var datasources = new ArrayList<SessionDatasourceState>();
+        var datasourceCounts = new HashMap<String, Integer>();
+        for (var sessionEntry : sessions.entrySet()) {
+            var sessionId = sessionEntry.getKey();
+            var sessionState = sessionEntry.getValue();
             if (outputPath.equals(sessionState.outputPath)) {
-                sessionState.datasources.forEach(datasources::put);
+                for (JdbcDatasourceState datasource : sessionState.datasources.values()) {
+                    if (datasource.isComplete()) {
+                        datasources.add(new SessionDatasourceState(sessionId, datasource));
+                        datasourceCounts.merge(datasource.name(), 1, Integer::sum);
+                    }
+                }
             }
         }
-        return datasources.values()
-            .stream()
-            .filter(JdbcDatasourceState::isComplete)
-            .sorted(Comparator.comparing(JdbcDatasourceState::name))
+        datasources.sort(Comparator.comparing(SessionDatasourceState::datasourceName));
+        var renderedNameIndexes = new HashMap<String, Integer>();
+        return datasources.stream()
+            .map(datasource -> datasource.render(datasourceCounts, renderedNameIndexes))
             .toList();
     }
 
@@ -99,7 +109,7 @@ final class IntellijIdeaDatasourceExporter {
         writeExport(outputPath, completeDatasources(outputPath));
     }
 
-    private void writeExport(Path outputPath, List<JdbcDatasourceState> completeDatasources) {
+    private void writeExport(Path outputPath, List<RenderedDatasource> completeDatasources) {
         try {
             if (completeDatasources.isEmpty()) {
                 Files.deleteIfExists(outputPath);
@@ -115,14 +125,14 @@ final class IntellijIdeaDatasourceExporter {
         }
     }
 
-    private String render(List<JdbcDatasourceState> completeDatasources) {
+    private String render(List<RenderedDatasource> completeDatasources) {
         var sb = new StringBuilder("#DataSourceSettings#\n");
-        for (JdbcDatasourceState datasource : completeDatasources) {
+        for (RenderedDatasource datasource : completeDatasources) {
             var driverMetadata = DriverMetadata.from(datasource.url, datasource.driverClassName);
-            sb.append("#LocalDataSource: ").append(datasource.name).append('\n');
+            sb.append("#LocalDataSource: ").append(datasource.displayName).append('\n');
             sb.append("#BEGIN#\n");
             sb.append("<data-source source=\"LOCAL\" name=\"")
-                .append(escape(datasource.name))
+                .append(escape(datasource.displayName))
                 .append("\" uuid=\"")
                 .append(datasource.uuid())
                 .append("\">");
@@ -257,9 +267,31 @@ final class IntellijIdeaDatasourceExporter {
         private String name() {
             return name;
         }
+    }
 
+    private record SessionDatasourceState(String sessionId, JdbcDatasourceState datasource) {
+        private String datasourceName() {
+            return datasource.name();
+        }
+
+        private RenderedDatasource render(Map<String, Integer> datasourceCounts, Map<String, Integer> renderedNameIndexes) {
+            String datasourceName = datasource.name();
+            int totalCount = datasourceCounts.getOrDefault(datasourceName, 0);
+            int occurrence = renderedNameIndexes.merge(datasourceName, 1, Integer::sum);
+            String displayName = totalCount > 1 && occurrence > 1 ? datasourceName + " (" + occurrence + ")" : datasourceName;
+            String uuidSeed = totalCount > 1 ? sessionId + ":" + datasourceName : datasourceName;
+            return new RenderedDatasource(displayName, uuidSeed, datasource.url, datasource.username, datasource.password, datasource.driverClassName);
+        }
+    }
+
+    private record RenderedDatasource(String displayName,
+                                      String uuidSeed,
+                                      String url,
+                                      String username,
+                                      String password,
+                                      String driverClassName) {
         private String uuid() {
-            return UUID.nameUUIDFromBytes(("intellij-idea-datasource:" + name).getBytes(StandardCharsets.UTF_8)).toString();
+            return UUID.nameUUIDFromBytes(("intellij-idea-datasource:" + uuidSeed).getBytes(StandardCharsets.UTF_8)).toString();
         }
     }
 

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/IntellijIdeaDatasourceExporter.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -68,11 +69,17 @@ final class IntellijIdeaDatasourceExporter {
                 var previousOutputPath = sessionState.outputPath;
                 sessionState.outputPath = config.outputPath();
                 var state = sessionState.datasources.computeIfAbsent(property.datasourceName(), JdbcDatasourceState::new);
+                boolean wasComplete = state.isComplete();
                 state.record(property.propertyName(), value);
-                if (previousOutputPath != null && !previousOutputPath.equals(sessionState.outputPath)) {
+                boolean outputPathChanged = previousOutputPath != null && !previousOutputPath.equals(sessionState.outputPath);
+                if (outputPathChanged) {
                     rewriteExport(previousOutputPath);
                 }
-                rewriteExport(sessionState.outputPath);
+                if ((outputPathChanged && sessionState.hasCompleteDatasources())
+                    || wasComplete
+                    || state.isComplete()) {
+                    rewriteExport(sessionState.outputPath);
+                }
             });
     }
 
@@ -177,6 +184,10 @@ final class IntellijIdeaDatasourceExporter {
 
         private ExportSessionState(Path outputPath) {
             this.outputPath = outputPath;
+        }
+
+        private boolean hasCompleteDatasources() {
+            return datasources.values().stream().anyMatch(JdbcDatasourceState::isComplete);
         }
     }
 
@@ -297,8 +308,8 @@ final class IntellijIdeaDatasourceExporter {
 
     private record DriverMetadata(String driverRef, Optional<String> dbms) {
         private static DriverMetadata from(String jdbcUrl, String driverClassName) {
-            String lowerDriver = driverClassName.toLowerCase();
-            String lowerUrl = jdbcUrl.toLowerCase();
+            String lowerDriver = driverClassName.toLowerCase(Locale.ROOT);
+            String lowerUrl = jdbcUrl.toLowerCase(Locale.ROOT);
             if (lowerDriver.contains("postgresql") || lowerUrl.startsWith("jdbc:postgresql:")) {
                 return new DriverMetadata("postgresql", Optional.of("POSTGRES"));
             }

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static io.micronaut.testresources.core.PropertyResolverSupport.resolveRequiredProperties;
@@ -39,17 +40,14 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
         super(new DelegateResolver());
     }
 
-    private static TestResourcesClient createClient() {
-        return TestResourcesClientFactory.findByConvention().orElse(NoOpClient.INSTANCE);
-    }
-
     private static final class DelegateResolver implements PropertyExpressionResolver, AutoCloseable {
 
         // Using a dummy hashmap for convenience
         private final Map<Boolean, TestResourcesClient> clientHolder = new ConcurrentHashMap<>();
+        private final String intellijIdeaExportSessionId = UUID.randomUUID().toString();
 
         private TestResourcesClient client() {
-            return clientHolder.computeIfAbsent(Boolean.TRUE, unused -> createClient());
+            return clientHolder.computeIfAbsent(Boolean.TRUE, unused -> TestResourcesClientFactory.findByConvention().orElse(NoOpClient.INSTANCE));
         }
 
         @Override
@@ -71,7 +69,13 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
             return Optional.empty();
         }
 
-        private static Optional<String> callClient(String expression, TestResourcesClient client, Map<String, Object> props, Map<String, Object> properties) {
+        private Optional<String> callClient(String expression, TestResourcesClient client, Map<String, Object> props, Map<String, Object> properties) {
+            if (client instanceof DefaultTestResourcesClient defaultClient) {
+                return withErrorHandling(
+                    () -> defaultClient.resolve(expression, props, properties, intellijIdeaExportSessionId),
+                    () -> "Test resources service wasn't able to revolve expression '" + expression + "'"
+                );
+            }
             return withErrorHandling(
                 () -> client.resolve(expression, props, properties),
                 () -> "Test resources service wasn't able to revolve expression '" + expression + "'"
@@ -96,8 +100,13 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
 
         @Override
         public synchronized void close() {
-            client().closeAll();
-            clientHolder.clear();
+            TestResourcesClient client = clientHolder.remove(Boolean.TRUE);
+            if (client instanceof DefaultTestResourcesClient defaultClient) {
+                defaultClient.clearIntellijIdeaDatasourceExport(intellijIdeaExportSessionId);
+            }
+            if (client != null) {
+                client.closeAll();
+            }
         }
     }
 

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -73,12 +73,12 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
             if (client instanceof DefaultTestResourcesClient defaultClient) {
                 return withErrorHandling(
                     () -> defaultClient.resolve(expression, props, properties, intellijIdeaExportSessionId),
-                    () -> "Test resources service wasn't able to revolve expression '" + expression + "'"
+                    () -> "Test resources service wasn't able to resolve expression '" + expression + "'"
                 );
             }
             return withErrorHandling(
                 () -> client.resolve(expression, props, properties),
-                () -> "Test resources service wasn't able to revolve expression '" + expression + "'"
+                () -> "Test resources service wasn't able to resolve expression '" + expression + "'"
             );
         }
 

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientPropertyExpressionResolver.java
@@ -110,7 +110,7 @@ public class TestResourcesClientPropertyExpressionResolver extends LazyTestResou
         }
     }
 
-    private static class Holder {
+    private static final class Holder {
         // This is a workaround to avoid that the logger ends up in image heap
         // in native-image
         private static final Logger LOGGER = LoggerFactory.getLogger(TestResourcesClientPropertyExpressionResolver.class);

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterStandaloneProjectTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterStandaloneProjectTest.groovy
@@ -1,0 +1,205 @@
+package io.micronaut.testresources.client
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.lang.Timeout
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Pattern
+
+@Timeout(600)
+class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification {
+    private static final List<String> SNAPSHOT_PUBLISH_TASKS = [
+        ':micronaut-test-resources-build-tools:publishToMavenLocal',
+        ':micronaut-test-resources-core:publishToMavenLocal',
+        ':micronaut-test-resources-client:publishToMavenLocal',
+        ':micronaut-test-resources-embedded:publishToMavenLocal',
+        ':micronaut-test-resources-testcontainers:publishToMavenLocal',
+        ':micronaut-test-resources-server:publishToMavenLocal',
+        ':micronaut-test-resources-jdbc-core:publishToMavenLocal',
+        ':micronaut-test-resources-jdbc-postgresql:publishToMavenLocal'
+    ]
+
+    @TempDir
+    Path tempDir
+
+    def "standalone Gradle project writes IntelliJ IDEA datasource export file"() {
+        given:
+        Path repoRoot = findRepositoryRoot()
+        Path mavenRepo = tempDir.resolve("maven-repo")
+        Path sampleProject = tempDir.resolve("sample-project")
+        Path outputFile = sampleProject.resolve("build/intellij-idea-datasources.xml")
+        String projectVersion = propertyValue(repoRoot.resolve("gradle.properties"), "projectVersion")
+        String micronautPlatformVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-platform")
+        String micronautGradlePluginVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-gradle-plugin")
+        writeStandaloneProject(sampleProject, outputFile, projectVersion, micronautPlatformVersion, micronautGradlePluginVersion)
+
+        when:
+        CommandResult publish = runGradle(repoRoot, ["--console=plain", "--no-daemon", "-Dmaven.repo.local=${mavenRepo}".toString()] + SNAPSHOT_PUBLISH_TASKS)
+        CommandResult build = runGradle(repoRoot, [
+            "--console=plain",
+            "--no-daemon",
+            "-p", sampleProject.toString(),
+            "test",
+            "--tests", "example.ExportSpec",
+            "-Dsample.repo=${mavenRepo.toUri()}".toString()
+        ])
+
+        then:
+        assert publish.exitCode == 0: publish.output
+        assert build.exitCode == 0: build.output
+        Files.exists(outputFile)
+
+        and:
+        def output = Files.readString(outputFile)
+        output.contains("#LocalDataSource: default")
+        output.contains("<jdbc-driver>org.postgresql.Driver</jdbc-driver>")
+        output.contains("<jdbc-url>jdbc:postgresql://")
+        output.contains("<user-name>test</user-name>")
+        output.contains("<password>test</password>")
+    }
+
+    private static void writeStandaloneProject(Path sampleProject,
+                                               Path outputFile,
+                                               String projectVersion,
+                                               String micronautPlatformVersion,
+                                               String micronautGradlePluginVersion) {
+        Files.createDirectories(sampleProject.resolve("src/test/groovy/example"))
+        Files.createDirectories(sampleProject.resolve("src/test/resources"))
+
+        Files.writeString(sampleProject.resolve("settings.gradle"), """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            rootProject.name = 'intellij-export-sample'
+            """.stripIndent())
+
+        Files.writeString(sampleProject.resolve("build.gradle"), """
+            import io.micronaut.gradle.testresources.StartTestResourcesService
+
+            plugins {
+                id 'groovy'
+                id 'io.micronaut.application' version '${micronautGradlePluginVersion}'
+                id 'io.micronaut.test-resources' version '${micronautGradlePluginVersion}'
+            }
+
+            repositories {
+                mavenCentral()
+                maven {
+                    url = uri(System.getProperty('sample.repo'))
+                }
+            }
+
+            micronaut {
+                version = '${micronautPlatformVersion}'
+                runtime('netty')
+                testRuntime('spock2')
+                processing {
+                    incremental true
+                    annotations 'example.*'
+                }
+                testResources {
+                    version = '${projectVersion}'
+                }
+            }
+
+            dependencies {
+                implementation 'io.micronaut:micronaut-runtime'
+                implementation 'io.micronaut.data:micronaut-data-jdbc'
+                implementation 'io.micronaut.sql:micronaut-jdbc-hikari'
+                runtimeOnly 'org.postgresql:postgresql'
+                runtimeOnly 'io.micronaut:micronaut-jackson-databind'
+                runtimeOnly 'org.yaml:snakeyaml'
+                testImplementation 'io.micronaut.test:micronaut-test-spock'
+                testImplementation 'org.apache.groovy:groovy'
+            }
+
+            test {
+                useJUnitPlatform()
+            }
+
+            tasks.withType(StartTestResourcesService).configureEach {
+                useClassDataSharing = false
+            }
+            """.stripIndent())
+
+        Files.writeString(sampleProject.resolve("src/test/resources/application-test.yml"), """
+            datasources:
+              default:
+                db-type: postgres
+                schema-generate: CREATE_DROP
+
+            test-resources:
+              intellij-idea:
+                enabled: true
+                output-path: ${outputFile}
+            """.stripIndent())
+
+        Files.writeString(sampleProject.resolve("src/test/groovy/example/ExportSpec.groovy"), """
+            package example
+
+            import io.micronaut.context.ApplicationContext
+            import io.micronaut.test.extensions.spock.annotation.MicronautTest
+            import jakarta.inject.Inject
+            import spock.lang.Specification
+
+            @MicronautTest(transactional = false)
+            class ExportSpec extends Specification {
+                @Inject
+                ApplicationContext applicationContext
+
+                void 'resolves datasource properties'() {
+                    expect:
+                    applicationContext.getRequiredProperty('datasources.default.url', String).startsWith('jdbc:postgresql://')
+                    applicationContext.getRequiredProperty('datasources.default.username', String)
+                    applicationContext.getRequiredProperty('datasources.default.password', String)
+                    applicationContext.getRequiredProperty('datasources.default.driver-class-name', String) == 'org.postgresql.Driver'
+                }
+            }
+            """.stripIndent())
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of("").toAbsolutePath().normalize()
+        while (current != null) {
+            if (Files.exists(current.resolve("settings.gradle")) && Files.exists(current.resolve("gradle.properties"))) {
+                return current
+            }
+            current = current.parent
+        }
+        throw new IllegalStateException("Unable to locate repository root from ${Path.of('').toAbsolutePath()}")
+    }
+
+    private static String propertyValue(Path file, String key) {
+        String pattern = "(?m)^" + Pattern.quote(key) + "=(.+)\$"
+        def matcher = Files.readString(file) =~ pattern
+        assert matcher.find(): "Unable to find ${key} in ${file}"
+        matcher.group(1).trim()
+    }
+
+    private static String versionCatalogValue(Path file, String key) {
+        String pattern = "(?m)^" + Pattern.quote(key) + "\\s*=\\s*\"([^\"]+)\""
+        def matcher = Files.readString(file) =~ pattern
+        assert matcher.find(): "Unable to find ${key} in ${file}"
+        matcher.group(1)
+    }
+
+    private static CommandResult runGradle(Path repoRoot, List<String> arguments) {
+        List<String> command = [repoRoot.resolve("gradlew").toString()] + arguments
+        Process process = new ProcessBuilder(command)
+            .directory(repoRoot.toFile())
+            .redirectErrorStream(true)
+            .start()
+        String output = process.inputStream.text
+        int exitCode = process.waitFor()
+        new CommandResult(exitCode, output)
+    }
+
+    private record CommandResult(int exitCode, String output) {
+    }
+}

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterStandaloneProjectTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterStandaloneProjectTest.groovy
@@ -33,7 +33,7 @@ class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification 
         String projectVersion = propertyValue(repoRoot.resolve("gradle.properties"), "projectVersion")
         String micronautPlatformVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-platform")
         String micronautGradlePluginVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-gradle-plugin")
-        writeStandaloneProject(sampleProject, outputFile, projectVersion, micronautPlatformVersion, micronautGradlePluginVersion)
+        writeStandaloneProject(sampleProject, "intellij-export-sample", outputFile, projectVersion, micronautPlatformVersion, micronautGradlePluginVersion)
 
         when:
         CommandResult publish = runGradle(repoRoot, ["--console=plain", "--no-daemon", "-Dmaven.repo.local=${mavenRepo}".toString()] + SNAPSHOT_PUBLISH_TASKS)
@@ -60,7 +60,63 @@ class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification 
         output.contains("<password>test</password>")
     }
 
+    def "standalone Gradle daemon reuse writes the default IntelliJ IDEA export into the current project"() {
+        given:
+        Path repoRoot = findRepositoryRoot()
+        Path mavenRepo = tempDir.resolve("maven-repo")
+        Path gradleUserHome = tempDir.resolve("gradle-user-home")
+        Path firstProject = tempDir.resolve("first-project")
+        Path secondProject = tempDir.resolve("second-project")
+        Path firstOutput = firstProject.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+        Path secondOutput = secondProject.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+        String projectVersion = propertyValue(repoRoot.resolve("gradle.properties"), "projectVersion")
+        String micronautPlatformVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-platform")
+        String micronautGradlePluginVersion = versionCatalogValue(repoRoot.resolve("gradle/libs.versions.toml"), "micronaut-gradle-plugin")
+        writeStandaloneProject(firstProject, "intellij-export-first", null, projectVersion, micronautPlatformVersion, micronautGradlePluginVersion)
+        writeStandaloneProject(secondProject, "intellij-export-second", null, projectVersion, micronautPlatformVersion, micronautGradlePluginVersion)
+
+        when:
+        CommandResult publish = runGradle(repoRoot, ["--console=plain", "--no-daemon", "-Dmaven.repo.local=${mavenRepo}".toString()] + SNAPSHOT_PUBLISH_TASKS)
+        CommandResult firstBuild = runGradle(repoRoot, [
+            "--console=plain",
+            "--gradle-user-home", gradleUserHome.toString(),
+            "-p", firstProject.toString(),
+            "test",
+            "--tests", "example.ExportSpec",
+            "-Dsample.repo=${mavenRepo.toUri()}".toString()
+        ])
+
+        then:
+        assert publish.exitCode == 0: publish.output
+        assert firstBuild.exitCode == 0: firstBuild.output
+        Files.exists(firstOutput)
+        !Files.exists(secondOutput)
+
+        when:
+        Files.delete(firstOutput)
+        CommandResult secondBuild = runGradle(repoRoot, [
+            "--console=plain",
+            "--gradle-user-home", gradleUserHome.toString(),
+            "-p", secondProject.toString(),
+            "test",
+            "--tests", "example.ExportSpec",
+            "-Dsample.repo=${mavenRepo.toUri()}".toString()
+        ])
+
+        then:
+        assert secondBuild.exitCode == 0: secondBuild.output
+        !Files.exists(firstOutput)
+        Files.exists(secondOutput)
+
+        and:
+        def output = Files.readString(secondOutput)
+        output.contains("#LocalDataSource: default")
+        output.contains("<jdbc-driver>org.postgresql.Driver</jdbc-driver>")
+        output.contains("<jdbc-url>jdbc:postgresql://")
+    }
+
     private static void writeStandaloneProject(Path sampleProject,
+                                               String projectName,
                                                Path outputFile,
                                                String projectVersion,
                                                String micronautPlatformVersion,
@@ -76,7 +132,7 @@ class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification 
                 }
             }
 
-            rootProject.name = 'intellij-export-sample'
+            rootProject.name = '${projectName}'
             """.stripIndent())
 
         Files.writeString(sampleProject.resolve("build.gradle"), """
@@ -128,7 +184,16 @@ class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification 
             }
             """.stripIndent())
 
-        Files.writeString(sampleProject.resolve("src/test/resources/application-test.yml"), """
+        String applicationConfig = outputFile == null ? """
+            datasources:
+              default:
+                db-type: postgres
+                schema-generate: CREATE_DROP
+
+            test-resources:
+              intellij-idea:
+                enabled: true
+            """.stripIndent() : """
             datasources:
               default:
                 db-type: postgres
@@ -138,7 +203,9 @@ class IntellijIdeaDatasourceExporterStandaloneProjectTest extends Specification 
               intellij-idea:
                 enabled: true
                 output-path: ${outputFile}
-            """.stripIndent())
+            """.stripIndent()
+
+        Files.writeString(sampleProject.resolve("src/test/resources/application-test.yml"), applicationConfig)
 
         Files.writeString(sampleProject.resolve("src/test/groovy/example/ExportSpec.groovy"), """
             package example

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
@@ -7,6 +7,7 @@ import spock.util.environment.RestoreSystemProperties
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.charset.StandardCharsets
+import java.util.Locale
 import java.util.UUID
 
 class IntellijIdeaDatasourceExporterTest extends Specification {
@@ -108,6 +109,29 @@ class IntellijIdeaDatasourceExporterTest extends Specification {
         then:
         Files.exists(outputFile)
         !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+    }
+
+    @RestoreSystemProperties
+    def "driver detection uses a locale-stable lowercasing strategy"() {
+        given:
+        Locale defaultLocale = Locale.default
+        Locale.setDefault(Locale.forLanguageTag("tr"))
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+
+        when:
+        exporter.export("datasources.default.url", "JDBC:MARIADB://localhost:3306/demo", config)
+        exporter.export("datasources.default.username", "demo_user", config)
+        exporter.export("datasources.default.password", "demo_secret", config)
+        exporter.export("datasources.default.driver-class-name", "ORG.MARIADB.JDBC.DRIVER", config)
+
+        then:
+        def output = Files.readString(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+        output.contains('<driver-ref>mariadb</driver-ref>')
+        output.contains('dbms="MARIADB"')
+
+        cleanup:
+        Locale.setDefault(defaultLocale)
     }
 
     def "overlapping sessions sharing an output path merge and rewrite live datasource state"() {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
@@ -146,6 +146,47 @@ class IntellijIdeaDatasourceExporterTest extends Specification {
         !Files.exists(outputFile)
     }
 
+    def "overlapping sessions sharing an output path preserve same-name datasources"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+        def outputFile = tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/first", config, "first")
+        exporter.export("datasources.default.username", "first_user", config, "first")
+        exporter.export("datasources.default.password", "first_secret", config, "first")
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config, "first")
+        exporter.export("datasources.default.url", "jdbc:mysql://localhost:3306/second", config, "second")
+        exporter.export("datasources.default.username", "second_user", config, "second")
+        exporter.export("datasources.default.password", "second_secret", config, "second")
+        exporter.export("datasources.default.driver-class-name", "com.mysql.cj.jdbc.Driver", config, "second")
+
+        then:
+        def combinedOutput = Files.readString(outputFile)
+        combinedOutput.contains("#LocalDataSource: default\n")
+        combinedOutput.contains("#LocalDataSource: default (2)\n")
+        combinedOutput.contains("<jdbc-url>jdbc:postgresql://localhost:5432/first</jdbc-url>")
+        combinedOutput.contains("<jdbc-url>jdbc:mysql://localhost:3306/second</jdbc-url>")
+        combinedOutput.readLines().count { it == "#BEGIN#" } == 2
+
+        when:
+        exporter.clearSession("first")
+
+        then:
+        def secondOnlyOutput = Files.readString(outputFile)
+        secondOnlyOutput.contains("#LocalDataSource: default\n")
+        !secondOnlyOutput.contains("#LocalDataSource: default (2)\n")
+        secondOnlyOutput.contains("<jdbc-url>jdbc:mysql://localhost:3306/second</jdbc-url>")
+        !secondOnlyOutput.contains("<jdbc-url>jdbc:postgresql://localhost:5432/first</jdbc-url>")
+
+        when:
+        exporter.clearSession("second")
+
+        then:
+        !Files.exists(outputFile)
+    }
+
     @RestoreSystemProperties
     def "system properties can enable the exporter"() {
         given:

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
@@ -1,0 +1,129 @@
+package io.micronaut.testresources.client
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.environment.RestoreSystemProperties
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+class IntellijIdeaDatasourceExporterTest extends Specification {
+    @TempDir
+    Path tempDir
+
+    def "exporter stays disabled by default"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", [:])
+        exporter.export("datasources.default.username", "user", [:])
+        exporter.export("datasources.default.password", "secret", [:])
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", [:])
+
+        then:
+        !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+    }
+
+    def "exporter uses the micronaut test-resources convention by default"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config)
+        exporter.export("datasources.default.username", "user", config)
+        exporter.export("datasources.default.password", "secret", config)
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config)
+
+        then:
+        Files.exists(tempDir.resolve(".micronaut/test-resources/intellij-idea-datasources.xml"))
+    }
+
+    def "exporter writes deterministic output for multiple datasources"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+
+        when:
+        exporter.export("datasources.analytics.url", "jdbc:mysql://127.0.0.1:3306/analytics", config)
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config)
+        exporter.export("datasources.analytics.username", "analytics_user", config)
+        exporter.export("datasources.default.username", "demo_user", config)
+        exporter.export("datasources.analytics.password", "analytics_secret", config)
+        exporter.export("datasources.default.password", "demo_secret", config)
+        exporter.export("datasources.analytics.driver-class-name", "com.mysql.cj.jdbc.Driver", config)
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config)
+
+        then:
+        def outputFile = tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+        Files.exists(outputFile)
+
+        and:
+        def output = Files.readString(outputFile)
+        def analyticsUuid = UUID.nameUUIDFromBytes("intellij-idea-datasource:analytics".getBytes(StandardCharsets.UTF_8))
+        def defaultUuid = UUID.nameUUIDFromBytes("intellij-idea-datasource:default".getBytes(StandardCharsets.UTF_8))
+        output == """#DataSourceSettings#
+#LocalDataSource: analytics
+#BEGIN#
+<data-source source="LOCAL" name="analytics" uuid="${analyticsUuid}"><database-info product="" version="" jdbc-version="" driver-name="" driver-version="" dbms="MYSQL"/><driver-ref>mysql</driver-ref><synchronize>true</synchronize><jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver><jdbc-url>jdbc:mysql://127.0.0.1:3306/analytics</jdbc-url><user-name>analytics_user</user-name><password>analytics_secret</password><working-dir>\$ProjectFileDir\$</working-dir></data-source>
+#END#
+#LocalDataSource: default
+#BEGIN#
+<data-source source="LOCAL" name="default" uuid="${defaultUuid}"><database-info product="" version="" jdbc-version="" driver-name="" driver-version="" dbms="POSTGRES"/><driver-ref>postgresql</driver-ref><synchronize>true</synchronize><jdbc-driver>org.postgresql.Driver</jdbc-driver><jdbc-url>jdbc:postgresql://localhost:5432/demo</jdbc-url><user-name>demo_user</user-name><password>demo_secret</password><working-dir>\$ProjectFileDir\$</working-dir></data-source>
+#END#
+"""
+    }
+
+    def "partial property resolution does not create malformed output"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config)
+        exporter.export("datasources.default.username", "demo_user", config)
+
+        then:
+        !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+    }
+
+    def "configured output path overrides the default"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def outputFile = tempDir.resolve("custom/idea-export.xml")
+        def config = [
+            (IntellijIdeaDatasourceExporter.ENABLED): true,
+            (IntellijIdeaDatasourceExporter.OUTPUT_PATH): "custom/idea-export.xml"
+        ]
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config)
+        exporter.export("datasources.default.username", "demo_user", config)
+        exporter.export("datasources.default.password", "demo_secret", config)
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config)
+
+        then:
+        Files.exists(outputFile)
+        !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+    }
+
+    @RestoreSystemProperties
+    def "system properties can enable the exporter"() {
+        given:
+        System.setProperty("micronaut.test.resources.${IntellijIdeaDatasourceExporter.ENABLED}".toString(), "true")
+        System.setProperty("micronaut.test.resources.${IntellijIdeaDatasourceExporter.OUTPUT_PATH}".toString(), "system/idea-export.xml")
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", [:])
+        exporter.export("datasources.default.username", "demo_user", [:])
+        exporter.export("datasources.default.password", "demo_secret", [:])
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", [:])
+
+        then:
+        Files.exists(tempDir.resolve("system/idea-export.xml"))
+    }
+}

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
@@ -110,6 +110,42 @@ class IntellijIdeaDatasourceExporterTest extends Specification {
         !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
     }
 
+    def "overlapping sessions sharing an output path merge and rewrite live datasource state"() {
+        given:
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+        def outputFile = tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config, "first")
+        exporter.export("datasources.default.username", "demo_user", config, "first")
+        exporter.export("datasources.default.password", "demo_secret", config, "first")
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config, "first")
+        exporter.export("datasources.analytics.url", "jdbc:mysql://localhost:3306/analytics", config, "second")
+        exporter.export("datasources.analytics.username", "analytics_user", config, "second")
+        exporter.export("datasources.analytics.password", "analytics_secret", config, "second")
+        exporter.export("datasources.analytics.driver-class-name", "com.mysql.cj.jdbc.Driver", config, "second")
+
+        then:
+        def combinedOutput = Files.readString(outputFile)
+        combinedOutput.contains("#LocalDataSource: default")
+        combinedOutput.contains("#LocalDataSource: analytics")
+
+        when:
+        exporter.clearSession("second")
+
+        then:
+        def firstOnlyOutput = Files.readString(outputFile)
+        firstOnlyOutput.contains("#LocalDataSource: default")
+        !firstOnlyOutput.contains("#LocalDataSource: analytics")
+
+        when:
+        exporter.clearSession("first")
+
+        then:
+        !Files.exists(outputFile)
+    }
+
     @RestoreSystemProperties
     def "system properties can enable the exporter"() {
         given:

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/IntellijIdeaDatasourceExporterTest.groovy
@@ -112,6 +112,26 @@ class IntellijIdeaDatasourceExporterTest extends Specification {
     }
 
     @RestoreSystemProperties
+    def "project path system property overrides the default export base"() {
+        given:
+        def otherProjectDir = tempDir.resolve("other-project")
+        Files.createDirectories(otherProjectDir)
+        System.setProperty("micronaut.test.resources.${IntellijIdeaDatasourceExporter.PROJECT_PATH_URI}".toString(), otherProjectDir.toUri().toString())
+        def exporter = new IntellijIdeaDatasourceExporter(tempDir)
+        def config = [(IntellijIdeaDatasourceExporter.ENABLED): true]
+
+        when:
+        exporter.export("datasources.default.url", "jdbc:postgresql://localhost:5432/demo", config)
+        exporter.export("datasources.default.username", "demo_user", config)
+        exporter.export("datasources.default.password", "demo_secret", config)
+        exporter.export("datasources.default.driver-class-name", "org.postgresql.Driver", config)
+
+        then:
+        Files.exists(otherProjectDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+        !Files.exists(tempDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH))
+    }
+
+    @RestoreSystemProperties
     def "driver detection uses a locale-stable lowercasing strategy"() {
         given:
         Locale defaultLocale = Locale.default

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 import spock.util.environment.RestoreSystemProperties
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 import static io.micronaut.testresources.client.ConfigFinder.systemPropertyNameOf
@@ -50,13 +51,101 @@ class TestResourcesClientTest extends Specification implements ClientCleanup {
         e.message == "Test resources service wasn't able to revolve expression 'throws': Something bad happened"
     }
 
-    private ApplicationContext createApplication() {
+    @RestoreSystemProperties
+    def "writes IntelliJ IDEA datasource export when enabled"() {
+        given:
+        def outputFile = tempDir.resolve("generated/intellij-idea-datasources.xml")
+        def app = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': outputFile.toString()
+        ])
+
+        when:
+        def defaultUrl = app.getRequiredProperty("datasources.default.url", String)
+        def defaultUser = app.getRequiredProperty("datasources.default.username", String)
+        def defaultPassword = app.getRequiredProperty("datasources.default.password", String)
+        def defaultDriver = app.getRequiredProperty("datasources.default.driver-class-name", String)
+        def analyticsUrl = app.getRequiredProperty("datasources.analytics.url", String)
+        def analyticsUser = app.getRequiredProperty("datasources.analytics.username", String)
+        def analyticsPassword = app.getRequiredProperty("datasources.analytics.password", String)
+        def analyticsDriver = app.getRequiredProperty("datasources.analytics.driver-class-name", String)
+
+        then:
+        defaultUrl == "jdbc:postgresql://localhost:15432/demo"
+        defaultUser == "demo_user"
+        defaultPassword == "demo_secret"
+        defaultDriver == "org.postgresql.Driver"
+        analyticsUrl == "jdbc:mysql://localhost:13306/analytics"
+        analyticsUser == "analytics_user"
+        analyticsPassword == "analytics_secret"
+        analyticsDriver == "com.mysql.cj.jdbc.Driver"
+        Files.exists(outputFile)
+
+        and:
+        def output = Files.readString(outputFile)
+        output.contains("#LocalDataSource: default")
+        output.contains("#LocalDataSource: analytics")
+        output.contains("<password>demo_secret</password>")
+        output.contains("<password>analytics_secret</password>")
+    }
+
+    @RestoreSystemProperties
+    def "overlapping application contexts isolate IntelliJ IDEA exporter state when reusing the cached client"() {
+        given:
+        def firstOutput = tempDir.resolve("generated/first/intellij-idea-datasources.xml")
+        def secondOutput = tempDir.resolve("generated/second/intellij-idea-datasources.xml")
+        def firstApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': firstOutput.toString()
+        ])
+        def secondApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': secondOutput.toString()
+        ])
+
+        when:
+        firstApp.getRequiredProperty("datasources.default.url", String)
+        firstApp.getRequiredProperty("datasources.default.username", String)
+        def cachedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+        resolveDatasource(secondApp, "analytics")
+        firstApp.getRequiredProperty("datasources.default.password", String)
+        firstApp.getRequiredProperty("datasources.default.driver-class-name", String)
+        def reusedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+
+        then:
+        reusedClient.is(cachedClient)
+        Files.exists(firstOutput)
+        Files.exists(secondOutput)
+
+        and:
+        def firstExport = Files.readString(firstOutput)
+        firstExport.contains("#LocalDataSource: default")
+        !firstExport.contains("#LocalDataSource: analytics")
+
+        and:
+        def secondExport = Files.readString(secondOutput)
+        secondExport.contains("#LocalDataSource: analytics")
+        !secondExport.contains("#LocalDataSource: default")
+
+        cleanup:
+        secondApp?.close()
+        firstApp?.close()
+    }
+
+    private ApplicationContext createApplication(Map<String, Object> properties = [:]) {
         System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), server.getURI().toString())
         def app = ApplicationContext.builder()
-                .properties(['server': 'false'])
+                .properties(['server': 'false'] + properties)
                 .start()
         assert !app.findBean(TestServer).present
         return app
+    }
+
+    private static void resolveDatasource(ApplicationContext app, String name) {
+        app.getRequiredProperty("datasources.${name}.url".toString(), String)
+        app.getRequiredProperty("datasources.${name}.username".toString(), String)
+        app.getRequiredProperty("datasources.${name}.password".toString(), String)
+        app.getRequiredProperty("datasources.${name}.driver-class-name".toString(), String)
     }
 
 }

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
@@ -199,6 +199,41 @@ class TestResourcesClientTest extends Specification implements ClientCleanup {
         firstApp?.close()
     }
 
+    @RestoreSystemProperties
+    def "cached client uses the current project path for the default IntelliJ IDEA export location"() {
+        given:
+        def firstProjectDir = tempDir.resolve("first-project")
+        def secondProjectDir = tempDir.resolve("second-project")
+        Files.createDirectories(firstProjectDir)
+        Files.createDirectories(secondProjectDir)
+        def firstOutput = firstProjectDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+        def secondOutput = secondProjectDir.resolve(IntellijIdeaDatasourceExporter.DEFAULT_OUTPUT_PATH)
+        System.setProperty(systemPropertyNameOf(IntellijIdeaDatasourceExporter.PROJECT_PATH_URI), firstProjectDir.toUri().toString())
+        def firstApp = createApplication([
+            'test-resources.intellij-idea.enabled': 'true'
+        ])
+
+        when:
+        resolveDatasource(firstApp, "default")
+        def cachedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+        Files.deleteIfExists(firstOutput)
+        System.setProperty(systemPropertyNameOf(IntellijIdeaDatasourceExporter.PROJECT_PATH_URI), secondProjectDir.toUri().toString())
+        def secondApp = createApplication([
+            'test-resources.intellij-idea.enabled': 'true'
+        ])
+        resolveDatasource(secondApp, "default")
+        def reusedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+
+        then:
+        reusedClient.is(cachedClient)
+        !Files.exists(firstOutput)
+        Files.exists(secondOutput)
+
+        cleanup:
+        secondApp?.close()
+        firstApp?.close()
+    }
+
     private ApplicationContext createApplication(Map<String, Object> properties = [:]) {
         System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), server.getURI().toString())
         def app = ApplicationContext.builder()

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
@@ -132,6 +132,39 @@ class TestResourcesClientTest extends Specification implements ClientCleanup {
         firstApp?.close()
     }
 
+    @RestoreSystemProperties
+    def "overlapping application contexts sharing an IntelliJ IDEA output path merge live datasource exports"() {
+        given:
+        def sharedOutput = tempDir.resolve("generated/shared/intellij-idea-datasources.xml")
+        def firstApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': sharedOutput.toString()
+        ])
+        def secondApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': sharedOutput.toString()
+        ])
+
+        when:
+        resolveDatasource(firstApp, "default")
+        def cachedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+        resolveDatasource(secondApp, "analytics")
+        def reusedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+
+        then:
+        reusedClient.is(cachedClient)
+        Files.exists(sharedOutput)
+
+        and:
+        def combinedExport = Files.readString(sharedOutput)
+        combinedExport.contains("#LocalDataSource: default")
+        combinedExport.contains("#LocalDataSource: analytics")
+
+        cleanup:
+        secondApp?.close()
+        firstApp?.close()
+    }
+
     private ApplicationContext createApplication(Map<String, Object> properties = [:]) {
         System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), server.getURI().toString())
         def app = ApplicationContext.builder()

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
@@ -48,7 +48,7 @@ class TestResourcesClientTest extends Specification implements ClientCleanup {
 
         then:
         TestResourcesException e = thrown()
-        e.message == "Test resources service wasn't able to revolve expression 'throws': Something bad happened"
+        e.message == "Test resources service wasn't able to resolve expression 'throws': Something bad happened"
     }
 
     @RestoreSystemProperties

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientTest.groovy
@@ -165,6 +165,40 @@ class TestResourcesClientTest extends Specification implements ClientCleanup {
         firstApp?.close()
     }
 
+    @RestoreSystemProperties
+    def "overlapping application contexts sharing an IntelliJ IDEA output path preserve same-name datasource exports"() {
+        given:
+        def sharedOutput = tempDir.resolve("generated/shared-default/intellij-idea-datasources.xml")
+        def firstApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': sharedOutput.toString()
+        ])
+        def secondApp = createApplication([
+            'test-resources.intellij-idea.enabled'    : 'true',
+            'test-resources.intellij-idea.output-path': sharedOutput.toString()
+        ])
+
+        when:
+        resolveDatasource(firstApp, "default")
+        def cachedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+        resolveDatasource(secondApp, "default")
+        def reusedClient = TestResourcesClientFactory.fromSystemProperties().orElseThrow()
+
+        then:
+        reusedClient.is(cachedClient)
+        Files.exists(sharedOutput)
+
+        and:
+        def combinedExport = Files.readString(sharedOutput)
+        combinedExport.contains("#LocalDataSource: default\n")
+        combinedExport.contains("#LocalDataSource: default (2)\n")
+        combinedExport.readLines().count { it == "#BEGIN#" } == 2
+
+        cleanup:
+        secondApp?.close()
+        firstApp?.close()
+    }
+
     private ApplicationContext createApplication(Map<String, Object> properties = [:]) {
         System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), server.getURI().toString())
         def app = ApplicationContext.builder()

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestServer.groovy
@@ -13,7 +13,20 @@ class TestServer implements TestResourcesResolver {
     @Override
     @Post("/list")
     List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        ["dummy1", "dummy2", "missing", "throws"]
+        [
+            "dummy1",
+            "dummy2",
+            "missing",
+            "throws",
+            "datasources.default.url",
+            "datasources.default.username",
+            "datasources.default.password",
+            "datasources.default.driver-class-name",
+            "datasources.analytics.url",
+            "datasources.analytics.username",
+            "datasources.analytics.password",
+            "datasources.analytics.driver-class-name"
+        ]
     }
 
     @Override
@@ -36,6 +49,30 @@ class TestServer implements TestResourcesResolver {
         }
         if ("throws" == name) {
             throw new RuntimeException("Something bad happened")
+        }
+        if ("datasources.default.url" == name) {
+            return Optional.of("jdbc:postgresql://localhost:15432/demo")
+        }
+        if ("datasources.default.username" == name) {
+            return Optional.of("demo_user")
+        }
+        if ("datasources.default.password" == name) {
+            return Optional.of("demo_secret")
+        }
+        if ("datasources.default.driver-class-name" == name) {
+            return Optional.of("org.postgresql.Driver")
+        }
+        if ("datasources.analytics.url" == name) {
+            return Optional.of("jdbc:mysql://localhost:13306/analytics")
+        }
+        if ("datasources.analytics.username" == name) {
+            return Optional.of("analytics_user")
+        }
+        if ("datasources.analytics.password" == name) {
+            return Optional.of("analytics_secret")
+        }
+        if ("datasources.analytics.driver-class-name" == name) {
+            return Optional.of("com.mysql.cj.jdbc.Driver")
         }
         Optional.of("value for $name".toString())
     }


### PR DESCRIPTION
## Summary
- add opt-in IntelliJ IDEA/DataGrip datasource export generation for resolved JDBC test resources
- keep exporter state scoped across overlapping cached-client sessions, including shared output paths and same-name collisions
- document the `.micronaut/test-resources/` default export path and add focused exporter/client regressions

## Verification
- `./gradlew :micronaut-test-resources-client:test --tests '*IntellijIdeaDatasourceExporterTest' --tests '*TestResourcesClientTest'`
- `./gradlew :micronaut-test-resources-client:check publishGuide`

Fixes #635

---
###### ✨ This message was AI-generated using gpt-5.4
