### PR TITLE
Turn off CDS logging

### DIFF
--- a/test-resources-build-tools/build.gradle
+++ b/test-resources-build-tools/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.groovy)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(libs.spock)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)
     embeddedDependencies(project(path: ":micronaut-test-resources-server", configuration: "embeddedDependencies"))
 }

--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -78,6 +78,7 @@ public class ServerUtils {
     private static final String CDS_HASH = "cds.bin";
     private static final String CDS_FILE = "cds.jsa";
     private static final String CDS_CLASS_LST = "cds.classlist";
+    private static final String CDS_LOGGING_OFF = "-Xlog:cds*=off";
     private static final String FLAT_JAR = "flat.jar";
 
     // See io.micronaut.testresources.testcontainers.DockerSupport.TIMEOUT
@@ -615,6 +616,7 @@ public class ServerUtils {
                                          File cdsFile,
                                          File cdsClassList,
                                          File cdsHashFile) {
+            jvmArguments.add(CDS_LOGGING_OFF);
             if (cdsClassList.exists()) {
                 try {
                     byte[] actualHash = computeClasspathHash(getClasspath().stream());

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -179,6 +179,7 @@ class ServerUtilsTest extends Specification {
         def cdsClassList = cdsDir.resolve("cds.classlist")
         def cdsArchiveFile = cdsDir.resolve("cds.jsa")
         def cdsFlatJar = cdsDir.resolve("flat.jar")
+        def cdsLoggingOffOption = "-Xlog:cds*=off"
         String cdsClassListOption = "-XX:DumpLoadedClassList=${cdsClassList.toAbsolutePath()}"
         String cdsSharedClassListOption = "-XX:SharedClassListFile=${cdsClassList.toAbsolutePath()}"
         String cdsSharedArchiveFileOption = "-XX:SharedArchiveFile=${cdsArchiveFile.toAbsolutePath()}"
@@ -193,6 +194,7 @@ class ServerUtilsTest extends Specification {
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             def jvmArgs = params.jvmArguments
+            assert jvmArgs.contains(cdsLoggingOffOption)
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
             assert params.classpath.contains(cdsFlatJar.toFile())
@@ -210,6 +212,7 @@ class ServerUtilsTest extends Specification {
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             def jvmArgs = params.jvmArguments
+            assert jvmArgs.contains(cdsLoggingOffOption)
             assert jvmArgs.contains("-Xshare:dump")
             assert jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
@@ -217,6 +220,7 @@ class ServerUtilsTest extends Specification {
         }
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             def jvmArgs = params.jvmArguments
+            assert jvmArgs.contains(cdsLoggingOffOption)
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
@@ -233,6 +237,7 @@ class ServerUtilsTest extends Specification {
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             def jvmArgs = params.jvmArguments
+            assert jvmArgs.contains(cdsLoggingOffOption)
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
@@ -249,6 +254,7 @@ class ServerUtilsTest extends Specification {
         then:
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             def jvmArgs = params.jvmArguments
+            assert jvmArgs.contains(cdsLoggingOffOption)
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
             assert params.classpath == []


### PR DESCRIPTION
## Summary

- suppress CDS unified logging for the forked Test Resources service with `-Xlog:cds*=off`
- keep the existing CDS startup optimization paths intact
- extend `ServerUtilsTest` to cover export, dump, and steady-state CDS launches

## Testing

- `./gradlew :micronaut-test-resources-build-tools:test --tests io.micronaut.testresources.buildtools.ServerUtilsTest`

## Release Tracking

- QA selected Micronaut organization project `5.0.0 Release` as the best-fit board for this PR.
- Ambiguity note preserved from QA intake: `5.0.0-M3` is also open/public, but there is no later-stage evidence that justifies changing the release-board choice.

Closes #543

---
###### ✨ This message was AI-generated using gpt-5.4
