### PR TITLE
Support shared containers across multiple databases

### DIFF
--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -13,11 +13,46 @@ In order for the database to be properly detected, _one of_ the following proper
 - `datasources.*.db-type`: the kind of database (preferred, one of `h2`, `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 
+<<<<<<< HEAD
 Most JDBC databases are started via Testcontainers, so `datasources.*.driver-class-name` should usually be left empty because the JDBC driver from Testcontainers has to be used for URIs like `jdbc:tc:postgres:14:///db`.
 H2 is the exception: it is supported in JDBC mode only, starts a containerless loopback-only in-memory TCP server, and automatically resolves `org.h2.Driver`.
 Shared or remote H2 test resources are not supported at this time, so the H2 resolver stays disabled when `micronaut.test.resources.server.uri` is configured.
 
 H2 support in this module is currently limited to JDBC test resources. R2DBC and Hibernate Reactive H2 support are out of scope for this feature.
+
+To opt multiple logical JDBC datasources into the same physical test resource, set `datasources.<name>.test-resources.resource-name` to the same value on each datasource:
+
+[configuration]
+----
+datasources:
+  read:
+    dialect: POSTGRES
+    test-resources:
+      resource-name: main-db
+  write:
+    dialect: POSTGRES
+    test-resources:
+      resource-name: main-db
+----
+
+If those datasources also declare different `datasources.<name>.db-name` values, Micronaut Test Resources will create separate databases on the shared PostgreSQL, MySQL, or MariaDB container and return datasource-specific URLs:
+
+[configuration]
+----
+datasources:
+  read:
+    dialect: POSTGRES
+    db-name: read_db
+    test-resources:
+      resource-name: main-db
+  write:
+    dialect: POSTGRES
+    db-name: write_db
+    test-resources:
+      resource-name: main-db
+----
+
+For other engines, `test-resources.resource-name` still controls physical container reuse, but engine-specific multi-database bootstrap is only enabled where it is currently supported.
 
 Micronaut Test Resources can also generate an IntelliJ IDEA/DataGrip datasource export file for resolved JDBC datasources.
 The export is opt-in and disabled by default.

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -13,7 +13,6 @@ In order for the database to be properly detected, _one of_ the following proper
 - `datasources.*.db-type`: the kind of database (preferred, one of `h2`, `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 
-<<<<<<< HEAD
 Most JDBC databases are started via Testcontainers, so `datasources.*.driver-class-name` should usually be left empty because the JDBC driver from Testcontainers has to be used for URIs like `jdbc:tc:postgres:14:///db`.
 H2 is the exception: it is supported in JDBC mode only, starts a containerless loopback-only in-memory TCP server, and automatically resolves `org.h2.Driver`.
 Shared or remote H2 test resources are not supported at this time, so the H2 resolver stays disabled when `micronaut.test.resources.server.uri` is configured.

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -51,7 +51,7 @@ datasources:
       resource-name: main-db
 ----
 
-For other engines, `test-resources.resource-name` still controls physical container reuse, but engine-specific multi-database bootstrap is only enabled where it is currently supported.
+For other engines, `datasources.<name>.test-resources.resource-name` still controls physical container reuse, but engine-specific multi-database bootstrap is only enabled where it is currently supported.
 
 Micronaut Test Resources can also generate an IntelliJ IDEA/DataGrip datasource export file for resolved JDBC datasources.
 The export is opt-in and disabled by default.

--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -24,3 +24,24 @@ In addition, R2DBC databases can be configured simply by reading the traditional
 
 In which case, the name of the datasource must match the name of the R2DBC datasource.
 This can be useful when using modules like Flyway which only support JDBC for updating schemas, but still have your application use R2DBC: in this case the container which will be used for R2DBC and JDBC will be the same.
+
+If the logical datasource names differ, you can still opt JDBC and R2DBC into the same physical test resource by setting `test-resources.resource-name` on both sides:
+
+[configuration]
+----
+datasources:
+  migrations:
+    dialect: POSTGRES
+    db-name: migrations_db
+    test-resources:
+      resource-name: main-db
+r2dbc:
+  datasources:
+    default:
+      dialect: POSTGRES
+      db-name: default_db
+      test-resources:
+        resource-name: main-db
+----
+
+The same property can also be shared by multiple R2DBC datasources to reuse one physical container. When PostgreSQL, MySQL, or MariaDB datasources also declare distinct `db-name` values, Micronaut Test Resources creates those databases on the shared container and returns datasource-specific R2DBC URLs. For other engines, `test-resources.resource-name` still only controls container identity.

--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -25,7 +25,7 @@ In addition, R2DBC databases can be configured simply by reading the traditional
 In which case, the name of the datasource must match the name of the R2DBC datasource.
 This can be useful when using modules like Flyway which only support JDBC for updating schemas, but still have your application use R2DBC: in this case the container which will be used for R2DBC and JDBC will be the same.
 
-If the logical datasource names differ, you can still opt JDBC and R2DBC into the same physical test resource by setting `test-resources.resource-name` on both sides:
+If the logical datasource names differ, you can still opt JDBC and R2DBC into the same physical test resource by setting `datasources.<name>.test-resources.resource-name` and `r2dbc.datasources.<name>.test-resources.resource-name` to the same value:
 
 [configuration]
 ----
@@ -44,4 +44,4 @@ r2dbc:
         resource-name: main-db
 ----
 
-The same property can also be shared by multiple R2DBC datasources to reuse one physical container. When PostgreSQL, MySQL, or MariaDB datasources also declare distinct `db-name` values, Micronaut Test Resources creates those databases on the shared container and returns datasource-specific R2DBC URLs. For other engines, `test-resources.resource-name` still only controls container identity.
+The same property can also be shared by multiple R2DBC datasources to reuse one physical container. When PostgreSQL, MySQL, or MariaDB datasources also declare distinct `db-name` values, Micronaut Test Resources creates those databases on the shared container and returns datasource-specific R2DBC URLs. For other engines, `r2dbc.datasources.<name>.test-resources.resource-name` still only controls container identity.

--- a/src/main/docs/guide/modules-mongodb.adoc
+++ b/src/main/docs/guide/modules-mongodb.adoc
@@ -11,3 +11,5 @@ Alternatively, if you have multiple MongoDB servers declared in your configurati
 For example, if you have `mongodb.servers.users` and `mongodb.servers.books` defined, then the test resources service will supply the `mongodb.servers.users.uri` and `mondodb.servers.books.uri` properties.
 
 Note that in this case, a _single_ server is used, the value of `test-resources.containers.mongodb.db-name` is ignored, and the database name is set to the name of the database you declared (in this example, this would be respectively `users` and `books`).
+
+This existing multiplexing behavior is unchanged by `test-resources.resource-name`. MongoDB already reuses one physical server across named logical databases when you configure `mongodb.servers.*`.

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -264,3 +264,5 @@ test-resources:
 It's worth noting that such containers need to be declared on the <<#advanced-networking,same network>> in order to be able to communicate with each other.
 
 WARNING: Dependencies between containers **only work between generic containers**. It is not possible to create a dependency between a generic container and a container created with the other test resources resolvers. For example, you cannot add a dependency on a container which provides a MySQL database by adding a `depends-on: mysql`.
+
+Container-backed resolvers can distinguish between the logical consumer name and the physical test resource identity. When multiple consumers set the same `test-resources.resource-name`, Micronaut Test Resources can reuse one physical container for the same provider and scope. Supported database resolvers can also combine that shared resource name with per-datasource `db-name` values to create multiple databases on the same shared container. Without that opt-in property, each logical consumer keeps the default isolated behavior.

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -16,6 +16,7 @@
 package io.micronaut.testresources.jdbc;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import io.micronaut.testresources.testcontainers.TestContainers;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.util.Collection;
@@ -33,6 +34,7 @@ import java.util.stream.Stream;
  */
 public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseContainer<? extends T>> extends AbstractTestContainersProvider<T> {
     public static final String PREFIX = "datasources";
+    public static final String RESOURCE_NAME = "test-resources.resource-name";
     private static final String URL = "url";
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
@@ -74,7 +76,9 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         String datasource = datasourceNameFrom(expression);
         return Stream.of(
                 datasourceExpressionOf(datasource, TYPE),
-                datasourceExpressionOf(datasource, DIALECT)
+                datasourceExpressionOf(datasource, DIALECT),
+                datasourceExpressionOf(datasource, DB_NAME),
+                datasourceExpressionOf(datasource, RESOURCE_NAME)
             ).toList();
     }
 
@@ -94,14 +98,55 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
 
     @Override
     protected Optional<String> resolveProperty(String expression, T container) {
+        return resolveProperty(expression, container, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String expression,
+                                               T container,
+                                               Map<String, Object> properties,
+                                               Map<String, Object> testResourcesConfig) {
         String value = switch (datasourcePropertyFrom(expression)) {
-            case URL -> container.getJdbcUrl();
+            case URL -> resolveJdbcUrl(expression, container, properties);
             case USERNAME -> container.getUsername();
             case PASSWORD -> container.getPassword();
             case DRIVER -> container.getDriverClassName();
-            default -> resolveDbSpecificProperty(expression, container);
+            default -> resolveDbSpecificProperty(expression, container, properties, testResourcesConfig);
         };
         return Optional.ofNullable(value);
+    }
+
+    @Override
+    protected String getContainerOwnerKey(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        if (supportsSharedContainerReuse(propertyName, properties)) {
+            return getSimpleName();
+        }
+        return super.getContainerOwnerKey(propertyName, properties, testResourcesConfig);
+    }
+
+    @Override
+    protected Map<String, Object> getContainerQuery(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        return supportsSharedContainerReuse(propertyName, properties) ? findSharedResourceName(propertyName, properties)
+            .<Map<String, Object>>map(name -> Map.of(RESOURCE_NAME, name))
+            .orElseGet(() -> super.getContainerQuery(propertyName, properties, testResourcesConfig)) : super.getContainerQuery(propertyName, properties, testResourcesConfig);
+    }
+
+    @Override
+    protected void prepareContainer(String propertyName,
+                                    T container,
+                                    Map<String, Object> properties,
+                                    Map<String, Object> testResourcesConfig) {
+        findRequestedDatabaseName(propertyName, properties)
+            .filter(databaseName -> supportsMultipleDatabases())
+            .filter(databaseName -> !databaseName.equals(container.getDatabaseName()))
+            .ifPresent(databaseName -> {
+                synchronized (container) {
+                    if (!TestContainers.hasDatabase(container, databaseName)) {
+                        createAdditionalDatabase(container, databaseName);
+                        TestContainers.rememberDatabase(container, databaseName);
+                    }
+                }
+            });
     }
 
     /**
@@ -114,6 +159,13 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
      */
     protected String resolveDbSpecificProperty(String propertyName, JdbcDatabaseContainer<?> container) {
         return null;
+    }
+
+    protected String resolveDbSpecificProperty(String propertyName,
+                                               JdbcDatabaseContainer<?> container,
+                                               Map<String, Object> properties,
+                                               Map<String, Object> testResourcesConfig) {
+        return resolveDbSpecificProperty(propertyName, container);
     }
 
     @Override
@@ -148,5 +200,44 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
 
     protected static String datasourceExpressionOf(String datasource, String property) {
         return PREFIX + "." + datasource + "." + property;
+    }
+
+    protected boolean supportsMultipleDatabases() {
+        return false;
+    }
+
+    protected void createAdditionalDatabase(T container, String databaseName) {
+        throw new UnsupportedOperationException("Additional database creation is not supported for " + getSimpleName());
+    }
+
+    protected String resolveJdbcUrl(String expression, T container, Map<String, Object> properties) {
+        return findRequestedDatabaseName(expression, properties)
+            .filter(databaseName -> supportsMultipleDatabases())
+            .map(databaseName -> jdbcUrlFor(container, databaseName))
+            .orElseGet(container::getJdbcUrl);
+    }
+
+    protected String jdbcUrlFor(T container, String databaseName) {
+        return container.getJdbcUrl();
+    }
+
+    protected Optional<String> findRequestedDatabaseName(String propertyName, Map<String, Object> requestedProperties) {
+        if (!isDatasourceExpression(propertyName)) {
+            return Optional.empty();
+        }
+        String datasource = datasourceNameFrom(propertyName);
+        return Optional.ofNullable(stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, DB_NAME))));
+    }
+
+    private Optional<String> findSharedResourceName(String propertyName, Map<String, Object> requestedProperties) {
+        if (!isDatasourceExpression(propertyName)) {
+            return Optional.empty();
+        }
+        String datasource = datasourceNameFrom(propertyName);
+        return Optional.ofNullable(stringOrNull(requestedProperties.get(datasourceExpressionOf(datasource, RESOURCE_NAME))));
+    }
+
+    private boolean supportsSharedContainerReuse(String propertyName, Map<String, Object> properties) {
+        return findSharedResourceName(propertyName, properties).isPresent();
     }
 }

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -136,6 +136,9 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
                                     T container,
                                     Map<String, Object> properties,
                                     Map<String, Object> testResourcesConfig) {
+        if (!URL.equals(datasourcePropertyFrom(propertyName))) {
+            return;
+        }
         findRequestedDatabaseName(propertyName, properties)
             .filter(databaseName -> supportsMultipleDatabases())
             .filter(databaseName -> !databaseName.equals(container.getDatabaseName()))

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -142,14 +142,11 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         findRequestedDatabaseName(propertyName, properties)
             .filter(databaseName -> supportsMultipleDatabases())
             .filter(databaseName -> !databaseName.equals(container.getDatabaseName()))
-            .ifPresent(databaseName -> {
-                synchronized (container) {
-                    if (!TestContainers.hasDatabase(container, databaseName)) {
-                        createAdditionalDatabase(container, databaseName);
-                        TestContainers.rememberDatabase(container, databaseName);
-                    }
-                }
-            });
+            .ifPresent(databaseName -> TestContainers.createDatabaseIfMissing(
+                container,
+                databaseName,
+                () -> createAdditionalDatabase(container, databaseName)
+            ));
     }
 
     /**

--- a/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-core/src/main/java/io/micronaut/testresources/jdbc/AbstractJdbcTestResourceProvider.java
@@ -161,6 +161,17 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         return null;
     }
 
+    /**
+     * Resolves vendor-specific properties using the started container plus the original
+     * requested-property map. Subclasses may override when the resolved value depends on
+     * request metadata in addition to the container state.
+     *
+     * @param propertyName the property to resolve
+     * @param container the started container
+     * @param properties the resolved properties for the request
+     * @param testResourcesConfig the test resources configuration
+     * @return the resolved property, or {@code null} if not resolvable
+     */
     protected String resolveDbSpecificProperty(String propertyName,
                                                JdbcDatabaseContainer<?> container,
                                                Map<String, Object> properties,
@@ -202,14 +213,38 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         return PREFIX + "." + datasource + "." + property;
     }
 
+    /**
+     * Indicates whether this provider can create additional logical databases inside the
+     * same running container. Subclasses overriding this method must also implement the
+     * database-creation hooks consistently for the same container type.
+     *
+     * @return {@code true} when additional logical databases are supported
+     */
     protected boolean supportsMultipleDatabases() {
         return false;
     }
 
+    /**
+     * Creates an additional logical database inside an already started container.
+     * This is only invoked when {@link #supportsMultipleDatabases()} returns {@code true},
+     * so subclasses overriding one hook should override the other as a matching pair.
+     *
+     * @param container the running container
+     * @param databaseName the database to create
+     */
     protected void createAdditionalDatabase(T container, String databaseName) {
         throw new UnsupportedOperationException("Additional database creation is not supported for " + getSimpleName());
     }
 
+    /**
+     * Resolves the JDBC URL for the requested datasource. Subclasses may override to
+     * customize how the requested logical database name maps onto the running container.
+     *
+     * @param expression the property expression being resolved
+     * @param container the running container
+     * @param properties the resolved properties for the request
+     * @return the JDBC URL to expose to the caller
+     */
     protected String resolveJdbcUrl(String expression, T container, Map<String, Object> properties) {
         return findRequestedDatabaseName(expression, properties)
             .filter(databaseName -> supportsMultipleDatabases())
@@ -217,10 +252,28 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
             .orElseGet(container::getJdbcUrl);
     }
 
+    /**
+     * Builds a JDBC URL that targets the supplied logical database on the running
+     * container. Subclasses overriding this method should return a URL compatible with
+     * the driver exposed by the container.
+     *
+     * @param container the running container
+     * @param databaseName the logical database name requested by the caller
+     * @return the JDBC URL for that database
+     */
     protected String jdbcUrlFor(T container, String databaseName) {
         return container.getJdbcUrl();
     }
 
+    /**
+     * Extracts the logical database name requested by the caller from the datasource
+     * property set. Subclasses may override when the provider supports alternative
+     * configuration keys for selecting databases.
+     *
+     * @param propertyName the property being resolved
+     * @param requestedProperties the resolved properties for the request
+     * @return the requested logical database name, if present
+     */
     protected Optional<String> findRequestedDatabaseName(String propertyName, Map<String, Object> requestedProperties) {
         if (!isDatasourceExpression(propertyName)) {
             return Optional.empty();

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
@@ -43,8 +43,49 @@ public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvide
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(MariaDBContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "mysql",
+                "-h127.0.0.1",
+                "-u",
+                container.getUsername(),
+                "-p" + container.getPassword(),
+                "-e",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create MariaDB database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected String jdbcUrlFor(MariaDBContainer container, String databaseName) {
+        return replaceDatabaseName(container.getJdbcUrl(), databaseName);
+    }
+
+    @Override
     protected MariaDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return new MariaDBContainer(imageName);
     }
 
+    private static String replaceDatabaseName(String jdbcUrl, String databaseName) {
+        int queryIndex = jdbcUrl.indexOf('?');
+        String querySuffix = queryIndex >= 0 ? jdbcUrl.substring(queryIndex) : "";
+        String baseUrl = queryIndex >= 0 ? jdbcUrl.substring(0, queryIndex) : jdbcUrl;
+        int databaseSeparator = baseUrl.lastIndexOf('/');
+        return baseUrl.substring(0, databaseSeparator + 1) + databaseName + querySuffix;
+    }
+
+    private static String quoteDatabaseName(String databaseName) {
+        return "`" + databaseName.replace("`", "``") + "`";
+    }
 }

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/main/java/io/micronaut/testresources/mariadb/MariaDBTestResourceProvider.java
@@ -49,8 +49,8 @@ public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvide
 
     @Override
     protected void createAdditionalDatabase(MariaDBContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
+        executeInContainer("Failed to create MariaDB database '" + databaseName + "'", () ->
+            container.execInContainer(
                 "mysql",
                 "-h127.0.0.1",
                 "-u",
@@ -58,13 +58,8 @@ public class MariaDBTestResourceProvider extends AbstractJdbcTestResourceProvide
                 "-p" + container.getPassword(),
                 "-e",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create MariaDB database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/groovy/io/micronaut/testresources/jdbc/mariadb/MariaDBTestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mariadb/src/test/groovy/io/micronaut/testresources/jdbc/mariadb/MariaDBTestResourceProviderSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.jdbc.mariadb
+
+import io.micronaut.testresources.mariadb.MariaDBTestResourceProvider
+import org.testcontainers.mariadb.MariaDBContainer
+import spock.lang.Specification
+
+class MariaDBTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new MariaDBTestResourceProvider()
+        def container = Mock(MariaDBContainer)
+        container.getUsername() >> "root"
+        container.getPassword() >> "secret"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-mssql/src/test/groovy/io/micronaut/testresources/mssql/MSSQLTestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mssql/src/test/groovy/io/micronaut/testresources/mssql/MSSQLTestResourceProviderSpec.groovy
@@ -19,5 +19,20 @@ class MSSQLTestResourceProviderSpec extends Specification {
         value << [StringUtils.TRUE, true, Boolean.TRUE]
     }
 
+    void "shared resource name reuse stays enabled when db-name is set"() {
+        given:
+        def provider = new MSSQLTestResourceProvider()
+        def properties = [
+                "datasources.default.db-type": "mssql",
+                "datasources.default.db-name": "app_db",
+                "datasources.default.test-resources.resource-name": "shared-mssql"
+        ]
+
+        expect:
+        provider.getContainerOwnerKey("datasources.default.url", properties, [:]) == "mssql"
+        provider.getContainerQuery("datasources.default.url", properties, [:]) == [
+                "test-resources.resource-name": "shared-mssql"
+        ]
+    }
 
 }

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -59,22 +59,17 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
 
     @Override
     protected void createAdditionalDatabase(MySQLContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
-                "mysql",
+        executeInContainer("Failed to create MySQL database '" + databaseName + "'", () ->
+            container.execInContainer(
+                DOCKER_OFFICIAL_IMAGE,
                 "-h127.0.0.1",
                 "-u",
                 container.getUsername(),
                 "-p" + container.getPassword(),
                 "-e",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create MySQL database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/main/java/io/micronaut/testresources/mysql/MySQLTestResourceProvider.java
@@ -53,6 +53,36 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(MySQLContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "mysql",
+                "-h127.0.0.1",
+                "-u",
+                container.getUsername(),
+                "-p" + container.getPassword(),
+                "-e",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create MySQL database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected String jdbcUrlFor(MySQLContainer container, String databaseName) {
+        return replaceDatabaseName(container.getJdbcUrl(), databaseName);
+    }
+
+    @Override
     protected MySQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         // Testcontainers uses by default the Docker Hub official image, so the MySQL official image needs to be set as compatible substitute
         if (imageName.asCanonicalNameString().startsWith(MYSQL_OFFICIAL_IMAGE)) {
@@ -78,17 +108,34 @@ public class MySQLTestResourceProvider extends AbstractJdbcTestResourceProvider<
     }
 
     @Override
-    protected String resolveDbSpecificProperty(String propertyName, JdbcDatabaseContainer<?> container) {
+    protected String resolveDbSpecificProperty(String propertyName,
+                                               JdbcDatabaseContainer<?> container,
+                                               Map<String, Object> properties,
+                                               Map<String, Object> testResourcesConfig) {
         if (X_PROTOCOL_URL.equals(propertyName.substring(propertyName.lastIndexOf(".") + 1))) {
             String username = container.getUsername();
             String password = container.getPassword();
             String host = container.getHost();
             String port = String.valueOf(container.getMappedPort(DEFAULT_X_PROTOCOL_PORT));
-            String schema = container.getDatabaseName();
+            String schema = findRequestedDatabaseName(propertyName, properties)
+                .filter(unused -> supportsMultipleDatabases())
+                .orElseGet(container::getDatabaseName);
 
             return "mysqlx://%s:%s@%s:%s/%s".formatted(username, password, host, port, schema);
         } else {
-            return super.resolveDbSpecificProperty(propertyName, container);
+            return super.resolveDbSpecificProperty(propertyName, container, properties, testResourcesConfig);
         }
+    }
+
+    private static String replaceDatabaseName(String jdbcUrl, String databaseName) {
+        int queryIndex = jdbcUrl.indexOf('?');
+        String querySuffix = queryIndex >= 0 ? jdbcUrl.substring(queryIndex) : "";
+        String baseUrl = queryIndex >= 0 ? jdbcUrl.substring(0, queryIndex) : jdbcUrl;
+        int databaseSeparator = baseUrl.lastIndexOf('/');
+        return baseUrl.substring(0, databaseSeparator + 1) + databaseName + querySuffix;
+    }
+
+    private static String quoteDatabaseName(String databaseName) {
+        return "`" + databaseName.replace("`", "``") + "`";
     }
 }

--- a/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/MySQLTestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-mysql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/MySQLTestResourceProviderSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.testresources.jdbc.mysql
+
+import io.micronaut.testresources.mysql.MySQLTestResourceProvider
+import org.testcontainers.mysql.MySQLContainer
+import spock.lang.Specification
+
+class MySQLTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new MySQLTestResourceProvider()
+        def container = Mock(MySQLContainer)
+        container.getUsername() >> "root"
+        container.getPassword() >> "secret"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
@@ -54,8 +54,51 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(PostgreSQLContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "psql",
+                "-v",
+                "ON_ERROR_STOP=1",
+                "-U",
+                container.getUsername(),
+                "-d",
+                container.getDatabaseName(),
+                "-c",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create PostgreSQL database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected String jdbcUrlFor(PostgreSQLContainer container, String databaseName) {
+        return replaceDatabaseName(container.getJdbcUrl(), databaseName);
+    }
+
+    @Override
     protected PostgreSQLContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return new PostgreSQLContainer(imageName);
     }
 
+    private static String replaceDatabaseName(String jdbcUrl, String databaseName) {
+        int queryIndex = jdbcUrl.indexOf('?');
+        String querySuffix = queryIndex >= 0 ? jdbcUrl.substring(queryIndex) : "";
+        String baseUrl = queryIndex >= 0 ? jdbcUrl.substring(0, queryIndex) : jdbcUrl;
+        int databaseSeparator = baseUrl.lastIndexOf('/');
+        return baseUrl.substring(0, databaseSeparator + 1) + databaseName + querySuffix;
+    }
+
+    private static String quoteDatabaseName(String databaseName) {
+        return "\"" + databaseName.replace("\"", "\"\"") + "\"";
+    }
 }

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/main/java/io/micronaut/testresources/postgres/PostgreSQLTestResourceProvider.java
@@ -60,8 +60,8 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
 
     @Override
     protected void createAdditionalDatabase(PostgreSQLContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
+        executeInContainer("Failed to create PostgreSQL database '" + databaseName + "'", () ->
+            container.execInContainer(
                 "psql",
                 "-v",
                 "ON_ERROR_STOP=1",
@@ -71,13 +71,8 @@ public class PostgreSQLTestResourceProvider extends AbstractJdbcTestResourceProv
                 container.getDatabaseName(),
                 "-c",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create PostgreSQL database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/SharedResourceNamePostgreSQLTest.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/test/groovy/io/micronaut/testresources/jdbc/mysql/SharedResourceNamePostgreSQLTest.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.testresources.jdbc.mysql
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.postgres.PostgreSQLTestResourceProvider
+import io.micronaut.testresources.testcontainers.TestContainers
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+
+class SharedResourceNamePostgreSQLTest extends AbstractTestContainersSpec {
+    void "shared resource name reuses one PostgreSQL container across distinct JDBC databases"() {
+        given:
+        def provider = new PostgreSQLTestResourceProvider()
+        def readProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "datasources.read.dialect": "POSTGRES",
+                "datasources.read.db-name": "read_db",
+                "datasources.read.test-resources.resource-name": "shared-postgres"
+        ]
+        def writeProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "datasources.write.dialect": "POSTGRES",
+                "datasources.write.db-name": "write_db",
+                "datasources.write.test-resources.resource-name": "shared-postgres"
+        ]
+
+        when:
+        def readUrl = provider.resolve("datasources.read.url", readProperties, [:])
+        def writeUrl = provider.resolve("datasources.write.url", writeProperties, [:])
+        def scope = Scope.of(scopeName)
+        def readContainers = TestContainers.findByRequestedProperty(scope, "datasources.read.url")
+        def writeContainers = TestContainers.findByRequestedProperty(scope, "datasources.write.url")
+        def databases = readContainers.first().execInContainer(
+                "psql",
+                "-U",
+                readContainers.first().username,
+                "-d",
+                readContainers.first().databaseName,
+                "-tAc",
+                "SELECT datname FROM pg_database WHERE datname IN ('read_db', 'write_db') ORDER BY datname"
+        ).stdout
+                .readLines()
+                .findAll { !it.isBlank() }
+
+        then:
+        readUrl.present
+        writeUrl.present
+        readContainers.size() == 1
+        writeContainers.size() == 1
+        readContainers.first().is(writeContainers.first())
+        withoutQueryString(readUrl.get()).endsWith("/read_db")
+        withoutQueryString(writeUrl.get()).endsWith("/write_db")
+        databases == ["read_db", "write_db"]
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+
+    private static String withoutQueryString(String url) {
+        int queryIndex = url.indexOf('?')
+        queryIndex >= 0 ? url.substring(0, queryIndex) : url
+    }
+}

--- a/test-resources-jdbc/test-resources-jdbc-postgresql/src/test/groovy/io/micronaut/testresources/postgres/PostgreSQLTestResourceProviderSpec.groovy
+++ b/test-resources-jdbc/test-resources-jdbc-postgresql/src/test/groovy/io/micronaut/testresources/postgres/PostgreSQLTestResourceProviderSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.testresources.postgres
+
+import org.testcontainers.postgresql.PostgreSQLContainer
+import spock.lang.Specification
+
+class PostgreSQLTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new PostgreSQLTestResourceProvider()
+        def container = Mock(PostgreSQLContainer)
+        container.getUsername() >> "postgres"
+        container.getDatabaseName() >> "postgres"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -103,22 +103,66 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
     protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
         String name = R2dbcSupport.removeR2dbPrefixFrom(propertyName);
         if (properties.containsKey(name)) {
-            return resolveUsingExistingContainer(propertyName, properties, name);
+            return resolveUsingExistingContainer(propertyName, properties, testResourcesConfig, name);
         }
         return Optional.empty();
     }
 
     @Override
     protected final Optional<String> resolveProperty(String expression, T container) {
+        return resolveProperty(expression, container, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    @Override
+    protected final Optional<String> resolveProperty(String expression,
+                                                    T container,
+                                                    Map<String, Object> properties,
+                                                    Map<String, Object> testResourcesConfig) {
         Optional<ConnectionFactoryOptions> options = extractOptions(container);
         if (options.isPresent()) {
             String propertyName = expression.substring(expression.lastIndexOf(".") + 1);
-            return Optional.ofNullable(resolveFromConnectionOptions(propertyName, options.get()));
+            return Optional.ofNullable(resolveFromConnectionOptions(expression, propertyName, options.get(), properties));
         }
         return Optional.empty();
     }
 
-    private Optional<String> resolveUsingExistingContainer(String propertyName, Map<String, Object> properties, String name) {
+    @Override
+    protected String getContainerOwnerKey(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        if (supportsSharedContainerReuse(propertyName, properties)) {
+            return getSimpleName();
+        }
+        return super.getContainerOwnerKey(propertyName, properties, testResourcesConfig);
+    }
+
+    @Override
+    protected Map<String, Object> getContainerQuery(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        return supportsSharedContainerReuse(propertyName, properties) ? findSharedResourceName(propertyName, properties)
+            .<Map<String, Object>>map(name -> Map.of(R2dbcSupport.RESOURCE_NAME, name))
+            .orElseGet(() -> super.getContainerQuery(propertyName, properties, testResourcesConfig)) : super.getContainerQuery(propertyName, properties, testResourcesConfig);
+    }
+
+    @Override
+    protected void prepareContainer(String propertyName,
+                                    T container,
+                                    Map<String, Object> properties,
+                                    Map<String, Object> testResourcesConfig) {
+        findRequestedDatabaseName(propertyName, properties)
+            .filter(databaseName -> supportsMultipleDatabases())
+            .filter(databaseName -> extractDefaultDatabaseName(container).map(defaultDatabase -> !defaultDatabase.equals(databaseName)).orElse(true))
+            .ifPresent(databaseName -> {
+                synchronized (container) {
+                    if (!TestContainers.hasDatabase(container, databaseName)) {
+                        createAdditionalDatabase(container, databaseName);
+                        TestContainers.rememberDatabase(container, databaseName);
+                    }
+                }
+            });
+    }
+
+    private Optional<String> resolveUsingExistingContainer(String propertyName,
+                                                           Map<String, Object> properties,
+                                                           Map<String, Object> testResourcesConfig,
+                                                           String name) {
         // Look for a container with JDBC
         LOGGER.debug("Resolving property: {} with properties {}", propertyName, properties);
         List<GenericContainer<?>> containers = TestContainers.findByRequestedProperty(Scope.from(properties), name);
@@ -128,15 +172,34 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         }
         return containers.stream()
             .findFirst()
-            .flatMap(this::extractOptions)
-            .map(options -> resolveFromConnectionOptions(propertyName, options));
+            .flatMap(container -> prepareAndExtractOptions(propertyName, properties, testResourcesConfig, container))
+            .map(options -> resolveFromConnectionOptions(propertyName, propertyName, options, properties));
     }
 
-    private String resolveFromConnectionOptions(String propertyName, ConnectionFactoryOptions options) {
+    private Optional<ConnectionFactoryOptions> prepareAndExtractOptions(String propertyName,
+                                                                        Map<String, Object> properties,
+                                                                        Map<String, Object> testResourcesConfig,
+                                                                        GenericContainer<?> container) {
+        Optional<ConnectionFactoryOptions> options = extractOptions(container);
+        if (options.isEmpty()) {
+            return Optional.empty();
+        }
+        @SuppressWarnings("unchecked")
+        T typedContainer = (T) container;
+        prepareContainer(propertyName, typedContainer, properties, testResourcesConfig);
+        return extractOptions(container);
+    }
+
+    private String resolveFromConnectionOptions(String expression,
+                                                String propertyName,
+                                                ConnectionFactoryOptions options,
+                                                Map<String, Object> properties) {
         String property = propertyName.substring(propertyName.lastIndexOf(".") + 1);
         switch (property) {
             case URL:
-                Object db = options.getValue(ConnectionFactoryOptions.DATABASE);
+                Object db = findRequestedDatabaseName(expression, properties)
+                    .filter(databaseName -> supportsMultipleDatabases())
+                    .orElseGet(() -> options.getValue(ConnectionFactoryOptions.DATABASE) == null ? null : String.valueOf(options.getValue(ConnectionFactoryOptions.DATABASE)));
                 String url;
                 if (db != null) {
                     url = String.format(
@@ -166,5 +229,41 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
     }
 
     protected abstract Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container);
+
+    protected boolean supportsMultipleDatabases() {
+        return false;
+    }
+
+    protected void createAdditionalDatabase(T container, String databaseName) {
+        throw new UnsupportedOperationException("Additional database creation is not supported for " + getSimpleName());
+    }
+
+    protected Optional<String> extractDefaultDatabaseName(T container) {
+        return Optional.empty();
+    }
+
+    private Optional<String> findSharedResourceName(String propertyName, Map<String, Object> properties) {
+        if (!propertyName.startsWith(R2dbcSupport.R2DBC_PREFIX)) {
+            return Optional.empty();
+        }
+        String datasource = R2dbcSupport.datasourceNameFrom(R2dbcSupport.removeR2dbPrefixFrom(propertyName));
+        return Optional.ofNullable(stringOrNull(properties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.RESOURCE_NAME))));
+    }
+
+    protected Optional<String> findRequestedDatabaseName(String propertyName, Map<String, Object> properties) {
+        if (!propertyName.startsWith(R2dbcSupport.R2DBC_PREFIX)) {
+            return Optional.empty();
+        }
+        String datasource = R2dbcSupport.datasourceNameFrom(R2dbcSupport.removeR2dbPrefixFrom(propertyName));
+        String r2dbcDatabaseName = stringOrNull(properties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.DB_NAME)));
+        if (r2dbcDatabaseName != null) {
+            return Optional.of(r2dbcDatabaseName);
+        }
+        return Optional.ofNullable(stringOrNull(properties.get(R2dbcSupport.datasourceExpressionOf(datasource, R2dbcSupport.DB_NAME))));
+    }
+
+    private boolean supportsSharedContainerReuse(String propertyName, Map<String, Object> properties) {
+        return findSharedResourceName(propertyName, properties).isPresent();
+    }
 
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -230,14 +230,37 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
 
     protected abstract Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container);
 
+    /**
+     * Indicates whether this provider can create additional logical databases inside the
+     * same running container. Subclasses overriding this method must also implement the
+     * matching database-creation hooks for the same container type.
+     *
+     * @return {@code true} when additional logical databases are supported
+     */
     protected boolean supportsMultipleDatabases() {
         return false;
     }
 
+    /**
+     * Creates an additional logical database inside an already started container.
+     * This is only invoked when {@link #supportsMultipleDatabases()} returns {@code true},
+     * so subclasses should override both hooks together.
+     *
+     * @param container the running container
+     * @param databaseName the database to create
+     */
     protected void createAdditionalDatabase(T container, String databaseName) {
         throw new UnsupportedOperationException("Additional database creation is not supported for " + getSimpleName());
     }
 
+    /**
+     * Extracts the default logical database name already configured on the running
+     * container. Subclasses may override when the provider can compare requested
+     * databases against a provider-specific default.
+     *
+     * @param container the running container
+     * @return the default logical database name, if one can be derived
+     */
     protected Optional<String> extractDefaultDatabaseName(T container) {
         return Optional.empty();
     }
@@ -250,6 +273,15 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         return Optional.ofNullable(stringOrNull(properties.get(R2dbcSupport.r2dbDatasourceExpressionOf(datasource, R2dbcSupport.RESOURCE_NAME))));
     }
 
+    /**
+     * Extracts the logical database name requested by the caller from the R2DBC
+     * datasource properties. Subclasses may override when the provider supports
+     * alternative configuration keys for database selection.
+     *
+     * @param propertyName the property being resolved
+     * @param properties the resolved properties for the request
+     * @return the requested logical database name, if present
+     */
     protected Optional<String> findRequestedDatabaseName(String propertyName, Map<String, Object> properties) {
         if (!propertyName.startsWith(R2dbcSupport.R2DBC_PREFIX)) {
             return Optional.empty();

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -146,6 +146,9 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
                                     T container,
                                     Map<String, Object> properties,
                                     Map<String, Object> testResourcesConfig) {
+        if (!propertyName.endsWith("." + URL)) {
+            return;
+        }
         findRequestedDatabaseName(propertyName, properties)
             .filter(databaseName -> supportsMultipleDatabases())
             .filter(databaseName -> extractDefaultDatabaseName(container).map(defaultDatabase -> !defaultDatabase.equals(databaseName)).orElse(true))
@@ -187,7 +190,7 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         @SuppressWarnings("unchecked")
         T typedContainer = (T) container;
         prepareContainer(propertyName, typedContainer, properties, testResourcesConfig);
-        return extractOptions(container);
+        return options;
     }
 
     private String resolveFromConnectionOptions(String expression,

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/AbstractR2DBCTestResourceProvider.java
@@ -152,14 +152,11 @@ public abstract class AbstractR2DBCTestResourceProvider<T extends GenericContain
         findRequestedDatabaseName(propertyName, properties)
             .filter(databaseName -> supportsMultipleDatabases())
             .filter(databaseName -> extractDefaultDatabaseName(container).map(defaultDatabase -> !defaultDatabase.equals(databaseName)).orElse(true))
-            .ifPresent(databaseName -> {
-                synchronized (container) {
-                    if (!TestContainers.hasDatabase(container, databaseName)) {
-                        createAdditionalDatabase(container, databaseName);
-                        TestContainers.rememberDatabase(container, databaseName);
-                    }
-                }
-            });
+            .ifPresent(databaseName -> TestContainers.createDatabaseIfMissing(
+                container,
+                databaseName,
+                () -> createAdditionalDatabase(container, databaseName)
+            ));
     }
 
     private Optional<String> resolveUsingExistingContainer(String propertyName,

--- a/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-core/src/main/java/io/micronaut/testresources/r2dbc/core/R2dbcSupport.java
@@ -36,6 +36,8 @@ public final class R2dbcSupport {
     public static final String DIALECT = "dialect";
     public static final String DRIVER = "driverClassName";
     public static final String TYPE = "db-type";
+    public static final String DB_NAME = "db-name";
+    public static final String RESOURCE_NAME = "test-resources.resource-name";
 
     public static final List<String> REQUIRED_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
         DIALECT,
@@ -59,7 +61,14 @@ public final class R2dbcSupport {
             String datasourceName = R2dbcSupport.datasourceNameFrom(regularDatasource);
             List<String> requiredProperties = Stream.concat(
                 Stream.of(regularDatasource),
-                REQUIRED_PROPERTIES.stream().map(k -> R2dbcSupport.r2dbDatasourceExpressionOf(datasourceName, k))
+                Stream.concat(
+                    REQUIRED_PROPERTIES.stream().map(k -> R2dbcSupport.r2dbDatasourceExpressionOf(datasourceName, k)),
+                    Stream.of(
+                        R2dbcSupport.r2dbDatasourceExpressionOf(datasourceName, DB_NAME),
+                        R2dbcSupport.r2dbDatasourceExpressionOf(datasourceName, RESOURCE_NAME),
+                        R2dbcSupport.datasourceExpressionOf(datasourceName, DB_NAME)
+                    )
+                )
             ).collect(Collectors.toList());
 
             LOGGER.debug("Required properties: {}", requiredProperties);
@@ -90,5 +99,9 @@ public final class R2dbcSupport {
 
     public static String r2dbDatasourceExpressionOf(String datasource, String property) {
         return R2DBC_DATASOURCES + "." + datasource + "." + property;
+    }
+
+    public static String datasourceExpressionOf(String datasource, String property) {
+        return DATASOURCES + "." + datasource + "." + property;
     }
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
@@ -47,6 +47,36 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(MariaDBContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "mysql",
+                "-h127.0.0.1",
+                "-u",
+                container.getUsername(),
+                "-p" + container.getPassword(),
+                "-e",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create MariaDB database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected Optional<String> extractDefaultDatabaseName(MariaDBContainer container) {
+        return Optional.of(container.getDatabaseName());
+    }
+
+    @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof MariaDBContainer) {
             return Optional.of(MariaDBR2DBCDatabaseContainer.getOptions((MariaDBContainer) container));
@@ -59,4 +89,7 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
         return new MariaDBContainer(imageName);
     }
 
+    private static String quoteDatabaseName(String databaseName) {
+        return "`" + databaseName.replace("`", "``") + "`";
+    }
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/main/java/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProvider.java
@@ -53,8 +53,8 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
 
     @Override
     protected void createAdditionalDatabase(MariaDBContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
+        executeInContainer("Failed to create MariaDB database '" + databaseName + "'", () ->
+            container.execInContainer(
                 "mysql",
                 "-h127.0.0.1",
                 "-u",
@@ -62,13 +62,8 @@ public class R2DBCMariaDBTestResourceProvider extends AbstractR2DBCTestResourceP
                 "-p" + container.getPassword(),
                 "-e",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create MariaDB database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProviderSpec.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mariadb/src/test/groovy/io/micronaut/testresources/r2dbc/mariadb/R2DBCMariaDBTestResourceProviderSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.testresources.r2dbc.mariadb
+
+import org.testcontainers.mariadb.MariaDBContainer
+import spock.lang.Specification
+
+class R2DBCMariaDBTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new R2DBCMariaDBTestResourceProvider()
+        def container = Mock(MariaDBContainer)
+        container.getUsername() >> "root"
+        container.getPassword() >> "secret"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/groovy/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProviderSpec.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mssql/src/test/groovy/io/micronaut/testresources/r2dbc/mssql/R2DBCMSSQLTestResourceProviderSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.testresources.r2dbc.mssql
+
+import spock.lang.Specification
+
+class R2DBCMSSQLTestResourceProviderSpec extends Specification {
+
+    void "shared resource name reuse stays enabled when db-name is set"() {
+        given:
+        def provider = new R2DBCMSSQLTestResourceProvider()
+        def properties = [
+                "r2dbc.datasources.default.db-type": "mssql",
+                "r2dbc.datasources.default.db-name": "app_db",
+                "r2dbc.datasources.default.test-resources.resource-name": "shared-mssql"
+        ]
+
+        expect:
+        provider.getContainerOwnerKey("r2dbc.datasources.default.url", properties, [:]) == "mssql"
+        provider.getContainerQuery("r2dbc.datasources.default.url", properties, [:]) == [
+                "test-resources.resource-name": "shared-mssql"
+        ]
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
@@ -47,6 +47,36 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(MySQLContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "mysql",
+                "-h127.0.0.1",
+                "-u",
+                container.getUsername(),
+                "-p" + container.getPassword(),
+                "-e",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create MySQL database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected Optional<String> extractDefaultDatabaseName(MySQLContainer container) {
+        return Optional.of(container.getDatabaseName());
+    }
+
+    @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof MySQLContainer) {
             return Optional.of(MySQLR2DBCDatabaseContainer.getOptions((MySQLContainer) container));
@@ -59,4 +89,7 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
         return new MySQLContainer(imageName);
     }
 
+    private static String quoteDatabaseName(String databaseName) {
+        return "`" + databaseName.replace("`", "``") + "`";
+    }
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/main/java/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProvider.java
@@ -53,8 +53,8 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
 
     @Override
     protected void createAdditionalDatabase(MySQLContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
+        executeInContainer("Failed to create MySQL database '" + databaseName + "'", () ->
+            container.execInContainer(
                 "mysql",
                 "-h127.0.0.1",
                 "-u",
@@ -62,13 +62,8 @@ public class R2DBCMySQLTestResourceProvider extends AbstractR2DBCTestResourcePro
                 "-p" + container.getPassword(),
                 "-e",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create MySQL database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProviderSpec.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-mysql/src/test/groovy/io/micronaut/testresources/r2dbc/mysql/R2DBCMySQLTestResourceProviderSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.testresources.r2dbc.mysql
+
+import org.testcontainers.mysql.MySQLContainer
+import spock.lang.Specification
+
+class R2DBCMySQLTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new R2DBCMySQLTestResourceProvider()
+        def container = Mock(MySQLContainer)
+        container.getUsername() >> "root"
+        container.getPassword() >> "secret"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/build.gradle
@@ -9,6 +9,7 @@ Provides support for PostgreSQL R2DBC test resources.
 dependencies {
     implementation(libs.managed.testcontainers.postgres)
     runtimeOnly(project(":micronaut-test-resources-jdbc-postgresql"))
+    testImplementation(project(":micronaut-test-resources-jdbc-postgresql"))
 
     testRuntimeOnly(mnR2dbc.r2dbc.postgresql)
     testRuntimeOnly(mnSql.postgresql)

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -58,6 +58,38 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
     }
 
     @Override
+    protected boolean supportsMultipleDatabases() {
+        return true;
+    }
+
+    @Override
+    protected void createAdditionalDatabase(PostgreSQLContainer container, String databaseName) {
+        try {
+            var result = container.execInContainer(
+                "psql",
+                "-v",
+                "ON_ERROR_STOP=1",
+                "-U",
+                container.getUsername(),
+                "-d",
+                container.getDatabaseName(),
+                "-c",
+                "CREATE DATABASE " + quoteDatabaseName(databaseName)
+            );
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(result.getStderr());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create PostgreSQL database '" + databaseName + "'", e);
+        }
+    }
+
+    @Override
+    protected Optional<String> extractDefaultDatabaseName(PostgreSQLContainer container) {
+        return Optional.of(container.getDatabaseName());
+    }
+
+    @Override
     protected Optional<ConnectionFactoryOptions> extractOptions(GenericContainer<?> container) {
         if (container instanceof PostgreSQLContainer) {
             return Optional.of(PostgreSQLR2DBCDatabaseContainer.getOptions((PostgreSQLContainer) container));
@@ -70,4 +102,7 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
         return new PostgreSQLContainer(imageName);
     }
 
+    private static String quoteDatabaseName(String databaseName) {
+        return "\"" + databaseName.replace("\"", "\"\"") + "\"";
+    }
 }

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/main/java/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProvider.java
@@ -64,8 +64,8 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
 
     @Override
     protected void createAdditionalDatabase(PostgreSQLContainer container, String databaseName) {
-        try {
-            var result = container.execInContainer(
+        executeInContainer("Failed to create PostgreSQL database '" + databaseName + "'", () ->
+            container.execInContainer(
                 "psql",
                 "-v",
                 "ON_ERROR_STOP=1",
@@ -75,13 +75,8 @@ public class R2DBCPostgreSQLTestResourceProvider extends AbstractR2DBCTestResour
                 container.getDatabaseName(),
                 "-c",
                 "CREATE DATABASE " + quoteDatabaseName(databaseName)
-            );
-            if (result.getExitCode() != 0) {
-                throw new IllegalStateException(result.getStderr());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to create PostgreSQL database '" + databaseName + "'", e);
-        }
+            )
+        );
     }
 
     @Override

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProviderSpec.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/R2DBCPostgreSQLTestResourceProviderSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.testresources.r2dbc.postgres
+
+import org.testcontainers.postgresql.PostgreSQLContainer
+import spock.lang.Specification
+
+class R2DBCPostgreSQLTestResourceProviderSpec extends Specification {
+    def cleanup() {
+        Thread.interrupted()
+    }
+
+    void "createAdditionalDatabase restores the interrupt status"() {
+        given:
+        def provider = new R2DBCPostgreSQLTestResourceProvider()
+        def container = Mock(PostgreSQLContainer)
+        container.getUsername() >> "postgres"
+        container.getDatabaseName() >> "postgres"
+        container.execInContainer(*_) >> { throw new InterruptedException("boom") }
+
+        when:
+        provider.createAdditionalDatabase(container, "extra_db")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+    }
+}

--- a/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/SharedResourceNamePostgreSQLTest.groovy
+++ b/test-resources-r2dbc/test-resources-r2dbc-postgresql/src/test/groovy/io/micronaut/testresources/r2dbc/postgres/SharedResourceNamePostgreSQLTest.groovy
@@ -1,0 +1,121 @@
+package io.micronaut.testresources.r2dbc.postgres
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.postgres.PostgreSQLTestResourceProvider
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+import io.micronaut.testresources.testcontainers.TestContainers
+
+class SharedResourceNamePostgreSQLTest extends AbstractTestContainersSpec {
+
+    void "shared resource name reuses one PostgreSQL container across JDBC and R2DBC databases"() {
+        given:
+        def jdbcProvider = new PostgreSQLTestResourceProvider()
+        def r2dbcProvider = new R2DBCPostgreSQLTestResourceProvider()
+        def jdbcProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "datasources.migrations.dialect": "POSTGRES",
+                "datasources.migrations.db-name": "migrations_db",
+                "datasources.migrations.test-resources.resource-name": "shared-postgres"
+        ]
+        def defaultR2dbcProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "r2dbc.datasources.default.dialect": "POSTGRES",
+                "r2dbc.datasources.default.db-name": "default_db",
+                "r2dbc.datasources.default.test-resources.resource-name": "shared-postgres"
+        ]
+        def reportingR2dbcProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "r2dbc.datasources.reporting.dialect": "POSTGRES",
+                "r2dbc.datasources.reporting.db-name": "reporting_db",
+                "r2dbc.datasources.reporting.test-resources.resource-name": "shared-postgres"
+        ]
+
+        when:
+        def jdbcUrl = jdbcProvider.resolve("datasources.migrations.url", jdbcProperties, [:])
+        def defaultR2dbcUrl = r2dbcProvider.resolve("r2dbc.datasources.default.url", defaultR2dbcProperties, [:])
+        def reportingR2dbcUrl = r2dbcProvider.resolve("r2dbc.datasources.reporting.url", reportingR2dbcProperties, [:])
+        def scope = Scope.of(scopeName)
+        def jdbcContainers = TestContainers.findByRequestedProperty(scope, "datasources.migrations.url")
+        def defaultContainers = TestContainers.findByRequestedProperty(scope, "r2dbc.datasources.default.url")
+        def reportingContainers = TestContainers.findByRequestedProperty(scope, "r2dbc.datasources.reporting.url")
+        def databases = jdbcContainers.first().execInContainer(
+                "psql",
+                "-U",
+                jdbcContainers.first().username,
+                "-d",
+                jdbcContainers.first().databaseName,
+                "-tAc",
+                "SELECT datname FROM pg_database WHERE datname IN ('migrations_db', 'default_db', 'reporting_db') ORDER BY datname"
+        ).stdout
+                .readLines()
+                .findAll { !it.isBlank() }
+
+        then:
+        jdbcUrl.present
+        defaultR2dbcUrl.present
+        reportingR2dbcUrl.present
+        withoutQueryString(jdbcUrl.get()).endsWith("/migrations_db")
+        withoutQueryString(defaultR2dbcUrl.get()).endsWith("/default_db")
+        withoutQueryString(reportingR2dbcUrl.get()).endsWith("/reporting_db")
+        jdbcContainers.size() == 1
+        defaultContainers.size() == 1
+        reportingContainers.size() == 1
+        jdbcContainers.first().is(defaultContainers.first())
+        defaultContainers.first().is(reportingContainers.first())
+        databases == ["default_db", "migrations_db", "reporting_db"]
+    }
+
+    void "same-name JDBC reuse prepares the requested R2DBC database before returning the URL"() {
+        given:
+        def jdbcProvider = new PostgreSQLTestResourceProvider()
+        def r2dbcProvider = new R2DBCPostgreSQLTestResourceProvider()
+        def jdbcProperties = [
+                (Scope.PROPERTY_KEY): scopeName,
+                "datasources.default.dialect": "POSTGRES",
+                "datasources.default.db-name": "migrations_db"
+        ]
+
+        when:
+        def jdbcUrl = jdbcProvider.resolve("datasources.default.url", jdbcProperties, [:])
+        def r2dbcProperties = [
+                (Scope.PROPERTY_KEY)          : scopeName,
+                "datasources.default.url"     : jdbcUrl.get(),
+                "datasources.default.dialect" : "POSTGRES",
+                "datasources.default.db-name" : "migrations_db",
+                "r2dbc.datasources.default.dialect": "POSTGRES",
+                "r2dbc.datasources.default.db-name": "reporting_db"
+        ]
+        def r2dbcUrl = r2dbcProvider.resolve("r2dbc.datasources.default.url", r2dbcProperties, [:])
+        def scope = Scope.of(scopeName)
+        def jdbcContainers = TestContainers.findByRequestedProperty(scope, "datasources.default.url")
+        def databases = jdbcContainers.first().execInContainer(
+                "psql",
+                "-U",
+                jdbcContainers.first().username,
+                "-d",
+                jdbcContainers.first().databaseName,
+                "-tAc",
+                "SELECT datname FROM pg_database WHERE datname IN ('migrations_db', 'reporting_db') ORDER BY datname"
+        ).stdout
+                .readLines()
+                .findAll { !it.isBlank() }
+
+        then:
+        jdbcUrl.present
+        r2dbcUrl.present
+        jdbcContainers.size() == 1
+        withoutQueryString(jdbcUrl.get()).endsWith("/migrations_db")
+        withoutQueryString(r2dbcUrl.get()).endsWith("/reporting_db")
+        databases == ["migrations_db", "reporting_db"]
+    }
+
+    @Override
+    String getImageName() {
+        "postgres"
+    }
+
+    private static String withoutQueryString(String url) {
+        int queryIndex = url.indexOf('?')
+        queryIndex >= 0 ? url.substring(0, queryIndex) : url
+    }
+}

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -149,12 +149,32 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
         return Optional.empty();
     }
 
+    /**
+     * Returns the owner key used to scope cached containers for this resolver.
+     * Subclasses may override to share a physical container across multiple logical
+     * consumers, but should keep the returned key stable for equivalent requests.
+     *
+     * @param propertyName the property being resolved
+     * @param properties the resolved properties for the request
+     * @param testResourcesConfig the test resources configuration
+     * @return the owner key used for container reuse
+     */
     protected String getContainerOwnerKey(String propertyName,
                                           Map<String, Object> properties,
                                           Map<String, Object> testResourcesConfig) {
         return getClass().getName();
     }
 
+    /**
+     * Returns the query object used to look up or create a cached container.
+     * Subclasses may override to normalize request-specific properties into a
+     * stable physical-resource identity while preserving any keys needed for safe reuse.
+     *
+     * @param propertyName the property being resolved
+     * @param properties the resolved properties for the request
+     * @param testResourcesConfig the test resources configuration
+     * @return the container query used for cache lookup
+     */
     protected Map<String, Object> getContainerQuery(String propertyName,
                                                     Map<String, Object> properties,
                                                     Map<String, Object> testResourcesConfig) {
@@ -171,6 +191,18 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
                                     Map<String, Object> testResourcesConfig) {
     }
 
+    /**
+     * Resolves the requested property from the started container with access to the
+     * full requested-property map and test-resources configuration. Subclasses may
+     * override when the resolved value depends on request metadata in addition to the
+     * container itself.
+     *
+     * @param propertyName the property being resolved
+     * @param container the started container
+     * @param properties the resolved properties for the request
+     * @param testResourcesConfig the test resources configuration
+     * @return the resolved value, if any
+     */
     protected Optional<String> resolveProperty(String propertyName,
                                                T container,
                                                Map<String, Object> properties,

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -17,6 +17,7 @@ package io.micronaut.testresources.testcontainers;
 
 import io.micronaut.testresources.core.Scope;
 import io.micronaut.testresources.core.ToggableTestResourcesResolver;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -212,10 +213,39 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
 
     protected abstract Optional<String> resolveProperty(String propertyName, T container);
 
+    /**
+     * Executes a command inside a running container and converts failures into a
+     * consistent {@link IllegalStateException}. Interrupted executions preserve the
+     * current thread interrupt status before the exception is raised.
+     *
+     * @param failureMessage the message to use when the command fails
+     * @param command the command to execute
+     */
+    protected final void executeInContainer(String failureMessage, ContainerCommand command) {
+        try {
+            Container.ExecResult result = command.execute();
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(failureMessage + ": " + result.getStderr());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(failureMessage, e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException(failureMessage, e);
+        }
+    }
+
     protected final String stringOrNull(Object value) {
         if (value == null) {
             return null;
         }
         return String.valueOf(value);
+    }
+
+    @FunctionalInterface
+    protected interface ContainerCommand {
+        Container.ExecResult execute() throws Exception;
     }
 }

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/AbstractTestContainersProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.testcontainers;
 
+import io.micronaut.testresources.core.Scope;
 import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -109,43 +110,72 @@ public abstract class AbstractTestContainersProvider<T extends GenericContainer<
             if (firstPass.isPresent()) {
                 return firstPass;
             }
-            return resolveProperty(propertyName,
-                TestContainers.getOrCreate(propertyName, this.getClass(), getSimpleName(),
-                    properties, () -> {
-                        String defaultImageName = getDefaultImageName();
-                        DockerImageName imageName = DockerImageName.parse(defaultImageName);
-                        Optional<TestContainerMetadata> metadata =
-                            TestContainerMetadataSupport.containerMetadataFor(
-                                    Collections.singletonList(getSimpleName()), testResourcesConfig)
-                                .findAny();
-                        if (metadata.isPresent()) {
-                            TestContainerMetadata md = metadata.get();
-                            if (md.getImageName().isPresent()) {
-                                imageName = DockerImageName.parse(md.getImageName().get())
-                                    .asCompatibleSubstituteFor(defaultImageName);
-                            }
-                            if (md.getImageTag().isPresent()) {
-                                imageName = imageName.withTag(md.getImageTag().get());
-                            }
+            Scope scope = Scope.from(properties);
+            String containerOwnerKey = getContainerOwnerKey(propertyName, properties, testResourcesConfig);
+            Map<String, Object> containerQuery = getContainerQuery(propertyName, properties, testResourcesConfig);
+            T container = TestContainers.getOrCreate(propertyName, containerOwnerKey, getSimpleName(),
+                scope, containerQuery, () -> {
+                    String defaultImageName = getDefaultImageName();
+                    DockerImageName imageName = DockerImageName.parse(defaultImageName);
+                    Optional<TestContainerMetadata> metadata =
+                        TestContainerMetadataSupport.containerMetadataFor(
+                                Collections.singletonList(getSimpleName()), testResourcesConfig)
+                            .findAny();
+                    if (metadata.isPresent()) {
+                        TestContainerMetadata md = metadata.get();
+                        if (md.getImageName().isPresent()) {
+                            imageName = DockerImageName.parse(md.getImageName().get())
+                                .asCompatibleSubstituteFor(defaultImageName);
                         }
-                        return imageName;
-                    }, imageName -> {
-                        Optional<TestContainerMetadata> metadata =
-                            TestContainerMetadataSupport.containerMetadataFor(
-                                    Collections.singletonList(getSimpleName()), testResourcesConfig)
-                                .findAny();
-                        T container = createContainer(imageName, properties, testResourcesConfig);
-                        configureContainer(container, properties, testResourcesConfig);
-                        metadata.ifPresent(
-                            md -> TestContainerMetadataSupport.applyMetadata(md, container));
-                        return container;
-                    }));
+                        if (md.getImageTag().isPresent()) {
+                            imageName = imageName.withTag(md.getImageTag().get());
+                        }
+                    }
+                    return imageName;
+                }, imageName -> {
+                    Optional<TestContainerMetadata> metadata =
+                        TestContainerMetadataSupport.containerMetadataFor(
+                                Collections.singletonList(getSimpleName()), testResourcesConfig)
+                            .findAny();
+                    T createdContainer = createContainer(imageName, properties, testResourcesConfig);
+                    configureContainer(createdContainer, properties, testResourcesConfig);
+                    metadata.ifPresent(
+                        md -> TestContainerMetadataSupport.applyMetadata(md, createdContainer));
+                    return createdContainer;
+                });
+            prepareContainer(propertyName, container, properties, testResourcesConfig);
+            return resolveProperty(propertyName, container, properties, testResourcesConfig);
         }
         return Optional.empty();
     }
 
+    protected String getContainerOwnerKey(String propertyName,
+                                          Map<String, Object> properties,
+                                          Map<String, Object> testResourcesConfig) {
+        return getClass().getName();
+    }
+
+    protected Map<String, Object> getContainerQuery(String propertyName,
+                                                    Map<String, Object> properties,
+                                                    Map<String, Object> testResourcesConfig) {
+        return properties;
+    }
+
     protected void configureContainer(T container, Map<String, Object> properties,
                                       Map<String, Object> testResourcesConfig) {
+    }
+
+    protected void prepareContainer(String propertyName,
+                                    T container,
+                                    Map<String, Object> properties,
+                                    Map<String, Object> testResourcesConfig) {
+    }
+
+    protected Optional<String> resolveProperty(String propertyName,
+                                               T container,
+                                               Map<String, Object> properties,
+                                               Map<String, Object> testResourcesConfig) {
+        return resolveProperty(propertyName, container);
     }
 
     protected abstract Optional<String> resolveProperty(String propertyName, T container);

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/GenericTestContainerProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.testcontainers;
 
+import io.micronaut.testresources.core.Scope;
 import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -127,8 +128,9 @@ public class GenericTestContainerProvider implements ToggableTestResourcesResolv
             .findFirst()
             .map(md -> {
                 DockerImageName imageName = DockerImageName.parse(md.getImageName().get());
-                return new MappedContainer(md, TestContainers.getOrCreate(propertyName, GenericTestContainerProvider.class,
+                return new MappedContainer(md, TestContainers.getOrCreate(propertyName, GenericTestContainerProvider.class.getName(),
                     md.getId(),
+                    Scope.from(properties),
                     properties,
                     () -> imageName,
                     unused -> {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
@@ -59,6 +59,7 @@ public final class TestContainers {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestContainers.class);
     private static final Map<String, Network> NETWORKS_BY_KEY = new ConcurrentHashMap<>();
     private static final Map<GenericContainer<?>, Set<String>> DATABASES_BY_CONTAINER = new IdentityHashMap<>();
+    private static final Map<GenericContainer<?>, Lock> DATABASE_LOCKS_BY_CONTAINER = new IdentityHashMap<>();
 
     private static final Lock MAP_LOCK = new ReentrantLock();
 
@@ -253,6 +254,7 @@ public final class TestContainers {
             CONTAINERS_BY_KEY.clear();
             CONTAINERS_BY_PROPERTY.clear();
             DATABASES_BY_CONTAINER.clear();
+            DATABASE_LOCKS_BY_CONTAINER.clear();
             NETWORKS_BY_KEY.values().forEach(Network::close);
             NETWORKS_BY_KEY.clear();
             return closed;
@@ -278,6 +280,7 @@ public final class TestContainers {
                     LOGGER.debug("Stopping container {}", container.getContainerId());
                     container.close();
                     DATABASES_BY_CONTAINER.remove(container);
+                    DATABASE_LOCKS_BY_CONTAINER.remove(container);
                     closed = true;
                     for (Set<GenericContainer<?>> value : CONTAINERS_BY_PROPERTY.values()) {
                         value.remove(container);
@@ -311,6 +314,23 @@ public final class TestContainers {
                 .add(databaseName);
             return null;
         });
+    }
+
+    public static void createDatabaseIfMissing(GenericContainer<?> container,
+                                               String databaseName,
+                                               Runnable databaseCreator) {
+        Lock lock = withMapLock("databaseLock", () ->
+            DATABASE_LOCKS_BY_CONTAINER.computeIfAbsent(container, unused -> new ReentrantLock())
+        );
+        lock.lock();
+        try {
+            if (!hasDatabase(container, databaseName)) {
+                databaseCreator.run();
+                rememberDatabase(container, databaseName);
+            }
+        } finally {
+            lock.unlock();
+        }
     }
 
     private static final class Key {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
@@ -26,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -57,6 +58,7 @@ public final class TestContainers {
     private static final Map<Key, Lock> OPERATIONS_PER_KEY = new ConcurrentHashMap<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(TestContainers.class);
     private static final Map<String, Network> NETWORKS_BY_KEY = new ConcurrentHashMap<>();
+    private static final Map<GenericContainer<?>, Set<String>> DATABASES_BY_CONTAINER = new IdentityHashMap<>();
 
     private static final Lock MAP_LOCK = new ReentrantLock();
 
@@ -95,8 +97,9 @@ public final class TestContainers {
      *
      * @param <T> the container type
      * @param requestedProperty the property that this container will resolve
-     * @param owner the class which requested the creation of a container
+     * @param owner the identity which requested the creation of a container
      * @param name the identifier of the container
+     * @param scope the test resources scope
      * @param query the parameters used to create the container. Different parameters mean
      * different container will be created.
      * @param imageNameSupplier the function which computes the image name
@@ -104,12 +107,13 @@ public final class TestContainers {
      * @return the container
      */
     static <T extends GenericContainer<? extends T>> T getOrCreate(String requestedProperty,
-                                                                   Class<?> owner,
+                                                                   String owner,
                                                                    String name,
+                                                                   Scope scope,
                                                                    Map<String, Object> query,
                                                                    Supplier<DockerImageName> imageNameSupplier,
                                                                    Function<DockerImageName, T> creator) {
-        return withKey(Key.of(owner, name, Scope.from(query), query), key -> {
+        return withKey(Key.of(owner, name, scope, query), key -> {
             try {
                 T container = withMapLock("getOrCreate", () -> (T) CONTAINERS_BY_KEY.get(key));
                 var dockerImageName = imageNameSupplier.get();
@@ -248,6 +252,7 @@ public final class TestContainers {
             }
             CONTAINERS_BY_KEY.clear();
             CONTAINERS_BY_PROPERTY.clear();
+            DATABASES_BY_CONTAINER.clear();
             NETWORKS_BY_KEY.values().forEach(Network::close);
             NETWORKS_BY_KEY.clear();
             return closed;
@@ -272,6 +277,7 @@ public final class TestContainers {
                     GenericContainer<?> container = entry.getValue();
                     LOGGER.debug("Stopping container {}", container.getContainerId());
                     container.close();
+                    DATABASES_BY_CONTAINER.remove(container);
                     closed = true;
                     for (Set<GenericContainer<?>> value : CONTAINERS_BY_PROPERTY.values()) {
                         value.remove(container);
@@ -292,20 +298,35 @@ public final class TestContainers {
         });
     }
 
+    public static boolean hasDatabase(GenericContainer<?> container, String databaseName) {
+        return withMapLock("hasDatabase", () ->
+            DATABASES_BY_CONTAINER.getOrDefault(container, Collections.emptySet()).contains(databaseName)
+        );
+    }
+
+    public static void rememberDatabase(GenericContainer<?> container, String databaseName) {
+        withMapLock("rememberDatabase", () -> {
+            DATABASES_BY_CONTAINER
+                .computeIfAbsent(container, unused -> new LinkedHashSet<>())
+                .add(databaseName);
+            return null;
+        });
+    }
+
     private static final class Key {
-        private final Class<?> type;
+        private final String owner;
         private final String name;
         private final Map<String, String> properties;
         private final int hashCode;
         private final Scope scope;
 
-        private Key(Class<?> type, String name, Scope scope, Map<String, String> properties) {
-            this.type = type;
+        private Key(String owner, String name, Scope scope, Map<String, String> properties) {
+            this.owner = owner;
             this.name = name;
             this.scope = scope;
             this.properties = properties;
             this.hashCode =
-                31 * (31 * (31 * type.hashCode() + properties.hashCode()) + scope.hashCode()) +
+                31 * (31 * (31 * owner.hashCode() + properties.hashCode()) + scope.hashCode()) +
                 name.hashCode();
         }
 
@@ -327,7 +348,7 @@ public final class TestContainers {
                 return false;
             }
 
-            if (!type.equals(key.type)) {
+            if (!owner.equals(key.owner)) {
                 return false;
             }
             return properties.equals(key.properties);
@@ -338,15 +359,15 @@ public final class TestContainers {
             return hashCode;
         }
 
-        static <T> Key of(Class<T> type, String name, Scope scope, Map<String, Object> properties) {
+        static Key of(String owner, String name, Scope scope, Map<String, Object> properties) {
             if (properties.isEmpty()) {
-                return new Key(type, name, scope, Collections.emptyMap());
+                return new Key(owner, name, scope, Collections.emptyMap());
             }
             Map<String, String> converted = new HashMap<>(properties.size());
             for (Map.Entry<String, Object> entry : properties.entrySet()) {
                 converted.put(entry.getKey(), String.valueOf(entry.getValue()));
             }
-            return new Key(type, name, scope, Collections.unmodifiableMap(converted));
+            return new Key(owner, name, scope, Collections.unmodifiableMap(converted));
         }
     }
 }

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/AbstractTestContainersProviderTest.groovy
@@ -8,6 +8,8 @@ class AbstractTestContainersProviderTest extends Specification {
         def provider = Mock(AbstractTestContainersProvider) {
             getDefaultImageName() >> 'my-image'
             getSimpleName() >> 'test'
+            getContainerOwnerKey(_, _, _) >> AbstractTestContainersProviderTest.name
+            getContainerQuery(_, _, _) >> [request: 'value']
         }
 
         when:

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
@@ -142,6 +142,23 @@ class TestContainersTest extends Specification {
         TestContainers.hasDatabase(second, "reporting_db")
     }
 
+    def "createDatabaseIfMissing only creates a database once per container"() {
+        def container = Stub(GenericContainer)
+        int created = 0
+
+        when:
+        TestContainers.createDatabaseIfMissing(container, "shared_db") {
+            created++
+        }
+        TestContainers.createDatabaseIfMissing(container, "shared_db") {
+            created++
+        }
+
+        then:
+        created == 1
+        TestContainers.hasDatabase(container, "shared_db")
+    }
+
     void create(String name, String scope, GenericContainer container) {
         TestContainers.getOrCreate("foo", TestContainersTest.name, name, Scope.of(scope), [
                 (Scope.PROPERTY_KEY): scope

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
@@ -61,8 +61,89 @@ class TestContainersTest extends Specification {
         ]
     }
 
+    def "normalized container identity can reuse a container across requested properties"() {
+        def container = Stub(GenericContainer)
+        int created = 0
+
+        when:
+        def jdbcContainer = TestContainers.getOrCreate("datasources.read.url", "postgres", "postgres", Scope.ROOT, [
+                "test-resources.resource-name": "shared"
+        ], () -> null) { imageName ->
+            created++
+            container
+        }
+        def r2dbcContainer = TestContainers.getOrCreate("r2dbc.datasources.write.url", "postgres", "postgres", Scope.ROOT, [
+                "test-resources.resource-name": "shared"
+        ], () -> null) { imageName ->
+            created++
+            Stub(GenericContainer)
+        }
+
+        then:
+        jdbcContainer.is(r2dbcContainer)
+        created == 1
+        TestContainers.findByRequestedProperty(Scope.ROOT, "datasources.read.url") == [container]
+        TestContainers.findByRequestedProperty(Scope.ROOT, "r2dbc.datasources.write.url") == [container]
+    }
+
+    def "different shared resource names still create different containers"() {
+        def first = Stub(GenericContainer)
+        def second = Stub(GenericContainer)
+
+        when:
+        def readContainer = TestContainers.getOrCreate("datasources.read.url", "postgres", "postgres", Scope.ROOT, [
+                "test-resources.resource-name": "primary"
+        ], () -> null) { imageName ->
+            first
+        }
+        def writeContainer = TestContainers.getOrCreate("datasources.write.url", "postgres", "postgres", Scope.ROOT, [
+                "test-resources.resource-name": "reporting"
+        ], () -> null) { imageName ->
+            second
+        }
+
+        then:
+        !readContainer.is(writeContainer)
+    }
+
+    def "normalized identity still isolates containers by scope"() {
+        def rootContainer = Stub(GenericContainer)
+        def childContainer = Stub(GenericContainer)
+
+        when:
+        def root = TestContainers.getOrCreate("datasources.default.url", "postgres", "postgres", Scope.of(null), [
+                "test-resources.resource-name": "shared"
+        ], () -> null) { imageName ->
+            rootContainer
+        }
+        def child = TestContainers.getOrCreate("datasources.default.url", "postgres", "postgres", Scope.of("child"), [
+                "test-resources.resource-name": "shared"
+        ], () -> null) { imageName ->
+            childContainer
+        }
+
+        then:
+        !root.is(child)
+    }
+
+    def "remembered databases are tracked per container"() {
+        def first = Stub(GenericContainer)
+        def second = Stub(GenericContainer)
+
+        when:
+        TestContainers.rememberDatabase(first, "read_db")
+        TestContainers.rememberDatabase(first, "write_db")
+        TestContainers.rememberDatabase(second, "reporting_db")
+
+        then:
+        TestContainers.hasDatabase(first, "read_db")
+        TestContainers.hasDatabase(first, "write_db")
+        !TestContainers.hasDatabase(first, "reporting_db")
+        TestContainers.hasDatabase(second, "reporting_db")
+    }
+
     void create(String name, String scope, GenericContainer container) {
-        TestContainers.getOrCreate("foo", TestContainersTest, name, [
+        TestContainers.getOrCreate("foo", TestContainersTest.name, name, Scope.of(scope), [
                 (Scope.PROPERTY_KEY): scope
         ], () -> null) { imageName ->
             container


### PR DESCRIPTION
## Summary
- add normalized shared-resource identity for shared JDBC and R2DBC testcontainers via `test-resources.resource-name`
- create and reuse additional PostgreSQL/MySQL/MariaDB databases inside a shared container when `db-name` differs
- add focused regression coverage and guide updates for shared physical-resource reuse semantics

## Verification
- `./gradlew :micronaut-test-resources-testcontainers:test --tests 'io.micronaut.testresources.testcontainers.AbstractTestContainersProviderTest' --tests 'io.micronaut.testresources.testcontainers.TestContainersTest' :micronaut-test-resources-jdbc-mssql:test --tests 'io.micronaut.testresources.mssql.MSSQLTestResourceProviderSpec' :micronaut-test-resources-r2dbc-mssql:test --tests 'io.micronaut.testresources.r2dbc.mssql.R2DBCMSSQLTestResourceProviderSpec' :micronaut-test-resources-jdbc-postgresql:test --tests 'io.micronaut.testresources.jdbc.mysql.SharedResourceNamePostgreSQLTest' :micronaut-test-resources-r2dbc-postgresql:test --tests 'io.micronaut.testresources.r2dbc.postgres.SharedResourceNamePostgreSQLTest'

## Release Metadata
- Micronaut org project: `Micronaut 5.0.0 Release`
- Ambiguity note: open org project `5.0.0-M3` may still matter for milestone timing

Closes #111

---
###### ✨ This message was AI-generated using gpt-5.4
