### PR TITLE
Warn once when a Test Resources Provider is disabled

### DIFF
--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/ToggableTestResourcesResolver.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/ToggableTestResourcesResolver.java
@@ -33,9 +33,12 @@ public interface ToggableTestResourcesResolver extends TestResourcesResolver {
         if (o == null) {
             return true;
         }
+        boolean enabled;
         if (o instanceof Boolean b) {
-            return b;
+            enabled = b;
+        } else {
+            enabled = Boolean.parseBoolean(String.valueOf(o));
         }
-        return Boolean.parseBoolean(String.valueOf(o));
+        return enabled;
     }
 }

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/ToggableTestResourcesResolverTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/ToggableTestResourcesResolverTest.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.testresources.core
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ToggableTestResourcesResolverTest extends Specification {
+    private final ToggableTestResourcesResolver resolver = new TestResolver()
+
+    void "missing config keeps provider enabled"() {
+        expect:
+        resolver.isEnabled([:])
+    }
+
+    @Unroll
+    void "false value #value disables provider"() {
+        expect:
+        !resolver.isEnabled(["kafka.enabled": value])
+
+        where:
+        value << [false, "false"]
+    }
+
+    @Unroll
+    void "truthy value #value keeps provider enabled"() {
+        expect:
+        resolver.isEnabled(["kafka.enabled": value])
+
+        where:
+        value << [true, "true"]
+    }
+
+    private static final class TestResolver implements ToggableTestResourcesResolver {
+        @Override
+        String getName() {
+            return "kafka"
+        }
+
+        @Override
+        String getDisplayName() {
+            return "Apache Kafka"
+        }
+
+        @Override
+        List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+            return []
+        }
+
+        @Override
+        Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+            return Optional.empty()
+        }
+    }
+}

--- a/test-resources-embedded/build.gradle
+++ b/test-resources-embedded/build.gradle
@@ -10,6 +10,7 @@ The resource resolvers are loaded via service loading.
 
 dependencies {
     api(project(':micronaut-test-resources-core'))
+    testImplementation(mnLogging.logback.classic)
 }
 
 testing {

--- a/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedDisabledResolverWarningSupport.java
+++ b/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedDisabledResolverWarningSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.embedded;
+
+import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
+import org.slf4j.Logger;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class EmbeddedDisabledResolverWarningSupport {
+    private static final Set<String> WARNED_DISABLED_RESOLVERS = ConcurrentHashMap.newKeySet();
+
+    private EmbeddedDisabledResolverWarningSupport() {
+    }
+
+    static boolean isEnabled(TestResourcesResolver resolver,
+                             Map<String, Object> testResourcesConfig,
+                             Logger logger) {
+        if (resolver instanceof ToggableTestResourcesResolver toggable) {
+            if (toggable.isEnabled(testResourcesConfig)) {
+                return true;
+            }
+            if (WARNED_DISABLED_RESOLVERS.add(toggable.getName())) {
+                logger.warn("Test resources provider for {} is disabled", toggable.getDisplayName());
+            }
+            return false;
+        }
+        return true;
+    }
+
+    static void resetWarnings() {
+        WARNED_DISABLED_RESOLVERS.clear();
+    }
+}

--- a/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertyExpressionResolver.java
+++ b/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertyExpressionResolver.java
@@ -20,7 +20,6 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.testresources.core.LazyTestResourcesExpressionResolver;
 import io.micronaut.testresources.core.TestResourcesResolver;
-import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,7 @@ public class EmbeddedTestResourcesPropertyExpressionResolver extends LazyTestRes
             List<TestResourcesResolver> resolvers = loader.getResolvers();
             Map<String, Object> testProperties = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
             for (TestResourcesResolver resolver : resolvers) {
-                if (resolver instanceof ToggableTestResourcesResolver toggable && !toggable.isEnabled(testProperties)) {
+                if (!EmbeddedDisabledResolverWarningSupport.isEnabled(resolver, testProperties, LOGGER)) {
                     continue;
                 }
                 if (canResolveExpression(propertyResolver, resolver, expression, testProperties)) {

--- a/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoader.java
+++ b/test-resources-embedded/src/main/java/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoader.java
@@ -19,7 +19,8 @@ import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.testresources.core.LazyTestResourcesPropertySourceLoader;
 import io.micronaut.testresources.core.PropertyExpressionProducer;
 import io.micronaut.testresources.core.TestResourcesResolver;
-import io.micronaut.testresources.core.ToggableTestResourcesResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
  */
 public class EmbeddedTestResourcesPropertySourceLoader extends LazyTestResourcesPropertySourceLoader {
     private static final Pattern CAMEL_CASE = Pattern.compile("([a-z])([A-Z])");
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedTestResourcesPropertySourceLoader.class);
 
     public EmbeddedTestResourcesPropertySourceLoader() {
         super(new EmbeddedTestResourcesProducer());
@@ -55,7 +57,7 @@ public class EmbeddedTestResourcesPropertySourceLoader extends LazyTestResources
         public List<String> produceKeys(ResourceLoader resourceLoader, Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
             return loader.getResolvers()
                 .stream()
-                .filter(r -> isEnabled(r, testResourcesConfig))
+                .filter(r -> EmbeddedDisabledResolverWarningSupport.isEnabled(r, testResourcesConfig, LOGGER))
                 .flatMap(r -> r.getResolvableProperties(propertyEntries, testResourcesConfig)
                     .stream().map(key -> assertValidKey(key, r))
                 ).distinct()
@@ -68,13 +70,6 @@ public class EmbeddedTestResourcesPropertySourceLoader extends LazyTestResources
                 throw new IllegalArgumentException("Test resources resolver [" + r.getClass().getName() + "] : Property key [" + key + "] is not valid. Property keys must be in kebab case.");
             }
             return key;
-        }
-
-        private static boolean isEnabled(TestResourcesResolver resolver, Map<String, Object> testResourcesConfig) {
-            if (resolver instanceof ToggableTestResourcesResolver toggable) {
-                return toggable.isEnabled(testResourcesConfig);
-            }
-            return true;
         }
     }
 }

--- a/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoaderWarningSpec.groovy
+++ b/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoaderWarningSpec.groovy
@@ -51,9 +51,10 @@ class EmbeddedTestResourcesPropertySourceLoaderWarningSpec extends Specification
         e.message.contains("kafka.bootstrap-servers")
         firstKeys == []
         secondKeys == []
-        appender.events.findAll { it.level == Level.WARN }*.formattedMessage == [
-            "Test resources provider for Apache Kafka is disabled"
-        ]
+        appender.events.count {
+            it.level == Level.WARN &&
+                it.formattedMessage == "Test resources provider for Apache Kafka is disabled"
+        } == 1
 
         cleanup:
         resolver.close()

--- a/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoaderWarningSpec.groovy
+++ b/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/EmbeddedTestResourcesPropertySourceLoaderWarningSpec.groovy
@@ -1,0 +1,143 @@
+package io.micronaut.testresources.embedded
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.core.convert.ArgumentConversionContext
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.core.value.PropertyResolver
+import io.micronaut.testresources.core.TestResourcesResolutionException
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.stream.Stream
+
+class EmbeddedTestResourcesPropertySourceLoaderWarningSpec extends Specification {
+    private final Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+    private final TestAppender appender = new TestAppender()
+
+    void setup() {
+        EmbeddedDisabledResolverWarningSupport.resetWarnings()
+        appender.start()
+        rootLogger.addAppender(appender)
+    }
+
+    void cleanup() {
+        rootLogger.detachAppender(appender)
+        appender.stop()
+        EmbeddedDisabledResolverWarningSupport.resetWarnings()
+    }
+
+    @Unroll
+    void "embedded key discovery and expression resolution warn once for disabled provider value #value"() {
+        given:
+        def resourceLoader = new TestResourceLoader([
+            "test-resources.kafka.enabled": value,
+            "kafka.test-port"             : 12345
+        ])
+        def loader = new EmbeddedTestResourcesPropertySourceLoader()
+        def resolver = new EmbeddedTestResourcesPropertyExpressionResolver()
+
+        when:
+        def firstKeys = loader.load("test-resources", resourceLoader).orElseThrow().iterator().toList()
+        def secondKeys = loader.load("test-resources", resourceLoader).orElseThrow().iterator().toList()
+        resolver.resolve(resourceLoader, ConversionService.SHARED, "auto.test.resources.kafka.bootstrap-servers", String)
+
+        then:
+        def e = thrown(TestResourcesResolutionException)
+        e.message.contains("kafka.bootstrap-servers")
+        firstKeys == []
+        secondKeys == []
+        appender.events.findAll { it.level == Level.WARN }*.formattedMessage == [
+            "Test resources provider for Apache Kafka is disabled"
+        ]
+
+        cleanup:
+        resolver.close()
+
+        where:
+        value << [false, "false"]
+    }
+
+    private static final class TestResourceLoader implements ResourceLoader, PropertyResolver {
+        private final Map<String, Object> properties
+
+        private TestResourceLoader(Map<String, Object> properties) {
+            this.properties = properties
+        }
+
+        @Override
+        boolean containsProperty(String name) {
+            properties.containsKey(name)
+        }
+
+        @Override
+        boolean containsProperties(String name) {
+            properties.keySet().any { it == name || it.startsWith("${name}.") }
+        }
+
+        @Override
+        <T> Optional<T> getProperty(String name, ArgumentConversionContext<T> conversionContext) {
+            def value = properties.get(name)
+            if (value == null) {
+                return Optional.empty()
+            }
+            return ConversionService.SHARED.convert(value, conversionContext)
+        }
+
+        @Override
+        Collection<List<String>> getPropertyPathMatches(String pathPattern) {
+            []
+        }
+
+        @Override
+        Collection<String> getPropertyEntries(String name) {
+            properties.keySet()
+                .findAll { it.startsWith("${name}.") }
+                .collect { it.substring(name.length() + 1) }
+        }
+
+        @Override
+        Map<String, Object> getProperties(String name) {
+            properties.findAll { key, ignored -> key.startsWith("${name}.") }
+                .collectEntries { key, value -> [(key.substring(name.length() + 1)): value] }
+        }
+
+        @Override
+        Optional<InputStream> getResourceAsStream(String path) {
+            Optional.empty()
+        }
+
+        @Override
+        Optional<URL> getResource(String path) {
+            Optional.empty()
+        }
+
+        @Override
+        Stream<URL> getResources(String path) {
+            Stream.empty()
+        }
+
+        @Override
+        boolean supportsPrefix(String path) {
+            false
+        }
+
+        @Override
+        ResourceLoader forBase(String basePath) {
+            this
+        }
+    }
+
+    private static final class TestAppender extends AppenderBase<ILoggingEvent> {
+        final List<ILoggingEvent> events = []
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            events << eventObject
+        }
+    }
+}

--- a/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/support/FakeKafkaResolver.java
+++ b/test-resources-embedded/src/test/groovy/io/micronaut/testresources/embedded/support/FakeKafkaResolver.java
@@ -16,6 +16,7 @@
 package io.micronaut.testresources.embedded.support;
 
 import io.micronaut.testresources.core.TestResourcesResolver;
+import io.micronaut.testresources.core.ToggableTestResourcesResolver;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,11 +25,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class FakeKafkaResolver implements TestResourcesResolver {
+public class FakeKafkaResolver implements ToggableTestResourcesResolver {
 
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap-servers";
     public static final String KAFKA_TOPIC = "kafka.topic";
     public static final String KAFKA_TEST_PORT = "kafka.test-port";
+
+    @Override
+    public String getName() {
+        return "kafka";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Apache Kafka";
+    }
 
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testFixturesImplementation(projects.micronautTestResourcesCore)
     testFixturesImplementation(projects.micronautTestResourcesTestcontainers)
     testImplementation(mn.micronaut.http.client)
+    testImplementation(mnLogging.logback.classic)
     testImplementation(projects.micronautTestResourcesClient)
     // TODO: MN5 Requires Micronaut Kafka release
 //    testRuntimeOnly(projects.micronautTestResourcesKafka)

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesController.java
@@ -40,6 +40,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -60,6 +62,7 @@ public class TestResourcesController implements TestResourcesResolver {
     private final EmbeddedServer embeddedServer;
     private final ApplicationContext applicationContext;
     private final TaskScheduler taskScheduler;
+    private final Set<String> warnedDisabledResolvers = ConcurrentHashMap.newKeySet();
 
     public TestResourcesController(List<PropertyResolutionListener> propertyResolutionListeners,
                                    EmbeddedServer embeddedServer,
@@ -155,8 +158,7 @@ public class TestResourcesController implements TestResourcesResolver {
         var sanitizedTestResourcesConfig = sanitizeTestResourcesConfig(testResourcesConfig);
         Optional<String> result = Optional.empty();
         for (TestResourcesResolver resolver : loader.getResolvers()) {
-            if (resolver instanceof ToggableTestResourcesResolver toggable &&
-                !toggable.isEnabled(sanitizedTestResourcesConfig)) {
+            if (!isEnabled(resolver, sanitizedTestResourcesConfig)) {
                 continue;
             }
             try {
@@ -277,10 +279,16 @@ public class TestResourcesController implements TestResourcesResolver {
             });
     }
 
-    private static boolean isEnabled(TestResourcesResolver resolver,
-                                     Map<String, Object> testResourcesConfig) {
+    private boolean isEnabled(TestResourcesResolver resolver,
+                              Map<String, Object> testResourcesConfig) {
         if (resolver instanceof ToggableTestResourcesResolver toggable) {
-            return toggable.isEnabled(testResourcesConfig);
+            if (toggable.isEnabled(testResourcesConfig)) {
+                return true;
+            }
+            if (warnedDisabledResolvers.add(toggable.getName())) {
+                LOGGER.warn("Test resources provider for {} is disabled", toggable.getDisplayName());
+            }
+            return false;
         }
         return true;
     }

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesControllerWarningSpec.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesControllerWarningSpec.groovy
@@ -1,0 +1,92 @@
+package io.micronaut.testresources.server
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskScheduler
+import io.micronaut.testresources.core.ResolverLoader
+import io.micronaut.testresources.core.ToggableTestResourcesResolver
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TestResourcesControllerWarningSpec extends Specification {
+    private final Logger logger = (Logger) LoggerFactory.getLogger(TestResourcesController)
+    private final TestAppender appender = new TestAppender()
+
+    void setup() {
+        appender.start()
+        logger.addAppender(appender)
+    }
+
+    void cleanup() {
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    @Unroll
+    void "repeated resolution attempts warn once for disabled provider value #value"() {
+        given:
+        def resolver = new TestResolver()
+        def controller = new TestResourcesController(
+            [],
+            Stub(EmbeddedServer),
+            Stub(ApplicationContext),
+            Stub(ResolverLoader) {
+                getResolvers() >> [resolver]
+            },
+            Stub(TaskScheduler)
+        )
+
+        when:
+        def first = controller.resolve("kafka.bootstrap.servers", [:], ["kafka.enabled": value])
+        def second = controller.resolve("kafka.bootstrap.servers", [:], ["kafka.enabled": value])
+
+        then:
+        !first.present
+        !second.present
+        resolver.resolveCalls == 0
+        appender.events*.formattedMessage == ["Test resources provider for Apache Kafka is disabled"]
+        appender.events*.level == [Level.WARN]
+
+        where:
+        value << [false, "false"]
+    }
+
+    private static final class TestResolver implements ToggableTestResourcesResolver {
+        int resolveCalls
+
+        @Override
+        String getName() {
+            return "kafka"
+        }
+
+        @Override
+        String getDisplayName() {
+            return "Apache Kafka"
+        }
+
+        @Override
+        List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+            return ["kafka.bootstrap.servers"]
+        }
+
+        @Override
+        Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+            resolveCalls++
+            return Optional.of("should-not-resolve")
+        }
+    }
+
+    private static final class TestAppender extends AppenderBase<ILoggingEvent> {
+        final List<ILoggingEvent> events = []
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            events << eventObject
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- warn once when disabled providers are skipped in embedded and server resolution flows
- cover embedded lazy key discovery plus follow-on expression resolution without duplicate warnings
- keep core toggle parsing focused and add regression tests for false and truthy values

## Verification
- `./gradlew :micronaut-test-resources-embedded:test --tests io.micronaut.testresources.embedded.EmbeddedTestResourcesPropertySourceLoaderWarningSpec :micronaut-test-resources-core:test --tests io.micronaut.testresources.core.ToggableTestResourcesResolverTest :micronaut-test-resources-server:test --tests io.micronaut.testresources.server.TestResourcesControllerWarningSpec`

## Release Metadata
- type: enhancement
- Micronaut org project: `5.0.0 Release`
- Ambiguity note: `5.0.0-M3` is still open/public, but `5.0.0 Release` remains the QA-selected best fit

Fixes #903

---
###### ✨ This message was AI-generated using gpt-5
