### PR TITLE
Document test resources settings directory usage

### DIFF
--- a/src/main/docs/guide/architecture-client.adoc
+++ b/src/main/docs/guide/architecture-client.adoc
@@ -3,3 +3,20 @@ It basically delegates requests of property resolution from Micronaut to the ser
 
 This client is automatically injected on the application classpath in development mode or during tests.
 As a user, you should never have to deal with this module directly.
+
+== Conventional lookup locations
+
+When the client is configured automatically, Micronaut Test Resources prefers system properties.
+This is the most reliable option because it supports the full client configuration, including shared servers and namespaces.
+
+If the client cannot find the server settings in system properties, it falls back to `test-resources.properties` files in conventional locations:
+
+* `./.micronaut/test-resources/test-resources.properties`
+* `~/.micronaut/test-resources/test-resources.properties` when the `TEST_RESOURCES_NAMESPACE` environment variable is not set
+* `~/.micronaut/test-resources-<namespace>/test-resources.properties` when the `TEST_RESOURCES_NAMESPACE` environment variable is set
+
+Build tools write this file when they start or connect to a test resources server.
+The working-directory location is scoped to the current project checkout.
+The user-home location is intended for settings shared across builds, so it can survive older experiments or manually managed shared servers.
+
+NOTE: If Micronaut Test Resources unexpectedly connects to an old server or fails because a recorded server is no longer running, remove the stale `test-resources.properties` file from the relevant `.micronaut` directory and rerun the build so the settings can be recreated.

--- a/src/main/docs/guide/architecture-client.adoc
+++ b/src/main/docs/guide/architecture-client.adoc
@@ -15,7 +15,7 @@ If the client cannot find the server settings in system properties, it falls bac
 * `~/.micronaut/test-resources/test-resources.properties` when the `TEST_RESOURCES_NAMESPACE` environment variable is not set
 * `~/.micronaut/test-resources-<namespace>/test-resources.properties` when the `TEST_RESOURCES_NAMESPACE` environment variable is set
 
-Build tools write this file when they start or connect to a test resources server.
+Build tools write this file when they start a server and create fresh recorded settings, then reuse it when reconnecting to an already-running shared server.
 The working-directory location is scoped to the current project checkout.
 The user-home location is intended for settings shared across builds, so it can survive older experiments or manually managed shared servers.
 


### PR DESCRIPTION
## Summary
- document the conventional `test-resources.properties` lookup locations used by the test resources client
- clarify that the home-directory fallback is namespace-specific: the default home path is used only when `TEST_RESOURCES_NAMESPACE` is unset
- add stale-file cleanup guidance for obsolete recorded server settings

## Verification
- ./gradlew publishGuide
- ./gradlew docs

Closes #874

---
###### ✨ This message was AI-generated using gpt-5
