### PR TITLE
Fix Java 25 CDS dump incompatibility

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -474,7 +474,9 @@ public class ServerUtils {
         @Override
         public Map<String, String> getSystemProperties() {
             Map<String, String> systemProperties = new HashMap<>();
-            systemProperties.put(JMX_SYSTEM_PROPERTY, null);
+            if (!isCDSDumpInvocation()) {
+                systemProperties.put(JMX_SYSTEM_PROPERTY, null);
+            }
             String dockerCheckTimeout = System.getProperty(DOCKER_CHECK_TIMEOUT_SECONDS_PROPERTY);
             if (dockerCheckTimeout == null) {
                 dockerCheckTimeout = System.getenv(DOCKER_CHECK_TIMEOUT_SECONDS_ENV);

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -60,7 +60,7 @@ class ServerUtilsTest extends Specification {
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
             assert params.mainClass == 'io.micronaut.testresources.server.TestResourcesService'
             assert params.classpath == classpath
-            def sysProps = ['com.sun.management.jmxremote': null]
+            def sysProps = [(JMX_PROPERTY): null]
             if (token != null) {
                 sysProps["server.access-token"] = token
             }
@@ -197,7 +197,8 @@ class ServerUtilsTest extends Specification {
             def jvmArgs = params.jvmArguments
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
-            assert params.systemProperties == [(JMX_PROPERTY): null]
+            assert params.systemProperties.containsKey(JMX_PROPERTY)
+            assert params.systemProperties.get(JMX_PROPERTY) == null
             assert params.classpath.contains(cdsFlatJar.toFile())
             assert Files.exists(cdsFlatJar)
             Files.write(cdsClassList, "test".getBytes())
@@ -224,7 +225,8 @@ class ServerUtilsTest extends Specification {
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
-            assert params.systemProperties == [(JMX_PROPERTY): null]
+            assert params.systemProperties.containsKey(JMX_PROPERTY)
+            assert params.systemProperties.get(JMX_PROPERTY) == null
         }
         1 * factory.waitFor(_) >> {
             portFile.toFile().text = "${embeddedServer.port}"
@@ -241,7 +243,8 @@ class ServerUtilsTest extends Specification {
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
-            assert params.systemProperties == [(JMX_PROPERTY): null]
+            assert params.systemProperties.containsKey(JMX_PROPERTY)
+            assert params.systemProperties.get(JMX_PROPERTY) == null
         }
         1 * factory.waitFor(_) >> {
             portFile.toFile().text = "${embeddedServer.port}"
@@ -257,7 +260,8 @@ class ServerUtilsTest extends Specification {
             def jvmArgs = params.jvmArguments
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
-            assert params.systemProperties == [(JMX_PROPERTY): null]
+            assert params.systemProperties.containsKey(JMX_PROPERTY)
+            assert params.systemProperties.get(JMX_PROPERTY) == null
             assert params.classpath == []
             Files.write(cdsClassList, "test".getBytes())
         }

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -14,6 +14,8 @@ import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 
 class ServerUtilsTest extends Specification {
+    private static final String JMX_PROPERTY = 'com.sun.management.jmxremote'
+
     @TempDir
     Path tmpDir
 
@@ -195,6 +197,7 @@ class ServerUtilsTest extends Specification {
             def jvmArgs = params.jvmArguments
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
+            assert params.systemProperties == [(JMX_PROPERTY): null]
             assert params.classpath.contains(cdsFlatJar.toFile())
             assert Files.exists(cdsFlatJar)
             Files.write(cdsClassList, "test".getBytes())
@@ -213,6 +216,7 @@ class ServerUtilsTest extends Specification {
             assert jvmArgs.contains("-Xshare:dump")
             assert jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
+            assert !params.systemProperties.containsKey(JMX_PROPERTY)
             Files.write(cdsArchiveFile, "test".getBytes())
         }
         1 * factory.startServer(_) >> { ServerUtils.ProcessParameters params ->
@@ -220,6 +224,7 @@ class ServerUtilsTest extends Specification {
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
+            assert params.systemProperties == [(JMX_PROPERTY): null]
         }
         1 * factory.waitFor(_) >> {
             portFile.toFile().text = "${embeddedServer.port}"
@@ -236,6 +241,7 @@ class ServerUtilsTest extends Specification {
             assert !jvmArgs.contains("-Xshare:dump")
             assert !jvmArgs.contains(cdsSharedClassListOption)
             assert jvmArgs.contains(cdsSharedArchiveFileOption)
+            assert params.systemProperties == [(JMX_PROPERTY): null]
         }
         1 * factory.waitFor(_) >> {
             portFile.toFile().text = "${embeddedServer.port}"
@@ -251,6 +257,7 @@ class ServerUtilsTest extends Specification {
             def jvmArgs = params.jvmArguments
             assert jvmArgs.contains("-Xshare:off")
             assert jvmArgs.contains(cdsClassListOption)
+            assert params.systemProperties == [(JMX_PROPERTY): null]
             assert params.classpath == []
             Files.write(cdsClassList, "test".getBytes())
         }


### PR DESCRIPTION
## Summary
- avoid the invalid `com.sun.management.jmxremote` + `-Xshare:dump` launch shape reported on Java 25 by omitting the JMX property only for the CDS dump subprocess
- preserve the JMX property for the class-list export pass and the final archive-backed startup
- extend `ServerUtilsTest` to assert the JMX property across the CDS lifecycle without brittle whole-map equality checks

## Verification
- `./gradlew :micronaut-test-resources-build-tools:test --tests io.micronaut.testresources.buildtools.ServerUtilsTest --rerun-tasks --no-daemon`

## Release Board Note
- QA originally targeted `5.0.0 Release`, with `5.0.0-M3` noted as ambiguous.
- The `5.0.0 Release` project no longer exists, so this PR is linked against the live `5.0.0-M3` board instead.

Fixes #1023

---
###### ✨ This message was AI-generated using gpt-5.4
