### PR TITLE
Fix standalone test resource discovery in client factory

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -190,7 +190,7 @@ public final class TestResourcesClientFactory {
                 .flatMap(Optional::stream)
                 .forEach(candidates::add);
         } catch (IOException e) {
-            throw new TestResourcesException(e);
+            return candidates;
         }
         return candidates;
     }
@@ -220,7 +220,9 @@ public final class TestResourcesClientFactory {
     }
 
     private static Optional<Path> existingPropertiesFile(Path location) {
-        if (Files.exists(location) && location.getFileName().endsWith(TEST_RESOURCES_PROPERTIES)) {
+        if (Files.isRegularFile(location)
+            && Files.isReadable(location)
+            && location.getFileName().endsWith(TEST_RESOURCES_PROPERTIES)) {
             return Optional.of(location);
         }
         return Optional.empty();

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -24,8 +24,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 /**
  * A factory responsible for creating a {@link TestResourcesClient}.
@@ -39,6 +42,9 @@ public final class TestResourcesClientFactory {
     private static final String TEST_RESOURCES_PROPERTIES = "test-resources.properties";
     private static final String DEFAULT_MICRONAUT_DIR = ".micronaut/test-resources/";
     private static final String DEFAULT_PROPERTIES_RELATIVE_PATH = DEFAULT_MICRONAUT_DIR + TEST_RESOURCES_PROPERTIES;
+    private static final String STANDALONE_SETTINGS_RELATIVE_PATH = DEFAULT_MICRONAUT_DIR + "test-resources-settings/" + TEST_RESOURCES_PROPERTIES;
+    private static final String SETTINGS_GRADLE = "settings.gradle";
+    private static final String SETTINGS_GRADLE_KTS = "settings.gradle.kts";
     private static final String TEST_RESOURCES_NAMESPACE = "TEST_RESOURCES_NAMESPACE";
     private static final String NAMESPACE_PREFIX = ".micronaut/test-resources-";
 
@@ -64,17 +70,19 @@ public final class TestResourcesClientFactory {
      * @return a configured client, or an empty optional.
      */
     public static Optional<TestResourcesClient> findByConvention() {
+        return findByConvention(
+            Paths.get("").toAbsolutePath(),
+            Paths.get(System.getProperty("user.home")),
+            System.getenv(TEST_RESOURCES_NAMESPACE)
+        );
+    }
+
+    static Optional<TestResourcesClient> findByConvention(Path currentDirectory,
+                                                          Path homeDirectory,
+                                                          String namespace) {
         return fromSystemProperties()
-            .or(() -> fromFileSystem(Paths.get(DEFAULT_PROPERTIES_RELATIVE_PATH)))
-            .or(() -> {
-                var homedir = Paths.get(System.getProperty("user.home"));
-                var namespace = System.getenv(TEST_RESOURCES_NAMESPACE);
-                if (namespace != null) {
-                    return fromFileSystem(homedir.resolve(
-                        NAMESPACE_PREFIX + namespace + "/" + TEST_RESOURCES_PROPERTIES));
-                }
-                return fromFileSystem(homedir.resolve(DEFAULT_PROPERTIES_RELATIVE_PATH));
-            });
+            .or(() -> findPropertiesFileByConvention(currentDirectory, homeDirectory, namespace)
+                .flatMap(TestResourcesClientFactory::fromFileSystem));
     }
 
     /**
@@ -127,6 +135,93 @@ public final class TestResourcesClientFactory {
             client = new DefaultTestResourcesClient(serverUri, accessToken, clientReadTimeout);
             cachedClient = new WeakReference<>(client);
             return Optional.of(client);
+        }
+        return Optional.empty();
+    }
+
+    static Optional<Path> findPropertiesFileByConvention(Path currentDirectory,
+                                                         Path homeDirectory,
+                                                         String namespace) {
+        return findLocalPropertiesFile(currentDirectory)
+            .or(() -> findHomePropertiesFile(homeDirectory, namespace));
+    }
+
+    private static Optional<Path> findLocalPropertiesFile(Path currentDirectory) {
+        var localProperties = existingPropertiesFile(currentDirectory.resolve(DEFAULT_PROPERTIES_RELATIVE_PATH));
+        if (localProperties.isPresent()) {
+            return localProperties;
+        }
+        return findStandalonePropertiesFile(currentDirectory);
+    }
+
+    private static Optional<Path> findStandalonePropertiesFile(Path currentDirectory) {
+        Path normalizedCurrentDirectory = currentDirectory.toAbsolutePath().normalize();
+        var buildRoot = findNearestGradleBuildRoot(normalizedCurrentDirectory);
+        Path candidateRoot = normalizedCurrentDirectory;
+        while (candidateRoot != null) {
+            var standaloneCandidates = findStandaloneCandidates(candidateRoot);
+            if (standaloneCandidates.size() == 1) {
+                return Optional.of(standaloneCandidates.get(0));
+            }
+            if (buildRoot.isEmpty() || candidateRoot.equals(buildRoot.get())) {
+                break;
+            }
+            candidateRoot = candidateRoot.getParent();
+        }
+        return Optional.empty();
+    }
+
+    private static List<Path> findStandaloneCandidates(Path lookupRoot) {
+        var candidates = new ArrayList<Path>();
+        if (!Files.isDirectory(lookupRoot)) {
+            return candidates;
+        }
+        boolean gradleBuildRoot = isGradleBuildRoot(lookupRoot);
+        existingPropertiesFile(lookupRoot.resolve(STANDALONE_SETTINGS_RELATIVE_PATH))
+            .ifPresent(candidates::add);
+        if (!gradleBuildRoot) {
+            return candidates;
+        }
+        try (Stream<Path> children = Files.list(lookupRoot)) {
+            children
+                .filter(Files::isDirectory)
+                .map(child -> child.resolve(STANDALONE_SETTINGS_RELATIVE_PATH))
+                .map(TestResourcesClientFactory::existingPropertiesFile)
+                .flatMap(Optional::stream)
+                .forEach(candidates::add);
+        } catch (IOException e) {
+            throw new TestResourcesException(e);
+        }
+        return candidates;
+    }
+
+    private static Optional<Path> findNearestGradleBuildRoot(Path directory) {
+        Path candidate = directory;
+        while (candidate != null) {
+            if (Files.isDirectory(candidate) && isGradleBuildRoot(candidate)) {
+                return Optional.of(candidate);
+            }
+            candidate = candidate.getParent();
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isGradleBuildRoot(Path directory) {
+        return Files.exists(directory.resolve(SETTINGS_GRADLE))
+            || Files.exists(directory.resolve(SETTINGS_GRADLE_KTS));
+    }
+
+    private static Optional<Path> findHomePropertiesFile(Path homeDirectory, String namespace) {
+        if (namespace != null) {
+            return existingPropertiesFile(homeDirectory.resolve(
+                NAMESPACE_PREFIX + namespace + "/" + TEST_RESOURCES_PROPERTIES));
+        }
+        return existingPropertiesFile(homeDirectory.resolve(DEFAULT_PROPERTIES_RELATIVE_PATH));
+    }
+
+    private static Optional<Path> existingPropertiesFile(Path location) {
+        if (Files.exists(location) && location.getFileName().endsWith(TEST_RESOURCES_PROPERTIES)) {
+            return Optional.of(location);
         }
         return Optional.empty();
     }

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientFactoryTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientFactoryTest.groovy
@@ -1,0 +1,136 @@
+package io.micronaut.testresources.client
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.environment.RestoreSystemProperties
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Optional
+
+import static io.micronaut.testresources.client.ConfigFinder.systemPropertyNameOf
+
+class TestResourcesClientFactoryTest extends Specification implements ClientCleanup {
+
+    @TempDir
+    Path tempDir
+
+    def cleanup() {
+        TestResourcesClientFactory.cachedClient = null
+    }
+
+    @RestoreSystemProperties
+    def "system properties win over filesystem fallback"() {
+        given:
+        def currentDirectory = tempDir.resolve("application")
+        Files.createDirectories(currentDirectory)
+        writeSettingsFile(currentDirectory.resolve(".micronaut/test-resources/test-resources.properties"), "http://file-system")
+        System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), "http://system-properties")
+
+        when:
+        def client = TestResourcesClientFactory.findByConvention(currentDirectory, tempDir.resolve("home"), null)
+
+        then:
+        client.present
+        client.get() instanceof DefaultTestResourcesClient
+        client.get().@baseUri == "http://system-properties"
+    }
+
+    def "existing local conventional file still resolves"() {
+        given:
+        def currentDirectory = tempDir.resolve("application")
+        writeSettingsFile(currentDirectory.resolve(".micronaut/test-resources/test-resources.properties"), "http://local")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null) ==
+            Optional.of(currentDirectory.resolve(".micronaut/test-resources/test-resources.properties"))
+    }
+
+    def "standalone module directory resolves nested settings file"() {
+        given:
+        def currentDirectory = tempDir.resolve("test-resources")
+        def settingsFile = currentDirectory.resolve(".micronaut/test-resources/test-resources-settings/test-resources.properties")
+        writeSettingsFile(settingsFile, "http://standalone")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null) ==
+            Optional.of(settingsFile)
+    }
+
+    def "consumer module directory resolves standalone settings file via ancestor lookup"() {
+        given:
+        def currentDirectory = tempDir.resolve("application")
+        Files.createDirectories(currentDirectory)
+        writeSettingsGradle(tempDir)
+        def settingsFile = tempDir.resolve("test-resources/.micronaut/test-resources/test-resources-settings/test-resources.properties")
+        writeSettingsFile(settingsFile, "http://standalone")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null) ==
+            Optional.of(settingsFile)
+    }
+
+    def "repository root resolves standalone settings file"() {
+        given:
+        def currentDirectory = tempDir
+        writeSettingsGradle(currentDirectory)
+        def settingsFile = tempDir.resolve("test-resources/.micronaut/test-resources/test-resources-settings/test-resources.properties")
+        writeSettingsFile(settingsFile, "http://standalone")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null) ==
+            Optional.of(settingsFile)
+    }
+
+    def "ambiguous standalone settings do not resolve nondeterministically"() {
+        given:
+        def currentDirectory = tempDir
+        writeSettingsGradle(currentDirectory)
+        writeSettingsFile(tempDir.resolve("test-resources-a/.micronaut/test-resources/test-resources-settings/test-resources.properties"), "http://one")
+        writeSettingsFile(tempDir.resolve("test-resources-b/.micronaut/test-resources/test-resources-settings/test-resources.properties"), "http://two")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null).empty
+    }
+
+    def "namespaced home fallback still resolves"() {
+        given:
+        def homeDirectory = tempDir.resolve("home")
+        def settingsFile = homeDirectory.resolve(".micronaut/test-resources-example/test-resources.properties")
+        writeSettingsFile(settingsFile, "http://home")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(tempDir.resolve("application"), homeDirectory, "example") ==
+            Optional.of(settingsFile)
+    }
+
+    def "non project ancestors do not contribute sibling standalone settings"() {
+        given:
+        def currentDirectory = tempDir.resolve("application")
+        Files.createDirectories(currentDirectory)
+        writeSettingsFile(tempDir.resolve("test-resources/.micronaut/test-resources/test-resources-settings/test-resources.properties"), "http://standalone")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null).empty
+    }
+
+    def "non project ancestors do not contribute direct standalone settings"() {
+        given:
+        def currentDirectory = tempDir.resolve("outer/project/application")
+        Files.createDirectories(currentDirectory)
+        writeSettingsGradle(tempDir.resolve("outer/project"))
+        writeSettingsFile(tempDir.resolve("outer/.micronaut/test-resources/test-resources-settings/test-resources.properties"), "http://standalone")
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null).empty
+    }
+
+    private static void writeSettingsFile(Path settingsFile, String serverUri) {
+        Files.createDirectories(settingsFile.parent)
+        Files.writeString(settingsFile, "server.uri=${serverUri}\n")
+    }
+
+    private static void writeSettingsGradle(Path projectDirectory) {
+        Files.writeString(projectDirectory.resolve("settings.gradle"), "rootProject.name = 'test-project'\n")
+    }
+}

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientFactoryTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientFactoryTest.groovy
@@ -46,6 +46,15 @@ class TestResourcesClientFactoryTest extends Specification implements ClientClea
             Optional.of(currentDirectory.resolve(".micronaut/test-resources/test-resources.properties"))
     }
 
+    def "directory named like properties file is ignored"() {
+        given:
+        def currentDirectory = tempDir.resolve("application")
+        Files.createDirectories(currentDirectory.resolve(".micronaut/test-resources/test-resources.properties"))
+
+        expect:
+        TestResourcesClientFactory.findPropertiesFileByConvention(currentDirectory, tempDir.resolve("home"), null).empty
+    }
+
     def "standalone module directory resolves nested settings file"() {
         given:
         def currentDirectory = tempDir.resolve("test-resources")


### PR DESCRIPTION
## Summary
- resolve standalone `test-resources-settings` discovery from the standalone module, consumer module, and repository root
- bound ancestor traversal to the nearest Gradle build root so unrelated parent-owned settings are ignored
- add focused regression tests for direct fallback, home fallback, ambiguity handling, and non-project ancestor guards

## Verification
- `./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.TestResourcesClientFactoryTest --rerun-tasks`

## Release Routing
- Micronaut org project target: `5.0.0 Release`
- QA ambiguity note preserved: `5.0.0-M3` was also plausible, but this PR follows the stable-train recommendation

Closes #638

---
###### ✨ This message was AI-generated using gpt-5.4
