### PR TITLE
Add Couchbase test resources support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ spock = "2.4-groovy-5.0"
 vertx-client = "5.0.10"
 amazon-awssdk-v1 = "1.12.797"
 amazon-awssdk-v2 = "2.42.38"
+couchbase-java-client = "3.11.1"
 jansi = "2.4.3"
 
 # Managed versions appear in the BOM
@@ -128,6 +129,7 @@ amazon-awssdk-v2-dynamodb = { module = "software.amazon.awssdk:dynamodb", versio
 amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2" }
 amazon-awssdk-v2-sqs = { module = "software.amazon.awssdk:sqs", version.ref = "amazon-awssdk-v2" }
 amazon-awssdk-v2-sns = { module = "software.amazon.awssdk:sns", version.ref = "amazon-awssdk-v2" }
+couchbase-java-client = { module = "com.couchbase.client:java-client", version.ref = "couchbase-java-client" }
 
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 #

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ jansi = "2.4.3"
 managed-opensearch-testcontainers = "4.1.0"
 managed-testcontainers = "2.0.4"
 managed-testcontainers-pulsar = "1.21.3"
-managed-testcontainers-couchbase = "1.21.3"
 managed-testcontainers-redis = "1.6.4"
 
 # Transitive dependencies upgrades
@@ -65,7 +64,7 @@ managed-solr-testcontainers = { module = "org.testcontainers:testcontainers-solr
 
 managed-testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "managed-testcontainers" }
 managed-testcontainers-consul = { module = "org.testcontainers:testcontainers-consul", version.ref = "managed-testcontainers" }
-managed-testcontainers-couchbase = { module = "org.testcontainers:couchbase", version.ref = "managed-testcontainers-couchbase" }
+managed-testcontainers-couchbase = { module = "org.testcontainers:testcontainers-couchbase", version.ref = "managed-testcontainers" }
 managed-testcontainers-elasticsearch = { module = "org.testcontainers:testcontainers-elasticsearch", version.ref = "managed-testcontainers" }
 managed-testcontainers-jdbc = { module = "org.testcontainers:testcontainers-jdbc", version.ref = "managed-testcontainers" }
 managed-testcontainers-hivemq = { module = "org.testcontainers:testcontainers-hivemq", version.ref = "managed-testcontainers" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ jansi = "2.4.3"
 managed-opensearch-testcontainers = "4.1.0"
 managed-testcontainers = "2.0.4"
 managed-testcontainers-pulsar = "1.21.3"
+managed-testcontainers-couchbase = "1.21.3"
 managed-testcontainers-redis = "1.6.4"
 
 # Transitive dependencies upgrades
@@ -64,6 +65,7 @@ managed-solr-testcontainers = { module = "org.testcontainers:testcontainers-solr
 
 managed-testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "managed-testcontainers" }
 managed-testcontainers-consul = { module = "org.testcontainers:testcontainers-consul", version.ref = "managed-testcontainers" }
+managed-testcontainers-couchbase = { module = "org.testcontainers:couchbase", version.ref = "managed-testcontainers-couchbase" }
 managed-testcontainers-elasticsearch = { module = "org.testcontainers:testcontainers-elasticsearch", version.ref = "managed-testcontainers" }
 managed-testcontainers-jdbc = { module = "org.testcontainers:testcontainers-jdbc", version.ref = "managed-testcontainers" }
 managed-testcontainers-hivemq = { module = "org.testcontainers:testcontainers-hivemq", version.ref = "managed-testcontainers" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,6 +65,7 @@ def localstackModules = [
 
 include 'test-resources-bom'
 include 'test-resources-build-tools'
+include 'test-resources-couchbase'
 include 'test-resources-core'
 include 'test-resources-client'
 include 'test-resources-control-panel'

--- a/src/main/docs/guide/modules-couchbase.adoc
+++ b/src/main/docs/guide/modules-couchbase.adoc
@@ -1,0 +1,18 @@
+Couchbase support will automatically start a https://www.couchbase.com[Couchbase Server container] and provide the values of the `couchbase.uri`, `couchbase.username`, and `couchbase.password` properties.
+
+The provider uses the `couchbase/server` image by default.
+
+You can override the image name and tag with `test-resources.containers.couchbase.image-name` and `test-resources.containers.couchbase.image-tag`.
+
+[configuration]
+----
+test-resources:
+  containers:
+    couchbase:
+      image-name: couchbase/server
+      image-tag: latest
+----
+
+If you already map one of those same properties explicitly through generic Testcontainers support, that explicit mapping still wins.
+
+For unsupported Couchbase topologies or additional property shapes, continue using xref:modules-testcontainers.adoc[generic Testcontainers support].

--- a/src/main/docs/guide/modules-couchbase.adoc
+++ b/src/main/docs/guide/modules-couchbase.adoc
@@ -13,6 +13,6 @@ test-resources:
       image-tag: latest
 ----
 
-If you already map one of those same properties explicitly through generic Testcontainers support, that explicit mapping still wins.
+If you explicitly map any of those same properties through generic Testcontainers support, the dedicated Couchbase provider stands down for the full `couchbase.uri` / `couchbase.username` / `couchbase.password` connection set so values never come from mixed containers.
 
 For unsupported Couchbase topologies or additional property shapes, continue using xref:modules-testcontainers.adoc[generic Testcontainers support].

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,8 @@ modules:
     title: MinIO
   modules-seaweedfs:
     title: SeaweedFS
+  modules-couchbase:
+    title: Couchbase
   modules-mongodb:
     title: MongoDB
   modules-mqtt:

--- a/test-resources-couchbase/build.gradle
+++ b/test-resources-couchbase/build.gradle
@@ -8,4 +8,5 @@ Provides support for launching a Couchbase test container.
 
 dependencies {
     implementation(libs.managed.testcontainers.couchbase)
+    testImplementation(libs.couchbase.java.client)
 }

--- a/test-resources-couchbase/build.gradle
+++ b/test-resources-couchbase/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+description = """
+Provides support for launching a Couchbase test container.
+"""
+
+dependencies {
+    implementation(libs.managed.testcontainers.couchbase)
+}

--- a/test-resources-couchbase/src/main/java/io/micronaut/testresources/couchbase/CouchbaseTestResourceProvider.java
+++ b/test-resources-couchbase/src/main/java/io/micronaut/testresources/couchbase/CouchbaseTestResourceProvider.java
@@ -48,10 +48,7 @@ public class CouchbaseTestResourceProvider extends AbstractTestContainersProvide
 
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        Set<String> explicitGenericMappings = explicitGenericMappings(testResourcesConfig);
-        return SUPPORTED_PROPERTIES_LIST.stream()
-            .filter(property -> !explicitGenericMappings.contains(property))
-            .toList();
+        return hasExplicitGenericOverlap(testResourcesConfig) ? List.of() : SUPPORTED_PROPERTIES_LIST;
     }
 
     @Override
@@ -86,7 +83,12 @@ public class CouchbaseTestResourceProvider extends AbstractTestContainersProvide
 
     @Override
     protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return SUPPORTED_PROPERTIES.contains(propertyName) && !explicitGenericMappings(testResourcesConfig).contains(propertyName);
+        return SUPPORTED_PROPERTIES.contains(propertyName) && !hasExplicitGenericOverlap(testResourcesConfig);
+    }
+
+    private static boolean hasExplicitGenericOverlap(Map<String, Object> testResourcesConfig) {
+        Set<String> explicitGenericMappings = explicitGenericMappings(testResourcesConfig);
+        return explicitGenericMappings.stream().anyMatch(SUPPORTED_PROPERTIES::contains);
     }
 
     private static Set<String> explicitGenericMappings(Map<String, Object> testResourcesConfig) {

--- a/test-resources-couchbase/src/main/java/io/micronaut/testresources/couchbase/CouchbaseTestResourceProvider.java
+++ b/test-resources-couchbase/src/main/java/io/micronaut/testresources/couchbase/CouchbaseTestResourceProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.couchbase;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.couchbase.CouchbaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A test resource provider which will spawn a Couchbase test container.
+ */
+public class CouchbaseTestResourceProvider extends AbstractTestContainersProvider<CouchbaseContainer> {
+    public static final String COUCHBASE_URI = "couchbase.uri";
+    public static final String COUCHBASE_USERNAME = "couchbase.username";
+    public static final String COUCHBASE_PASSWORD = "couchbase.password";
+    public static final String DEFAULT_IMAGE = "couchbase/server";
+    public static final String SIMPLE_NAME = "couchbase";
+    public static final String DISPLAY_NAME = "Couchbase";
+
+    private static final String CONTAINERS_PREFIX = "containers.";
+    private static final List<String> SUPPORTED_PROPERTIES_LIST = List.of(
+        COUCHBASE_URI,
+        COUCHBASE_USERNAME,
+        COUCHBASE_PASSWORD
+    );
+    private static final Set<String> SUPPORTED_PROPERTIES = Set.copyOf(SUPPORTED_PROPERTIES_LIST);
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        Set<String> explicitGenericMappings = explicitGenericMappings(testResourcesConfig);
+        return SUPPORTED_PROPERTIES_LIST.stream()
+            .filter(property -> !explicitGenericMappings.contains(property))
+            .toList();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return SIMPLE_NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected CouchbaseContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new CouchbaseContainer(imageName);
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, CouchbaseContainer container) {
+        return switch (propertyName) {
+            case COUCHBASE_URI -> Optional.of(container.getConnectionString());
+            case COUCHBASE_USERNAME -> Optional.of(container.getUsername());
+            case COUCHBASE_PASSWORD -> Optional.of(container.getPassword());
+            default -> Optional.empty();
+        };
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return SUPPORTED_PROPERTIES.contains(propertyName) && !explicitGenericMappings(testResourcesConfig).contains(propertyName);
+    }
+
+    private static Set<String> explicitGenericMappings(Map<String, Object> testResourcesConfig) {
+        Set<String> mappedProperties = new LinkedHashSet<>();
+        for (String containerName : configuredContainerNames(testResourcesConfig)) {
+            String prefix = CONTAINERS_PREFIX + containerName + ".";
+            Object imageName = testResourcesConfig.get(prefix + "image-name");
+            if (imageName == null || String.valueOf(imageName).isBlank()) {
+                continue;
+            }
+            mappedProperties.addAll(extractHostNames(prefix, testResourcesConfig));
+            mappedProperties.addAll(extractExposedPortProperties(prefix, testResourcesConfig));
+        }
+        return mappedProperties;
+    }
+
+    private static Set<String> configuredContainerNames(Map<String, Object> testResourcesConfig) {
+        Set<String> containerNames = new LinkedHashSet<>();
+        for (String key : testResourcesConfig.keySet()) {
+            if (!key.startsWith(CONTAINERS_PREFIX)) {
+                continue;
+            }
+            String remainder = key.substring(CONTAINERS_PREFIX.length());
+            int dot = remainder.indexOf('.');
+            if (dot > 0) {
+                containerNames.add(remainder.substring(0, dot));
+            }
+        }
+        return containerNames;
+    }
+
+    private static Set<String> extractHostNames(String prefix, Map<String, Object> testResourcesConfig) {
+        Object hostNames = testResourcesConfig.get(prefix + "hostnames");
+        if (hostNames instanceof List<?> list) {
+            Set<String> values = new LinkedHashSet<>(list.size());
+            for (Object value : list) {
+                values.add(String.valueOf(value));
+            }
+            return values;
+        }
+        if (hostNames != null) {
+            return Set.of(String.valueOf(hostNames));
+        }
+        return Set.of();
+    }
+
+    private static Set<String> extractExposedPortProperties(String prefix, Map<String, Object> testResourcesConfig) {
+        Object exposedPorts = testResourcesConfig.get(prefix + "exposed-ports");
+        if (!(exposedPorts instanceof List<?> list)) {
+            return Set.of();
+        }
+        List<String> propertyNames = new ArrayList<>();
+        for (Object definition : list) {
+            if (definition instanceof Map<?, ?> mappings) {
+                propertyNames.addAll(mappings.keySet().stream().map(String::valueOf).toList());
+            }
+        }
+        return new LinkedHashSet<>(propertyNames);
+    }
+}

--- a/test-resources-couchbase/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-couchbase/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.couchbase.CouchbaseTestResourceProvider

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseCustomImageTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseCustomImageTest.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.testresources.couchbase
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.testcontainers.TestContainers
+import org.testcontainers.couchbase.CouchbaseContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Specification
+
+class CouchbaseCustomImageTest extends Specification {
+    void cleanup() {
+        TestContainers.closeAll()
+    }
+
+    def "applies custom Couchbase image metadata"() {
+        given:
+        def provider = new CapturingCouchbaseTestResourceProvider()
+        def config = [
+            'containers.couchbase.image-name': 'custom/couchbase',
+            'containers.couchbase.image-tag' : '7.6.5'
+        ]
+
+        when:
+        def resolved = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, [(Scope.PROPERTY_KEY): 'custom-image'], config)
+
+        then:
+        resolved.orElse(null) == 'couchbase://localhost:11210'
+        provider.requestedImageName.toString() == 'custom/couchbase:7.6.5'
+    }
+
+    private static final class CapturingCouchbaseTestResourceProvider extends CouchbaseTestResourceProvider {
+        DockerImageName requestedImageName
+
+        @Override
+        protected CouchbaseContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+            requestedImageName = imageName
+            return new CouchbaseContainer(imageName) {
+                @Override
+                void start() {
+                }
+
+                @Override
+                void stop() {
+                }
+
+                @Override
+                String getConnectionString() {
+                    'couchbase://localhost:11210'
+                }
+            }
+        }
+    }
+}

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseGenericContainerPrecedenceTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseGenericContainerPrecedenceTest.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.testresources.couchbase
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.testcontainers.GenericTestContainerProvider
+import io.micronaut.testresources.testcontainers.TestContainers
+import spock.lang.Specification
+
+class CouchbaseGenericContainerPrecedenceTest extends Specification {
+    void cleanup() {
+        TestContainers.closeAll()
+    }
+
+    def "explicit generic container mappings win for supported Couchbase properties"() {
+        given:
+        def provider = new CouchbaseTestResourceProvider()
+        def genericProvider = new GenericTestContainerProvider()
+        def config = [
+            'containers.explicit.image-name'   : 'couchbase/server',
+            'containers.explicit.exposed-ports': [[(CouchbaseTestResourceProvider.COUCHBASE_URI): 8091]],
+            'containers.explicit.hostnames'    : [
+                CouchbaseTestResourceProvider.COUCHBASE_USERNAME,
+                CouchbaseTestResourceProvider.COUCHBASE_PASSWORD
+            ]
+        ]
+
+        expect:
+        !provider.getResolvableProperties([:], config).contains(CouchbaseTestResourceProvider.COUCHBASE_URI)
+        !provider.getResolvableProperties([:], config).contains(CouchbaseTestResourceProvider.COUCHBASE_USERNAME)
+        !provider.getResolvableProperties([:], config).contains(CouchbaseTestResourceProvider.COUCHBASE_PASSWORD)
+
+        and:
+        genericProvider.getResolvableProperties([:], config).containsAll([
+            CouchbaseTestResourceProvider.COUCHBASE_URI,
+            CouchbaseTestResourceProvider.COUCHBASE_USERNAME,
+            CouchbaseTestResourceProvider.COUCHBASE_PASSWORD
+        ])
+
+        and:
+        provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, [(Scope.PROPERTY_KEY): 'generic-precedence'], config).isEmpty()
+        TestContainers.listAll().isEmpty()
+    }
+}

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseGenericContainerPrecedenceTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseGenericContainerPrecedenceTest.groovy
@@ -39,4 +39,22 @@ class CouchbaseGenericContainerPrecedenceTest extends Specification {
         provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, [(Scope.PROPERTY_KEY): 'generic-precedence'], config).isEmpty()
         TestContainers.listAll().isEmpty()
     }
+
+    def "partial explicit generic mappings disable the whole Couchbase connection set"() {
+        given:
+        def provider = new CouchbaseTestResourceProvider()
+        def config = [
+            'containers.explicit.image-name'   : 'couchbase/server',
+            'containers.explicit.exposed-ports': [[(CouchbaseTestResourceProvider.COUCHBASE_URI): 8091]]
+        ]
+
+        expect:
+        provider.getResolvableProperties([:], config).isEmpty()
+
+        and:
+        provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, [(Scope.PROPERTY_KEY): 'generic-precedence-partial-uri'], config).isEmpty()
+        provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_USERNAME, [(Scope.PROPERTY_KEY): 'generic-precedence-partial-username'], config).isEmpty()
+        provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_PASSWORD, [(Scope.PROPERTY_KEY): 'generic-precedence-partial-password'], config).isEmpty()
+        TestContainers.listAll().isEmpty()
+    }
 }

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
@@ -1,14 +1,23 @@
 package io.micronaut.testresources.couchbase
 
+import com.couchbase.client.java.Cluster
+import com.couchbase.client.java.json.JsonObject
+import com.couchbase.client.java.manager.bucket.BucketSettings
 import io.micronaut.testresources.core.Scope
 import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
 import io.micronaut.testresources.testcontainers.TestContainers
+
+import java.time.Duration
 
 class CouchbaseTestResourceProviderTest extends AbstractTestContainersSpec {
     private final CouchbaseTestResourceProvider provider = new CouchbaseTestResourceProvider()
     private final Map<String, Object> requestedProperties = [(Scope.PROPERTY_KEY): scopeName]
 
     def "starts Couchbase and resolves supported connection properties from the same container"() {
+        Cluster cluster = null
+        def bucketName = 'testresources'
+        def documentId = 'doc-1'
+
         when:
         def uri = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, requestedProperties, [:]).orElse(null)
         def username = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_USERNAME, requestedProperties, [:]).orElse(null)
@@ -17,16 +26,27 @@ class CouchbaseTestResourceProviderTest extends AbstractTestContainersSpec {
         def uriContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_URI)
         def usernameContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_USERNAME)
         def passwordContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_PASSWORD)
+        cluster = Cluster.connect(uri, username, password)
+        cluster.buckets().createBucket(BucketSettings.create(bucketName).ramQuotaMB(100))
+        def bucket = cluster.bucket(bucketName)
+        bucket.waitUntilReady(Duration.ofMinutes(2))
+        def collection = bucket.defaultCollection()
+        collection.upsert(documentId, JsonObject.create().put('title', 'Micronaut Test Resources'))
+        def stored = collection.get(documentId)
 
         then:
         uri?.startsWith('couchbase://')
         username
         password
+        stored.contentAsObject().getString('title') == 'Micronaut Test Resources'
 
         and:
         uriContainers.size() == 1
         usernameContainers == uriContainers
         passwordContainers == uriContainers
         TestContainers.listByScope(scopeName).values().flatten().size() == 1
+
+        cleanup:
+        cluster?.disconnect()
     }
 }

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
@@ -1,25 +1,22 @@
 package io.micronaut.testresources.couchbase
 
 import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
 import io.micronaut.testresources.testcontainers.TestContainers
-import spock.lang.Specification
 
-class CouchbaseTestResourceProviderTest extends Specification {
+class CouchbaseTestResourceProviderTest extends AbstractTestContainersSpec {
     private final CouchbaseTestResourceProvider provider = new CouchbaseTestResourceProvider()
-    private final Map<String, Object> requestedProperties = [(Scope.PROPERTY_KEY): 'couchbase']
-
-    void cleanupSpec() {
-        TestContainers.closeScope('couchbase')
-    }
+    private final Map<String, Object> requestedProperties = [(Scope.PROPERTY_KEY): scopeName]
 
     def "starts Couchbase and resolves supported connection properties from the same container"() {
         when:
         def uri = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, requestedProperties, [:]).orElse(null)
         def username = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_USERNAME, requestedProperties, [:]).orElse(null)
         def password = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_PASSWORD, requestedProperties, [:]).orElse(null)
-        def uriContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_URI)
-        def usernameContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_USERNAME)
-        def passwordContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_PASSWORD)
+        def scope = Scope.of(scopeName)
+        def uriContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_URI)
+        def usernameContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_USERNAME)
+        def passwordContainers = TestContainers.findByRequestedProperty(scope, CouchbaseTestResourceProvider.COUCHBASE_PASSWORD)
 
         then:
         uri?.startsWith('couchbase://')
@@ -30,6 +27,6 @@ class CouchbaseTestResourceProviderTest extends Specification {
         uriContainers.size() == 1
         usernameContainers == uriContainers
         passwordContainers == uriContainers
-        TestContainers.listByScope('couchbase').values().flatten().size() == 1
+        TestContainers.listByScope(scopeName).values().flatten().size() == 1
     }
 }

--- a/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
+++ b/test-resources-couchbase/src/test/groovy/io/micronaut/testresources/couchbase/CouchbaseTestResourceProviderTest.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.testresources.couchbase
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.testcontainers.TestContainers
+import spock.lang.Specification
+
+class CouchbaseTestResourceProviderTest extends Specification {
+    private final CouchbaseTestResourceProvider provider = new CouchbaseTestResourceProvider()
+    private final Map<String, Object> requestedProperties = [(Scope.PROPERTY_KEY): 'couchbase']
+
+    void cleanupSpec() {
+        TestContainers.closeScope('couchbase')
+    }
+
+    def "starts Couchbase and resolves supported connection properties from the same container"() {
+        when:
+        def uri = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_URI, requestedProperties, [:]).orElse(null)
+        def username = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_USERNAME, requestedProperties, [:]).orElse(null)
+        def password = provider.resolve(CouchbaseTestResourceProvider.COUCHBASE_PASSWORD, requestedProperties, [:]).orElse(null)
+        def uriContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_URI)
+        def usernameContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_USERNAME)
+        def passwordContainers = TestContainers.findByRequestedProperty(Scope.of('couchbase'), CouchbaseTestResourceProvider.COUCHBASE_PASSWORD)
+
+        then:
+        uri?.startsWith('couchbase://')
+        username
+        password
+
+        and:
+        uriContainers.size() == 1
+        usernameContainers == uriContainers
+        passwordContainers == uriContainers
+        TestContainers.listByScope('couchbase').values().flatten().size() == 1
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `test-resources-couchbase` module backed by Testcontainers
- resolve `couchbase.uri`, `couchbase.username`, and `couchbase.password` while preserving explicit generic-container mappings for overlapping keys
- document the new provider and add focused module tests

## Verification
- `./gradlew :micronaut-test-resources-couchbase:test`

Closes #388.

Project note: QA selected Micronaut org project `5.0.0-M3` as the best-fit active board because there is no dedicated public Test Resources `4.0.0` project.
---
###### ✨ This message was AI-generated using gpt-5.4
