### PR TITLE
Ignore inherited MICRONAUT_CONFIG_FILES in the test resources server

### DIFF
--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -68,3 +68,7 @@ micronautBuild {
         enabled = false
     }
 }
+
+tasks.named("test") {
+    systemProperty("test.resources.server.runtime.classpath", sourceSets.main.runtimeClasspath.asPath)
+}

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -19,6 +19,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.annotation.ContextConfigurer;
+import io.micronaut.context.env.CachedEnvironment;
 import io.micronaut.context.env.Environment;
 import io.micronaut.runtime.Micronaut;
 import io.micronaut.runtime.server.EmbeddedServer;
@@ -28,8 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.function.UnaryOperator;
 
 /**
  * Main entry point for the server.
@@ -37,9 +40,12 @@ import java.util.Arrays;
 @Singleton
 public class TestResourcesService {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestResourcesService.class);
+    private static final String MICRONAUT_CONFIG_FILES_ENV = "MICRONAUT_CONFIG_FILES";
+    private static final String CACHED_ENVIRONMENT_GETENV_FIELD = "getenv";
 
     public static void main(String[] args) {
         long sd = System.nanoTime();
+        ignoreInheritedConfigFilesEnvironmentVariable();
         ApplicationContext context = Micronaut.run(TestResourcesService.class, args);
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
@@ -58,6 +64,30 @@ public class TestResourcesService {
         long dur = System.nanoTime() - sd;
         LOGGER.info("A Micronaut Test Resources server is listening on port {}, started in {}ms",
             context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
+    }
+
+    private static void ignoreInheritedConfigFilesEnvironmentVariable() {
+        if (System.getenv(MICRONAUT_CONFIG_FILES_ENV) == null) {
+            return;
+        }
+        try {
+            Field getenvField = CachedEnvironment.class.getDeclaredField(CACHED_ENVIRONMENT_GETENV_FIELD);
+            getenvField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            UnaryOperator<String> existing = (UnaryOperator<String>) getenvField.get(null);
+            UnaryOperator<String> sanitizedGetenv = key -> {
+                if (MICRONAUT_CONFIG_FILES_ENV.equals(key)) {
+                    return null;
+                }
+                if (existing != null) {
+                    return existing.apply(key);
+                }
+                return System.getenv(key);
+            };
+            getenvField.set(null, sanitizedGetenv);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to ignore inherited " + MICRONAUT_CONFIG_FILES_ENV, e);
+        }
     }
 
     /**
@@ -83,6 +113,7 @@ public class TestResourcesService {
             builder.packages("io.micronaut.testresources.server")
                 .deduceEnvironment(false)
                 .environments(Environment.TEST)
+                .environmentVariableExcludes(MICRONAUT_CONFIG_FILES_ENV)
                 .banner(false);
         }
     }

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -49,11 +49,7 @@ public class TestResourcesService {
 
     public static void main(String[] args) {
         long sd = System.nanoTime();
-        ApplicationContext context = Micronaut.build(args)
-            .mainClass(TestResourcesService.class)
-            .enableDefaultPropertySources(false)
-            .propertySources(defaultPropertySources(args))
-            .start();
+        ApplicationContext context = start(args);
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
             .findFirst()
@@ -71,6 +67,14 @@ public class TestResourcesService {
         long dur = System.nanoTime() - sd;
         LOGGER.info("A Micronaut Test Resources server is listening on port {}, started in {}ms",
             context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
+    }
+
+    static ApplicationContext start(String[] args) {
+        return Micronaut.build(args)
+            .mainClass(TestResourcesService.class)
+            .enableDefaultPropertySources(false)
+            .propertySources(defaultPropertySources(args))
+            .start();
     }
 
     static PropertySource[] defaultPropertySources(String[] args) {

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -46,7 +46,7 @@ public class TestResourcesService {
 
     public static void main(String[] args) {
         long sd = System.nanoTime();
-        ignoreInheritedConfigFilesEnvironmentVariable();
+        ignoreInheritedConfigFilesEnvironmentVariable(System.getenv(MICRONAUT_CONFIG_FILES_ENV));
         ApplicationContext context = Micronaut.run(TestResourcesService.class, args);
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
@@ -67,8 +67,8 @@ public class TestResourcesService {
             context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
     }
 
-    private static void ignoreInheritedConfigFilesEnvironmentVariable() {
-        if (System.getenv(MICRONAUT_CONFIG_FILES_ENV) == null) {
+    static void ignoreInheritedConfigFilesEnvironmentVariable(String inheritedConfigFilesValue) {
+        if (inheritedConfigFilesValue == null) {
             return;
         }
         installCachedEnvironmentConfigFilesOverride();

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
@@ -70,22 +71,30 @@ public class TestResourcesService {
         if (System.getenv(MICRONAUT_CONFIG_FILES_ENV) == null) {
             return;
         }
+        installCachedEnvironmentConfigFilesOverride();
+    }
+
+    static UnaryOperator<String> configFilesSanitizingGetenv(UnaryOperator<String> existing) {
+        return key -> {
+            if (MICRONAUT_CONFIG_FILES_ENV.equals(key)) {
+                return null;
+            }
+            if (existing != null) {
+                return existing.apply(key);
+            }
+            return System.getenv(key);
+        };
+    }
+
+    @SuppressWarnings("java:S3011")
+    static void installCachedEnvironmentConfigFilesOverride() {
         try {
             Field getenvField = CachedEnvironment.class.getDeclaredField(CACHED_ENVIRONMENT_GETENV_FIELD);
             getenvField.setAccessible(true);
             @SuppressWarnings("unchecked")
             UnaryOperator<String> existing = (UnaryOperator<String>) getenvField.get(null);
-            UnaryOperator<String> sanitizedGetenv = key -> {
-                if (MICRONAUT_CONFIG_FILES_ENV.equals(key)) {
-                    return null;
-                }
-                if (existing != null) {
-                    return existing.apply(key);
-                }
-                return System.getenv(key);
-            };
-            getenvField.set(null, sanitizedGetenv);
-        } catch (ReflectiveOperationException e) {
+            getenvField.set(null, configFilesSanitizingGetenv(existing));
+        } catch (InaccessibleObjectException | SecurityException | ReflectiveOperationException e) {
             throw new IllegalStateException("Unable to ignore inherited " + MICRONAUT_CONFIG_FILES_ENV, e);
         }
     }

--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/TestResourcesService.java
@@ -19,8 +19,14 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.annotation.ContextConfigurer;
-import io.micronaut.context.env.CachedEnvironment;
+import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.EnvironmentPropertySource;
+import io.micronaut.context.env.PropertiesPropertySourceLoader;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.context.env.SystemPropertiesPropertySource;
+import io.micronaut.core.cli.CommandLine;
+import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.runtime.Micronaut;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.scheduling.annotation.Scheduled;
@@ -29,11 +35,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
-import java.lang.reflect.Field;
-import java.lang.reflect.InaccessibleObjectException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.function.UnaryOperator;
+import java.util.List;
 
 /**
  * Main entry point for the server.
@@ -42,12 +46,14 @@ import java.util.function.UnaryOperator;
 public class TestResourcesService {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestResourcesService.class);
     private static final String MICRONAUT_CONFIG_FILES_ENV = "MICRONAUT_CONFIG_FILES";
-    private static final String CACHED_ENVIRONMENT_GETENV_FIELD = "getenv";
 
     public static void main(String[] args) {
         long sd = System.nanoTime();
-        ignoreInheritedConfigFilesEnvironmentVariable(System.getenv(MICRONAUT_CONFIG_FILES_ENV));
-        ApplicationContext context = Micronaut.run(TestResourcesService.class, args);
+        ApplicationContext context = Micronaut.build(args)
+            .mainClass(TestResourcesService.class)
+            .enableDefaultPropertySources(false)
+            .propertySources(defaultPropertySources(args))
+            .start();
         Arrays.stream(args)
             .filter(arg -> arg.startsWith("--port-file="))
             .findFirst()
@@ -67,36 +73,19 @@ public class TestResourcesService {
             context.getBean(EmbeddedServer.class).getPort(), Duration.ofNanos(dur).toMillis());
     }
 
-    static void ignoreInheritedConfigFilesEnvironmentVariable(String inheritedConfigFilesValue) {
-        if (inheritedConfigFilesValue == null) {
-            return;
-        }
-        installCachedEnvironmentConfigFilesOverride();
-    }
-
-    static UnaryOperator<String> configFilesSanitizingGetenv(UnaryOperator<String> existing) {
-        return key -> {
-            if (MICRONAUT_CONFIG_FILES_ENV.equals(key)) {
-                return null;
-            }
-            if (existing != null) {
-                return existing.apply(key);
-            }
-            return System.getenv(key);
+    static PropertySource[] defaultPropertySources(String[] args) {
+        return new PropertySource[]{
+            loadBundledApplicationPropertySource(),
+            new SystemPropertiesPropertySource(),
+            new EnvironmentPropertySource(List.of(), List.of(MICRONAUT_CONFIG_FILES_ENV)),
+            new CommandLinePropertySource(CommandLine.parse(args))
         };
     }
 
-    @SuppressWarnings("java:S3011")
-    static void installCachedEnvironmentConfigFilesOverride() {
-        try {
-            Field getenvField = CachedEnvironment.class.getDeclaredField(CACHED_ENVIRONMENT_GETENV_FIELD);
-            getenvField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            UnaryOperator<String> existing = (UnaryOperator<String>) getenvField.get(null);
-            getenvField.set(null, configFilesSanitizingGetenv(existing));
-        } catch (InaccessibleObjectException | SecurityException | ReflectiveOperationException e) {
-            throw new IllegalStateException("Unable to ignore inherited " + MICRONAUT_CONFIG_FILES_ENV, e);
-        }
+    static PropertySource loadBundledApplicationPropertySource() {
+        return new PropertiesPropertySourceLoader()
+            .load("application", ClassPathResourceLoader.defaultLoader(TestResourcesService.class.getClassLoader()))
+            .orElseThrow(() -> new IllegalStateException("Unable to load bundled application.properties"));
     }
 
     /**

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
@@ -1,0 +1,117 @@
+package io.micronaut.testresources.server
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.concurrent.PollingConditions
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+class TestResourcesServiceConfigFilesSpec extends Specification {
+    private static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(30)
+    private static final String ACCESS_TOKEN = "dev8-token"
+    private static final String MICRONAUT_CONFIG_FILES_ENV = "MICRONAUT_CONFIG_FILES"
+    private static final String RUNTIME_CLASSPATH_PROPERTY = "test.resources.server.runtime.classpath"
+
+    @TempDir
+    Path tempDir
+
+    def cleanup() {
+        runningProcesses.each { Process process ->
+            stopProcess(process)
+        }
+        runningProcesses.clear()
+    }
+
+    def "starts and writes the port file when MICRONAUT_CONFIG_FILES points to YAML"() {
+        given:
+        def yamlConfig = tempDir.resolve("local-secrets.yml")
+        Files.writeString(yamlConfig, "foo:\n  bar: baz\n")
+        def portFile = tempDir.resolve("port-file")
+
+        when:
+        def process = startServer(portFile, [(MICRONAUT_CONFIG_FILES_ENV): yamlConfig.toString()])
+        def port = waitForPortFile(portFile)
+
+        then:
+        port > 0
+        process.isAlive()
+    }
+
+    def "keeps honoring explicit system properties while ignoring inherited config files"() {
+        given:
+        def yamlConfig = tempDir.resolve("local-secrets.yml")
+        Files.writeString(yamlConfig, "foo:\n  bar: baz\n")
+        def portFile = tempDir.resolve("port-file")
+
+        when:
+        def process = startServer(
+            portFile,
+            [(MICRONAUT_CONFIG_FILES_ENV): yamlConfig.toString()],
+            ["-Dserver.access-token=${ACCESS_TOKEN}".toString()]
+        )
+        def port = waitForPortFile(portFile)
+
+        then:
+        request(port).statusCode() == 401
+        request(port, [(AccessConfiguration.ACCESS_TOKEN): ACCESS_TOKEN]).statusCode() == 200
+        process.isAlive()
+    }
+
+    private final List<Process> runningProcesses = []
+
+    private Process startServer(Path portFile, Map<String, String> environment, List<String> jvmArgs = []) {
+        def command = [
+            javaCommand(),
+            *jvmArgs,
+            "-cp",
+            System.getProperty(RUNTIME_CLASSPATH_PROPERTY),
+            TestResourcesService.name,
+            "--port-file=${portFile.toAbsolutePath()}".toString()
+        ]
+        def builder = new ProcessBuilder(command)
+        builder.redirectErrorStream(true)
+        builder.environment().putAll(environment)
+        def process = builder.start()
+        runningProcesses.add(process)
+        return process
+    }
+
+    private int waitForPortFile(Path portFile) {
+        def conditions = new PollingConditions(timeout: STARTUP_TIMEOUT.seconds, initialDelay: 0.1, delay: 0.2)
+        conditions.eventually {
+            assert Files.exists(portFile)
+            assert Files.size(portFile) > 0
+        }
+        return Integer.parseInt(Files.readString(portFile).trim())
+    }
+
+    private HttpResponse<String> request(int port, Map<String, String> headers = [:]) {
+        def requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:${port}/list"))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+        headers.each { name, value -> requestBuilder.header(name, value) }
+        return HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+    }
+
+    private static String javaCommand() {
+        Path.of(System.getProperty("java.home"), "bin", "java").toString()
+    }
+
+    private static void stopProcess(Process process) {
+        if (!process.isAlive()) {
+            return
+        }
+        process.destroy()
+        if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+        }
+    }
+}

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
@@ -70,12 +70,13 @@ class TestResourcesServiceConfigFilesSpec extends Specification {
             javaCommand(),
             *jvmArgs,
             "-cp",
-            System.getProperty(RUNTIME_CLASSPATH_PROPERTY),
+            System.getProperty(RUNTIME_CLASSPATH_PROPERTY, System.getProperty("java.class.path")),
             TestResourcesService.name,
             "--port-file=${portFile.toAbsolutePath()}".toString()
         ]
         def builder = new ProcessBuilder(command)
         builder.redirectErrorStream(true)
+        builder.redirectOutput(tempDir.resolve("server-${runningProcesses.size()}.log").toFile())
         builder.environment().putAll(environment)
         def process = builder.start()
         runningProcesses.add(process)

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
@@ -1,31 +1,21 @@
 package io.micronaut.testresources.server
 
 import io.micronaut.context.ApplicationContextBuilder
-import io.micronaut.context.env.CachedEnvironment
+import io.micronaut.context.env.CommandLinePropertySource
+import io.micronaut.context.env.EnvironmentPropertySource
+import io.micronaut.context.env.SystemPropertiesPropertySource
 import spock.lang.Specification
 
-import java.lang.reflect.Field
-import java.util.function.UnaryOperator
-
 class TestResourcesServiceTest extends Specification {
-    def "sanitizing getenv hides MICRONAUT_CONFIG_FILES and delegates other keys"() {
-        given:
-        def getenv = TestResourcesService.configFilesSanitizingGetenv { String key ->
-            "value-for-" + key
-        } as UnaryOperator<String>
+    def "manual bootstrap property sources preserve supported inputs"() {
+        when:
+        def propertySources = TestResourcesService.defaultPropertySources(["--server.port=9999"] as String[])
 
-        expect:
-        getenv.apply("MICRONAUT_CONFIG_FILES") == null
-        getenv.apply("OTHER_ENV") == "value-for-OTHER_ENV"
-    }
-
-    def "sanitizing getenv falls back to the process environment when no existing hook is installed"() {
-        given:
-        def getenv = TestResourcesService.configFilesSanitizingGetenv(null)
-
-        expect:
-        getenv.apply("MICRONAUT_CONFIG_FILES") == null
-        getenv.apply("PATH") == System.getenv("PATH")
+        then:
+        propertySources*.name == ["application", "system", "env", "cli"]
+        propertySources[1] instanceof SystemPropertiesPropertySource
+        propertySources[2] instanceof EnvironmentPropertySource
+        propertySources[3] instanceof CommandLinePropertySource
     }
 
     def "configurer excludes MICRONAUT_CONFIG_FILES from environment variables"() {
@@ -44,41 +34,12 @@ class TestResourcesServiceTest extends Specification {
         0 * _
     }
 
-    def "ignoring inherited config files does nothing when the environment variable is absent"() {
-        given:
-        Field getenvField = CachedEnvironment.class.getDeclaredField("getenv")
-        getenvField.setAccessible(true)
-        UnaryOperator<String> original = (UnaryOperator<String>) getenvField.get(null)
-        UnaryOperator<String> existing = { String key -> "existing-" + key } as UnaryOperator<String>
-        getenvField.set(null, existing)
-
+    def "bundled application properties are loaded for manual bootstrap"() {
         when:
-        TestResourcesService.ignoreInheritedConfigFilesEnvironmentVariable(null)
+        def propertySource = TestResourcesService.loadBundledApplicationPropertySource()
 
         then:
-        getenvField.get(null).is(existing)
-
-        cleanup:
-        getenvField.set(null, original)
-    }
-
-    def "ignoring inherited config files installs the cached environment override"() {
-        given:
-        Field getenvField = CachedEnvironment.class.getDeclaredField("getenv")
-        getenvField.setAccessible(true)
-        UnaryOperator<String> original = (UnaryOperator<String>) getenvField.get(null)
-        UnaryOperator<String> existing = { String key -> "existing-" + key } as UnaryOperator<String>
-        getenvField.set(null, existing)
-
-        when:
-        TestResourcesService.ignoreInheritedConfigFilesEnvironmentVariable("present")
-        UnaryOperator<String> overridden = (UnaryOperator<String>) getenvField.get(null)
-
-        then:
-        overridden.apply("MICRONAUT_CONFIG_FILES") == null
-        overridden.apply("OTHER_ENV") == "existing-OTHER_ENV"
-
-        cleanup:
-        getenvField.set(null, original)
+        propertySource.get("micronaut.application.name") == "Test resources server"
+        propertySource.get("micronaut.server.port") == "-1"
     }
 }

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
@@ -1,9 +1,11 @@
 package io.micronaut.testresources.server
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.env.CommandLinePropertySource
 import io.micronaut.context.env.EnvironmentPropertySource
 import io.micronaut.context.env.SystemPropertiesPropertySource
+import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
 
 class TestResourcesServiceTest extends Specification {
@@ -41,5 +43,22 @@ class TestResourcesServiceTest extends Specification {
         then:
         propertySource.get("micronaut.application.name") == "Test resources server"
         propertySource.get("micronaut.server.port") == "-1"
+    }
+
+    def "manual bootstrap starts the embedded server with supported property sources"() {
+        given:
+        ApplicationContext context = null
+
+        when:
+        context = TestResourcesService.start([] as String[])
+        def server = context.getBean(EmbeddedServer)
+
+        then:
+        server.isRunning()
+        server.port > 0
+        context.environment.activeNames.contains("test")
+
+        cleanup:
+        context?.close()
     }
 }

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.testresources.server
+
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.env.CachedEnvironment
+import spock.lang.Specification
+
+import java.lang.reflect.Field
+import java.util.function.UnaryOperator
+
+class TestResourcesServiceTest extends Specification {
+    def "sanitizing getenv hides MICRONAUT_CONFIG_FILES and delegates other keys"() {
+        given:
+        def getenv = TestResourcesService.configFilesSanitizingGetenv { String key ->
+            "value-for-" + key
+        } as UnaryOperator<String>
+
+        expect:
+        getenv.apply("MICRONAUT_CONFIG_FILES") == null
+        getenv.apply("OTHER_ENV") == "value-for-OTHER_ENV"
+    }
+
+    def "configurer excludes MICRONAUT_CONFIG_FILES from environment variables"() {
+        given:
+        def builder = Mock(ApplicationContextBuilder)
+
+        when:
+        new TestResourcesService.Configurer().configure(builder)
+
+        then:
+        1 * builder.packages("io.micronaut.testresources.server") >> builder
+        1 * builder.deduceEnvironment(false) >> builder
+        1 * builder.environments("test") >> builder
+        1 * builder.environmentVariableExcludes("MICRONAUT_CONFIG_FILES") >> builder
+        1 * builder.banner(false) >> builder
+        0 * _
+    }
+
+    def "installing the cached environment override replaces the getenv operator"() {
+        given:
+        Field getenvField = CachedEnvironment.class.getDeclaredField("getenv")
+        getenvField.setAccessible(true)
+        UnaryOperator<String> original = (UnaryOperator<String>) getenvField.get(null)
+        UnaryOperator<String> existing = { String key -> "existing-" + key } as UnaryOperator<String>
+        getenvField.set(null, existing)
+
+        when:
+        TestResourcesService.installCachedEnvironmentConfigFilesOverride()
+        UnaryOperator<String> overridden = (UnaryOperator<String>) getenvField.get(null)
+
+        then:
+        overridden.apply("MICRONAUT_CONFIG_FILES") == null
+        overridden.apply("OTHER_ENV") == "existing-OTHER_ENV"
+
+        cleanup:
+        getenvField.set(null, original)
+    }
+}

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceTest.groovy
@@ -19,6 +19,15 @@ class TestResourcesServiceTest extends Specification {
         getenv.apply("OTHER_ENV") == "value-for-OTHER_ENV"
     }
 
+    def "sanitizing getenv falls back to the process environment when no existing hook is installed"() {
+        given:
+        def getenv = TestResourcesService.configFilesSanitizingGetenv(null)
+
+        expect:
+        getenv.apply("MICRONAUT_CONFIG_FILES") == null
+        getenv.apply("PATH") == System.getenv("PATH")
+    }
+
     def "configurer excludes MICRONAUT_CONFIG_FILES from environment variables"() {
         given:
         def builder = Mock(ApplicationContextBuilder)
@@ -35,7 +44,7 @@ class TestResourcesServiceTest extends Specification {
         0 * _
     }
 
-    def "installing the cached environment override replaces the getenv operator"() {
+    def "ignoring inherited config files does nothing when the environment variable is absent"() {
         given:
         Field getenvField = CachedEnvironment.class.getDeclaredField("getenv")
         getenvField.setAccessible(true)
@@ -44,7 +53,25 @@ class TestResourcesServiceTest extends Specification {
         getenvField.set(null, existing)
 
         when:
-        TestResourcesService.installCachedEnvironmentConfigFilesOverride()
+        TestResourcesService.ignoreInheritedConfigFilesEnvironmentVariable(null)
+
+        then:
+        getenvField.get(null).is(existing)
+
+        cleanup:
+        getenvField.set(null, original)
+    }
+
+    def "ignoring inherited config files installs the cached environment override"() {
+        given:
+        Field getenvField = CachedEnvironment.class.getDeclaredField("getenv")
+        getenvField.setAccessible(true)
+        UnaryOperator<String> original = (UnaryOperator<String>) getenvField.get(null)
+        UnaryOperator<String> existing = { String key -> "existing-" + key } as UnaryOperator<String>
+        getenvField.set(null, existing)
+
+        when:
+        TestResourcesService.ignoreInheritedConfigFilesEnvironmentVariable("present")
         UnaryOperator<String> overridden = (UnaryOperator<String>) getenvField.get(null)
 
         then:


### PR DESCRIPTION
## Summary
- ignore inherited `MICRONAUT_CONFIG_FILES` before the internal test-resources server bootstraps
- exclude that env var from the server environment property source after startup
- add a regression spec that launches the real server main class on the module runtime classpath and verifies startup plus explicit `server.access-token` behavior

## Release targeting
- Chosen Micronaut organization project: `5.0.0 Release`
- Ambiguity note: `5.0.0-M3` is also still open/public, but `5.0.0 Release` remains the better fit for this repo's default-branch line

Fixes #155

---
###### ✨ This message was AI-generated using gpt-5.4
