### PR TITLE
Add anonymous volume support for generic testcontainers

### DIFF
--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -101,7 +101,7 @@ test-resources:
         - /path/to/readwrite/container/data
 ----
 
-Unlike `*-fs-bind`, anonymous volumes do not map a host path. They use Docker-managed storage attached only to the container path, which is useful when the container expects persistent writable directories but you do not want filesystem exposure from the host.
+Unlike `*-fs-bind`, anonymous volumes do not map a host path. They use Docker-managed storage attached only to the container path, which is useful when the container expects persistent writable directories but you do not want filesystem exposure from the host. Anonymous volume targets must remain distinct from any existing bind, mount, or tmpfs target for the same container path.
 
 It is also possible to copy files from the host to the container:
 

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -83,6 +83,26 @@ test-resources:
         - /path/to/readwrite/container/file
 ----
 
+Generic containers can also declare Docker-managed anonymous volumes when you need container-local storage without binding any host filesystem path:
+
+[configuration]
+----
+test-resources:
+  containers:
+    mycontainer:
+      image-name: my/container
+      hostnames:
+        - my.service.host
+      exposed-ports:
+        - my.service.port: 1883
+      ro-anonymous-volumes:
+        - /path/to/readonly/container/data
+      rw-anonymous-volumes:
+        - /path/to/readwrite/container/data
+----
+
+Unlike `*-fs-bind`, anonymous volumes do not map a host path. They use Docker-managed storage attached only to the container path, which is useful when the container expects persistent writable directories but you do not want filesystem exposure from the host.
+
 It is also possible to copy files from the host to the container:
 
 [configuration]

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadata.java
@@ -34,6 +34,8 @@ final class TestContainerMetadata {
 
     private final Map<String, String> rwFsBinds;
     private final Map<String, String> roFsBinds;
+    private final Set<String> rwAnonymousVolumes;
+    private final Set<String> roAnonymousVolumes;
     private final Set<String> rwTmpfsMappings;
     private final Set<String> roTmpfsMappings;
     private final List<String> command;
@@ -59,6 +61,8 @@ final class TestContainerMetadata {
                           Set<String> hostNames,
                           Map<String, String> rwFsBinds,
                           Map<String, String> roFsBinds,
+                          Set<String> rwAnonymousVolumes,
+                          Set<String> roAnonymousVolumes,
                           Set<String> rwTmpfsMappings,
                           Set<String> roTmpfsMappings,
                           List<String> command,
@@ -82,6 +86,8 @@ final class TestContainerMetadata {
         this.hostNames = hostNames;
         this.rwFsBinds = rwFsBinds;
         this.roFsBinds = roFsBinds;
+        this.rwAnonymousVolumes = rwAnonymousVolumes;
+        this.roAnonymousVolumes = roAnonymousVolumes;
         this.rwTmpfsMappings = rwTmpfsMappings;
         this.roTmpfsMappings = roTmpfsMappings;
         this.command = command;
@@ -130,6 +136,14 @@ final class TestContainerMetadata {
 
     public List<String> getCommand() {
         return command;
+    }
+
+    public Set<String> getRwAnonymousVolumes() {
+        return rwAnonymousVolumes;
+    }
+
+    public Set<String> getRoAnonymousVolumes() {
+        return roAnonymousVolumes;
     }
 
     public Optional<String> getWorkingDirectory() {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
@@ -15,6 +15,10 @@
  */
 package io.micronaut.testresources.testcontainers;
 
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.Mount;
+import com.github.dockerjava.api.model.MountType;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.DefaultMutableConversionService;
 import io.micronaut.core.convert.MutableConversionService;
@@ -82,6 +86,8 @@ final class TestContainerMetadataSupport {
         Set<String> hostNames = extractHostsFrom(prefix, testResourcesConfig);
         Map<String, String> rwFsBinds = extractFsBindsFrom(prefix, testResourcesConfig, false);
         Map<String, String> roFsBinds = extractFsBindsFrom(prefix, testResourcesConfig, true);
+        Set<String> rwAnonymousVolumes = extractAnonymousVolumesFrom(prefix, testResourcesConfig, false);
+        Set<String> roAnonymousVolumes = extractAnonymousVolumesFrom(prefix, testResourcesConfig, true);
         Set<String> rwTmpfsMappings = extractTmpfsMappingsFrom(prefix, testResourcesConfig, false);
         Set<String> roTmpfsMappings = extractTmpfsMappingsFrom(prefix, testResourcesConfig, true);
         Map<String, String> env = extractMapFrom(prefix, "env", testResourcesConfig);
@@ -98,7 +104,7 @@ final class TestContainerMetadataSupport {
         String networkMode = extractStringParameterFrom(prefix, "network-mode", testResourcesConfig);
         Set<String> dependsOn = extractSetFrom(prefix, testResourcesConfig, "depends-on");
         WaitStrategy waitStrategy = extractWaitStrategyFrom(prefix, testResourcesConfig);
-        return Optional.of(new TestContainerMetadata(name, imageName, imageTag, exposedPorts, hostNames, rwFsBinds, roFsBinds, rwTmpfsMappings, roTmpfsMappings, command, workingDirectory, env, labels, startupTimeout, fileCopies, memory, swapMemory, sharedMemory, network, networkAliases, networkMode, waitStrategy, dependsOn));
+        return Optional.of(new TestContainerMetadata(name, imageName, imageTag, exposedPorts, hostNames, rwFsBinds, roFsBinds, rwAnonymousVolumes, roAnonymousVolumes, rwTmpfsMappings, roTmpfsMappings, command, workingDirectory, env, labels, startupTimeout, fileCopies, memory, swapMemory, sharedMemory, network, networkAliases, networkMode, waitStrategy, dependsOn));
     }
 
     private static Long extractMemoryParameterFrom(String prefix, Map<String, Object> testResourcesConfig, String key) {
@@ -189,6 +195,10 @@ final class TestContainerMetadataSupport {
 
     private static Set<String> extractTmpfsMappingsFrom(String prefix, Map<String, Object> testResourcesConfig, boolean readOnly) {
         return extractSetFrom(prefix, testResourcesConfig, (readOnly ? "ro-" : "rw-") + "tmpfs-mappings");
+    }
+
+    private static Set<String> extractAnonymousVolumesFrom(String prefix, Map<String, Object> testResourcesConfig, boolean readOnly) {
+        return extractSetFrom(prefix, testResourcesConfig, (readOnly ? "ro-" : "rw-") + "anonymous-volumes");
     }
 
     private static Map<String, String> extractFsBindsFrom(String prefix,
@@ -403,6 +413,9 @@ final class TestContainerMetadataSupport {
         }
         md.getRwFsBinds().forEach((hostPath, containerPath) -> applyFsBind(container, hostPath, containerPath, BindMode.READ_WRITE));
         md.getRoFsBinds().forEach((hostPath, containerPath) -> applyFsBind(container, hostPath, containerPath, BindMode.READ_ONLY));
+        if (!md.getRwAnonymousVolumes().isEmpty() || !md.getRoAnonymousVolumes().isEmpty()) {
+            container.withCreateContainerCmdModifier(cmd -> applyAnonymousVolumes(cmd, md.getRwAnonymousVolumes(), md.getRoAnonymousVolumes()));
+        }
         md.getRwTmpfsMappings().forEach((mapping) -> applyTmpFsMapping(container, mapping, BindMode.READ_WRITE));
         md.getRoTmpfsMappings().forEach((mapping) -> applyTmpFsMapping(container, mapping, BindMode.READ_ONLY));
         if (!md.getCommand().isEmpty()) {
@@ -434,5 +447,29 @@ final class TestContainerMetadataSupport {
 
     static void applyTmpFsMapping(GenericContainer<?> container, String mapping, BindMode bindMode) {
         container.withTmpFs(Collections.singletonMap(mapping, bindMode.accessMode.name()));
+    }
+
+    private static CreateContainerCmd applyAnonymousVolumes(CreateContainerCmd cmd,
+                                                            Set<String> rwAnonymousVolumes,
+                                                            Set<String> roAnonymousVolumes) {
+        HostConfig hostConfig = Optional.ofNullable(cmd.getHostConfig()).orElseGet(HostConfig::newHostConfig);
+        List<Mount> existingMounts = Optional.ofNullable(hostConfig.getMounts())
+            .orElseGet(Collections::emptyList);
+        List<Mount> anonymousVolumeMounts = Stream.concat(
+                rwAnonymousVolumes.stream().map(path -> anonymousVolumeMount(path, false)),
+                roAnonymousVolumes.stream().map(path -> anonymousVolumeMount(path, true))
+            )
+            .collect(Collectors.toList());
+        cmd.withHostConfig(hostConfig.withMounts(Stream.concat(existingMounts.stream(), anonymousVolumeMounts.stream())
+            .distinct()
+            .collect(Collectors.toList())));
+        return cmd;
+    }
+
+    private static Mount anonymousVolumeMount(String containerPath, boolean readOnly) {
+        return new Mount()
+            .withType(MountType.VOLUME)
+            .withTarget(containerPath)
+            .withReadOnly(readOnly);
     }
 }

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
@@ -16,6 +16,7 @@
 package io.micronaut.testresources.testcontainers;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Mount;
 import com.github.dockerjava.api.model.MountType;
@@ -454,6 +455,7 @@ final class TestContainerMetadataSupport {
                                                             Set<String> roAnonymousVolumes) {
         assertNoConflictingAnonymousVolumes(rwAnonymousVolumes, roAnonymousVolumes);
         HostConfig hostConfig = Optional.ofNullable(cmd.getHostConfig()).orElseGet(HostConfig::newHostConfig);
+        assertNoConflictingContainerTargets(hostConfig, rwAnonymousVolumes, roAnonymousVolumes);
         List<Mount> existingMounts = Optional.ofNullable(hostConfig.getMounts())
             .orElseGet(Collections::emptyList);
         List<Mount> anonymousVolumeMounts = Stream.concat(
@@ -475,6 +477,37 @@ final class TestContainerMetadataSupport {
         Set<String> overlaps = new LinkedHashSet<>(rwAnonymousVolumes);
         overlaps.retainAll(roAnonymousVolumes);
         throw new IllegalArgumentException("Anonymous volumes cannot be declared as both read-write and read-only: " + overlaps);
+    }
+
+    private static void assertNoConflictingContainerTargets(HostConfig hostConfig,
+                                                            Set<String> rwAnonymousVolumes,
+                                                            Set<String> roAnonymousVolumes) {
+        Set<String> requestedTargets = Stream.concat(rwAnonymousVolumes.stream(), roAnonymousVolumes.stream())
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> existingTargets = existingContainerTargets(hostConfig);
+        requestedTargets.retainAll(existingTargets);
+        if (!requestedTargets.isEmpty()) {
+            throw new IllegalArgumentException("Anonymous volumes cannot reuse container paths already configured by mounts, filesystem binds, or tmpfs mappings: " + requestedTargets);
+        }
+    }
+
+    private static Set<String> existingContainerTargets(HostConfig hostConfig) {
+        Stream<String> mountTargets = Optional.ofNullable(hostConfig.getMounts())
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .map(Mount::getTarget);
+        Stream<String> bindTargets = Arrays.stream(Optional.ofNullable(hostConfig.getBinds()).orElseGet(() -> new Bind[0]))
+            .map(Bind::getVolume)
+            .filter(Objects::nonNull)
+            .map(volume -> volume.getPath());
+        Stream<String> tmpfsTargets = Optional.ofNullable(hostConfig.getTmpFs())
+            .orElseGet(Collections::emptyMap)
+            .keySet()
+            .stream();
+        return Stream.of(mountTargets, bindTargets, tmpfsTargets)
+            .flatMap(stream -> stream)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static Mount anonymousVolumeMount(String containerPath, boolean readOnly) {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainerMetadataSupport.java
@@ -452,6 +452,7 @@ final class TestContainerMetadataSupport {
     private static CreateContainerCmd applyAnonymousVolumes(CreateContainerCmd cmd,
                                                             Set<String> rwAnonymousVolumes,
                                                             Set<String> roAnonymousVolumes) {
+        assertNoConflictingAnonymousVolumes(rwAnonymousVolumes, roAnonymousVolumes);
         HostConfig hostConfig = Optional.ofNullable(cmd.getHostConfig()).orElseGet(HostConfig::newHostConfig);
         List<Mount> existingMounts = Optional.ofNullable(hostConfig.getMounts())
             .orElseGet(Collections::emptyList);
@@ -464,6 +465,16 @@ final class TestContainerMetadataSupport {
             .distinct()
             .collect(Collectors.toList())));
         return cmd;
+    }
+
+    private static void assertNoConflictingAnonymousVolumes(Set<String> rwAnonymousVolumes,
+                                                            Set<String> roAnonymousVolumes) {
+        if (Collections.disjoint(rwAnonymousVolumes, roAnonymousVolumes)) {
+            return;
+        }
+        Set<String> overlaps = new LinkedHashSet<>(rwAnonymousVolumes);
+        overlaps.retainAll(roAnonymousVolumes);
+        throw new IllegalArgumentException("Anonymous volumes cannot be declared as both read-write and read-only: " + overlaps);
     }
 
     private static Mount anonymousVolumeMount(String containerPath, boolean readOnly) {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainersConfiguration.java
@@ -36,6 +36,8 @@ final class TestContainersConfiguration {
     private Map<String, Integer> exposedPorts;
     private Map<String, String> roFsBind;
     private Map<String, String> rwFsBind;
+    private Set<String> roAnonymousVolumes;
+    private Set<String> rwAnonymousVolumes;
     private List<String> command;
     private String workingDirectory;
     private Map<String, String> env;
@@ -161,6 +163,40 @@ final class TestContainersConfiguration {
      */
     public void setRwFsBind(Map<String, String> rwFsBind) {
         this.rwFsBind = rwFsBind;
+    }
+
+    /**
+     * Returns the set of read-only anonymous Docker-managed volumes.
+     * @return the read-only anonymous volumes.
+     */
+    public Set<String> getRoAnonymousVolumes() {
+        return roAnonymousVolumes;
+    }
+
+    /**
+     * The paths in the container filesystem that should be mounted as
+     * Docker-managed anonymous volumes in read-only mode.
+     * @param roAnonymousVolumes the read-only anonymous volumes.
+     */
+    public void setRoAnonymousVolumes(Set<String> roAnonymousVolumes) {
+        this.roAnonymousVolumes = roAnonymousVolumes;
+    }
+
+    /**
+     * Returns the set of read-write anonymous Docker-managed volumes.
+     * @return the read-write anonymous volumes.
+     */
+    public Set<String> getRwAnonymousVolumes() {
+        return rwAnonymousVolumes;
+    }
+
+    /**
+     * The paths in the container filesystem that should be mounted as
+     * Docker-managed anonymous volumes in read-write mode.
+     * @param rwAnonymousVolumes the read-write anonymous volumes.
+     */
+    public void setRwAnonymousVolumes(Set<String> rwAnonymousVolumes) {
+        this.rwAnonymousVolumes = rwAnonymousVolumes;
     }
 
     /**

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -471,6 +471,68 @@ class TestContainerMetadataSupportTest extends Specification {
         ex.message == 'Anonymous volumes cannot be declared as both read-write and read-only: [/shared-data]'
     }
 
+    def "rejects anonymous volumes that overlap existing filesystem binds"() {
+        given:
+        def config = """
+            containers:
+                foo:
+                    rw-anonymous-volumes:
+                        - /shared-data
+        """
+        def metadata = metadataFrom(config, "foo").get()
+        def container = TestContainerMetadataSupport.applyMetadata(metadata, new GenericContainer("alpine:3.20"))
+        def hostConfig = HostConfig.newHostConfig()
+                .withBinds(new Bind('/host-data', new Volume('/shared-data')))
+        CreateContainerCmd cmd
+        cmd = [
+            getHostConfig: { -> hostConfig },
+            withHostConfig: { HostConfig value ->
+                hostConfig = value
+                cmd
+            }
+        ] as CreateContainerCmd
+
+        when:
+        container.createContainerCmdModifiers.each { modifier ->
+            modifier.modify(cmd)
+        }
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == 'Anonymous volumes cannot reuse container paths already configured by mounts, filesystem binds, or tmpfs mappings: [/shared-data]'
+    }
+
+    def "rejects anonymous volumes that overlap existing tmpfs mappings"() {
+        given:
+        def config = """
+            containers:
+                foo:
+                    ro-anonymous-volumes:
+                        - /shared-data
+        """
+        def metadata = metadataFrom(config, "foo").get()
+        def container = TestContainerMetadataSupport.applyMetadata(metadata, new GenericContainer("alpine:3.20"))
+        def hostConfig = HostConfig.newHostConfig()
+                .withTmpFs(['/shared-data': 'rw'])
+        CreateContainerCmd cmd
+        cmd = [
+            getHostConfig: { -> hostConfig },
+            withHostConfig: { HostConfig value ->
+                hostConfig = value
+                cmd
+            }
+        ] as CreateContainerCmd
+
+        when:
+        container.createContainerCmdModifiers.each { modifier ->
+            modifier.modify(cmd)
+        }
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == 'Anonymous volumes cannot reuse container paths already configured by mounts, filesystem binds, or tmpfs mappings: [/shared-data]'
+    }
+
     def "reads log wait strategy"() {
         def config = """
                 containers:

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -1,5 +1,12 @@
 package io.micronaut.testresources.testcontainers
 
+import com.github.dockerjava.api.command.CreateContainerCmd
+import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.HostConfig
+import com.github.dockerjava.api.model.Mount
+import com.github.dockerjava.api.model.MountType
+import com.github.dockerjava.api.model.Volume
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.DockerHealthcheckWaitStrategy
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
@@ -136,6 +143,29 @@ class TestContainerMetadataSupportTest extends Specification {
         with(md.get()) {
             roTmpfsMappings.containsAll(['/some/path', '/some/other/path'])
             rwTmpfsMappings.containsAll(['/yet/another/path', '/yet/another/other/path'])
+        }
+    }
+
+    def "reads anonymous volumes"() {
+        def config = """
+            containers:
+                foo:
+                    ro-anonymous-volumes:
+                        - /some/path
+                        - /some/other/path
+                    rw-anonymous-volumes:
+                        - /yet/another/path
+                        - /yet/another/other/path
+        """
+
+        when:
+        def md = metadataFrom(config, "foo")
+
+        then:
+        md.present
+        with(md.get()) {
+            roAnonymousVolumes.containsAll(['/some/path', '/some/other/path'])
+            rwAnonymousVolumes.containsAll(['/yet/another/path', '/yet/another/other/path'])
         }
     }
 
@@ -365,6 +395,48 @@ class TestContainerMetadataSupportTest extends Specification {
         md3.get().with {
             networkMode.get() == 'third'
         }
+    }
+
+    def "applies anonymous volumes without losing existing create command settings"() {
+        given:
+        def config = """
+            containers:
+                foo:
+                    ro-anonymous-volumes:
+                        - /ro-data
+                    rw-anonymous-volumes:
+                        - /rw-data
+                    memory: 128m
+        """
+        def metadata = metadataFrom(config, "foo").get()
+        def container = TestContainerMetadataSupport.applyMetadata(metadata, new GenericContainer("alpine:3.20"))
+        def hostConfig = HostConfig.newHostConfig()
+                .withBinds(new Bind('/host-data', new Volume('/existing-bind')))
+                .withMounts([new Mount().withType(MountType.VOLUME).withTarget('/existing-data').withReadOnly(false)])
+        CreateContainerCmd cmd
+        cmd = [
+            getHostConfig: { -> hostConfig },
+            withHostConfig: { HostConfig value ->
+                hostConfig = value
+                cmd
+            }
+        ] as CreateContainerCmd
+
+        when:
+        container.createContainerCmdModifiers.each { modifier ->
+            modifier.modify(cmd)
+        }
+
+        then:
+        hostConfig.memory == 134217728L
+        hostConfig.mounts == [
+                new Mount().withType(MountType.VOLUME).withTarget('/existing-data').withReadOnly(false),
+                new Mount().withType(MountType.VOLUME).withTarget('/rw-data').withReadOnly(false),
+                new Mount().withType(MountType.VOLUME).withTarget('/ro-data').withReadOnly(true)
+        ]
+        hostConfig.binds.toList() == [
+            new Bind('/host-data', new Volume('/existing-bind'))
+        ]
     }
 
     def "reads log wait strategy"() {

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainerMetadataSupportTest.groovy
@@ -439,6 +439,38 @@ class TestContainerMetadataSupportTest extends Specification {
         ]
     }
 
+    def "rejects conflicting anonymous volume access modes for the same path"() {
+        given:
+        def config = """
+            containers:
+                foo:
+                    ro-anonymous-volumes:
+                        - /shared-data
+                    rw-anonymous-volumes:
+                        - /shared-data
+        """
+        def metadata = metadataFrom(config, "foo").get()
+        def container = TestContainerMetadataSupport.applyMetadata(metadata, new GenericContainer("alpine:3.20"))
+        def hostConfig = HostConfig.newHostConfig()
+        CreateContainerCmd cmd
+        cmd = [
+            getHostConfig: { -> hostConfig },
+            withHostConfig: { HostConfig value ->
+                hostConfig = value
+                cmd
+            }
+        ] as CreateContainerCmd
+
+        when:
+        container.createContainerCmdModifiers.each { modifier ->
+            modifier.modify(cmd)
+        }
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == 'Anonymous volumes cannot be declared as both read-write and read-only: [/shared-data]'
+    }
+
     def "reads log wait strategy"() {
         def config = """
                 containers:


### PR DESCRIPTION
## Summary
- add additive `ro-anonymous-volumes` and `rw-anonymous-volumes` support for generic testcontainers
- apply anonymous Docker-managed volumes with Docker volume mounts so read-only paths use a daemon-accepted shape
- document the new configuration and cover parsing plus create-command composition in tests

## Verification
- `./gradlew :micronaut-test-resources-testcontainers:test --tests io.micronaut.testresources.testcontainers.TestContainerMetadataSupportTest`
- `./gradlew docs`

Closes #101.

Micronaut organization project target: `5.0.0 Release`.
Ambiguity note preserved from QA: public project `5.0.0-M3` also exists, but `5.0.0 Release` remains the chosen board.

---
###### ✨ This message was AI-generated using gpt-5.4
