### PR TITLE
Add Kafka topic provisioning support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,14 @@ repositories {
 //    }
 }
 
+def rootSonarExtension = extensions.findByName("sonar")
+if (rootSonarExtension != null) {
+    rootSonarExtension.skipProject = true
+}
+
 project(":micronaut-test-resources-bom") {
-    def sonarExtension = extensions.findByName("sonar")
-    if (sonarExtension != null) {
-        sonarExtension.skipProject = true
+    def bomSonarExtension = extensions.findByName("sonar")
+    if (bomSonarExtension != null) {
+        bomSonarExtension.skipProject = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,15 +19,3 @@ repositories {
 //        url "https://s01.oss.sonatype.org/content/repositories/snapshots"
 //    }
 }
-
-def rootSonarExtension = extensions.findByName("sonar")
-if (rootSonarExtension != null) {
-    rootSonarExtension.skipProject = true
-}
-
-project(":micronaut-test-resources-bom") {
-    def bomSonarExtension = extensions.findByName("sonar")
-    if (bomSonarExtension != null) {
-        bomSonarExtension.skipProject = true
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -19,3 +19,10 @@ repositories {
 //        url "https://s01.oss.sonatype.org/content/repositories/snapshots"
 //    }
 }
+
+project(":micronaut-test-resources-bom") {
+    def sonarExtension = extensions.findByName("sonar")
+    if (sonarExtension != null) {
+        sonarExtension.skipProject = true
+    }
+}

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -8,6 +8,8 @@ The optional `test-resources.containers.kafka.partitions` property applies the s
 
 NOTE: Topic replication is fixed to `1` because the Kafka test resource starts a single-broker container. This feature is intended for test-time broker preparation, not general Kafka administration.
 
+NOTE: When a cached Kafka broker is reused inside the same test-resources scope, configured topics must agree on the partition count. If a topic already exists with a different partition count, resolution fails with a clear error instead of mutating the existing topic.
+
 [configuration]
 ----
 test-resources:

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -2,6 +2,23 @@ Kafka support will automatically start a https://kafka.apache.org[Kafka containe
 
 The default image can be overwritten by setting the `test-resources.containers.kafka.image-name` property.
 
+Kafka topics are only provisioned when `test-resources.containers.kafka.topics` is configured. When set, test resources creates any missing topics before returning `kafka.bootstrap.servers`.
+
+The optional `test-resources.containers.kafka.partitions` property applies the same partition count to every configured topic and defaults to `1`.
+
+NOTE: Topic replication is fixed to `1` because the Kafka test resource starts a single-broker container. This feature is intended for test-time broker preparation, not general Kafka administration.
+
+[configuration]
+----
+test-resources:
+  containers:
+    kafka:
+      topics:
+        - orders
+        - shipments
+      partitions: 3
+----
+
 TIP: See the guide for https://guides.micronaut.io/latest/testing-micronaut-kafka-listener-using-testcontainers.html[Testing Kafka Listener using Testcontainers with the Micronaut Framework] to learn more.
 
 

--- a/test-resources-kafka/build.gradle
+++ b/test-resources-kafka/build.gradle
@@ -9,6 +9,7 @@ Provides support for launching a Kafka test container.
 
 dependencies {
     implementation(libs.managed.testcontainers.kafka)
+    implementation(mnKafka.kafka.clients)
 
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnKafka.micronaut.kafka)

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -16,11 +16,25 @@
 package io.micronaut.testresources.kafka;
 
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import io.micronaut.testresources.core.TestResourcesResolutionException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.*;
-
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ExecutionException;
+import java.math.BigDecimal;
 
 
 /**
@@ -29,10 +43,16 @@ import java.util.*;
 public class KafkaTestResourceProvider extends AbstractTestContainersProvider<KafkaContainer> {
 
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
+    public static final String KAFKA_TOPICS = "containers.kafka.topics";
+    public static final String KAFKA_PARTITIONS = "containers.kafka.partitions";
     public static final String DEFAULT_IMAGE = "apache/kafka:4.1.1";
+    public static final int DEFAULT_PARTITIONS = 1;
 
     public static final String DISPLAY_NAME = "Kafka";
     public static final String SIMPLE_NAME = "kafka";
+
+    private final Map<KafkaContainer, TopicProvisioningConfiguration> topicProvisioningConfigurations =
+        Collections.synchronizedMap(new WeakHashMap<>());
 
     @Override
     public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
@@ -56,16 +76,124 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
 
     @Override
     protected KafkaContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new KafkaContainer(imageName);
+        KafkaContainer container = new KafkaContainer(imageName);
+        topicProvisioningConfigurations.put(container, topicProvisioningConfiguration(testResourcesConfig));
+        return container;
     }
 
     @Override
     protected Optional<String> resolveProperty(String propertyName, KafkaContainer container) {
+        ensureTopicsExist(container);
         return Optional.of(container.getBootstrapServers());
     }
 
     @Override
     protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         return KAFKA_BOOTSTRAP_SERVERS.equals(propertyName);
+    }
+
+    private void ensureTopicsExist(KafkaContainer container) {
+        TopicProvisioningConfiguration configuration = topicProvisioningConfigurations.get(container);
+        if (configuration == null || configuration.provisioned() || configuration.topics().isEmpty()) {
+            return;
+        }
+        synchronized (container) {
+            TopicProvisioningConfiguration currentConfiguration = topicProvisioningConfigurations.get(container);
+            if (currentConfiguration == null || currentConfiguration.provisioned() || currentConfiguration.topics().isEmpty()) {
+                return;
+            }
+            provisionTopics(container, currentConfiguration);
+            topicProvisioningConfigurations.put(container, currentConfiguration.markProvisioned());
+        }
+    }
+
+    private void provisionTopics(KafkaContainer container, TopicProvisioningConfiguration configuration) {
+        Properties adminClientConfiguration = new Properties();
+        adminClientConfiguration.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+        try (AdminClient adminClient = AdminClient.create(adminClientConfiguration)) {
+            Set<String> existingTopics = adminClient.listTopics().names().get();
+            List<NewTopic> topicsToCreate = configuration.topics().stream()
+                .filter(topic -> !existingTopics.contains(topic))
+                .map(topic -> new NewTopic(topic, configuration.partitions(), (short) 1))
+                .toList();
+            if (topicsToCreate.isEmpty()) {
+                return;
+            }
+            var createTopicsResult = adminClient.createTopics(topicsToCreate);
+            for (NewTopic topic : topicsToCreate) {
+                try {
+                    createTopicsResult.values().get(topic.name()).get();
+                } catch (ExecutionException e) {
+                    if (!(e.getCause() instanceof TopicExistsException)) {
+                        throw e;
+                    }
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TestResourcesResolutionException("Interrupted while provisioning Kafka topics", e);
+        } catch (ExecutionException e) {
+            throw new TestResourcesResolutionException("Failed to provision Kafka topics", e);
+        }
+    }
+
+    private TopicProvisioningConfiguration topicProvisioningConfiguration(Map<String, Object> testResourcesConfig) {
+        List<String> topics = configuredTopics(testResourcesConfig);
+        if (topics.isEmpty()) {
+            return new TopicProvisioningConfiguration(topics, DEFAULT_PARTITIONS, false);
+        }
+        return new TopicProvisioningConfiguration(topics, configuredPartitions(testResourcesConfig), false);
+    }
+
+    static List<String> configuredTopics(Map<String, Object> testResourcesConfig) {
+        Object configuredTopics = testResourcesConfig.get(KAFKA_TOPICS);
+        if (configuredTopics == null) {
+            return Collections.emptyList();
+        }
+        List<String> rawTopics;
+        if (configuredTopics instanceof List<?> list) {
+            rawTopics = list.stream().map(String::valueOf).toList();
+        } else {
+            rawTopics = Collections.singletonList(String.valueOf(configuredTopics));
+        }
+        LinkedHashSet<String> topics = new LinkedHashSet<>();
+        for (String rawTopic : rawTopics) {
+            String topic = rawTopic.trim();
+            if (topic.isEmpty()) {
+                throw new IllegalArgumentException("Kafka topic names must not be blank");
+            }
+            topics.add(topic);
+        }
+        return List.copyOf(topics);
+    }
+
+    static int configuredPartitions(Map<String, Object> testResourcesConfig) {
+        Object configuredPartitions = testResourcesConfig.get(KAFKA_PARTITIONS);
+        int partitions = configuredPartitions == null ? DEFAULT_PARTITIONS : asInteger(configuredPartitions, KAFKA_PARTITIONS);
+        if (partitions < 1) {
+            throw new IllegalArgumentException("Kafka topic partitions must be greater than or equal to 1");
+        }
+        return partitions;
+    }
+
+    private static int asInteger(Object value, String propertyName) {
+        if (value instanceof Number number) {
+            try {
+                return new BigDecimal(String.valueOf(number)).intValueExact();
+            } catch (ArithmeticException | NumberFormatException e) {
+                throw new IllegalArgumentException("Kafka topic property '" + propertyName + "' must be an integer", e);
+            }
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Kafka topic property '" + propertyName + "' must be an integer", e);
+        }
+    }
+
+    private record TopicProvisioningConfiguration(List<String> topics, int partitions, boolean provisioned) {
+        private TopicProvisioningConfiguration markProvisioned() {
+            return new TopicProvisioningConfiguration(topics, partitions, true);
+        }
     }
 }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -34,6 +34,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.math.BigDecimal;
 
 
@@ -50,6 +52,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
 
     public static final String DISPLAY_NAME = "Kafka";
     public static final String SIMPLE_NAME = "kafka";
+    private static final long ADMIN_TIMEOUT_SECONDS = 30;
 
     private final Map<KafkaContainer, TopicProvisioningConfiguration> topicProvisioningConfigurations =
         Collections.synchronizedMap(new WeakHashMap<>());
@@ -111,7 +114,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         Properties adminClientConfiguration = new Properties();
         adminClientConfiguration.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
         try (AdminClient adminClient = AdminClient.create(adminClientConfiguration)) {
-            Set<String> existingTopics = adminClient.listTopics().names().get();
+            Set<String> existingTopics = adminClient.listTopics().names().get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             List<NewTopic> topicsToCreate = configuration.topics().stream()
                 .filter(topic -> !existingTopics.contains(topic))
                 .map(topic -> new NewTopic(topic, configuration.partitions(), (short) 1))
@@ -122,7 +125,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
             var createTopicsResult = adminClient.createTopics(topicsToCreate);
             for (NewTopic topic : topicsToCreate) {
                 try {
-                    createTopicsResult.values().get(topic.name()).get();
+                    createTopicsResult.values().get(topic.name()).get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 } catch (ExecutionException e) {
                     if (!(e.getCause() instanceof TopicExistsException)) {
                         throw e;
@@ -131,10 +134,19 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new TestResourcesResolutionException("Interrupted while provisioning Kafka topics", e);
+            throw new TestResourcesResolutionException("Interrupted while provisioning Kafka topics " + topicProvisioningDetails(configuration), e);
         } catch (ExecutionException e) {
-            throw new TestResourcesResolutionException("Failed to provision Kafka topics", e);
+            throw new TestResourcesResolutionException("Failed to provision Kafka topics " + topicProvisioningDetails(configuration), e);
+        } catch (TimeoutException e) {
+            throw new TestResourcesResolutionException(
+                "Timed out after " + ADMIN_TIMEOUT_SECONDS + "s while provisioning Kafka topics " + topicProvisioningDetails(configuration),
+                e
+            );
         }
+    }
+
+    private static String topicProvisioningDetails(TopicProvisioningConfiguration configuration) {
+        return "[topics=" + configuration.topics() + ", partitions=" + configuration.partitions() + "]";
     }
 
     private TopicProvisioningConfiguration topicProvisioningConfiguration(Map<String, Object> testResourcesConfig) {

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -20,6 +20,7 @@ import io.micronaut.testresources.core.TestResourcesResolutionException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -129,6 +130,15 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         adminClientConfiguration.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
         try (AdminClient adminClient = AdminClient.create(adminClientConfiguration)) {
             Set<String> existingTopics = adminClient.listTopics().names().get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            List<String> configuredExistingTopics = configuration.topics().stream()
+                .filter(existingTopics::contains)
+                .toList();
+            if (!configuredExistingTopics.isEmpty()) {
+                Map<String, TopicDescription> existingTopicDescriptions = adminClient.describeTopics(configuredExistingTopics)
+                    .allTopicNames()
+                    .get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                verifyExistingTopicPartitions(existingTopicDescriptions, configuration);
+            }
             List<NewTopic> topicsToCreate = configuration.topics().stream()
                 .filter(topic -> !existingTopics.contains(topic))
                 .map(topic -> new NewTopic(topic, configuration.partitions(), (short) 1))
@@ -156,6 +166,20 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
                 "Timed out after " + ADMIN_TIMEOUT_SECONDS + "s while provisioning Kafka topics " + topicProvisioningDetails(configuration),
                 e
             );
+        }
+    }
+
+    private static void verifyExistingTopicPartitions(Map<String, TopicDescription> existingTopicDescriptions,
+                                                      TopicProvisioningConfiguration configuration) {
+        for (Map.Entry<String, TopicDescription> entry : existingTopicDescriptions.entrySet()) {
+            int existingPartitions = entry.getValue().partitions().size();
+            if (existingPartitions != configuration.partitions()) {
+                throw new TestResourcesResolutionException(
+                    "Kafka topic '" + entry.getKey() + "' already exists with " + existingPartitions
+                        + " partitions, which conflicts with requested " + configuration.partitions() + " "
+                        + topicProvisioningDetails(configuration)
+                );
+            }
         }
     }
 

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -54,6 +54,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     public static final String SIMPLE_NAME = "kafka";
     private static final long ADMIN_TIMEOUT_SECONDS = 30;
 
+    private final Object topicProvisioningMonitor = new Object();
     private final Map<KafkaContainer, TopicProvisioningConfiguration> topicProvisioningConfigurations =
         Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -100,7 +101,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         if (configuration == null || configuration.provisioned() || configuration.topics().isEmpty()) {
             return;
         }
-        synchronized (container) {
+        synchronized (topicProvisioningMonitor) {
             TopicProvisioningConfiguration currentConfiguration = topicProvisioningConfigurations.get(container);
             if (currentConfiguration == null || currentConfiguration.provisioned() || currentConfiguration.topics().isEmpty()) {
                 return;

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -205,11 +205,11 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     }
 
     private TopicProvisioningConfiguration topicProvisioningConfiguration(Map<String, Object> testResourcesConfig) {
-        int partitions = configuredPartitions(testResourcesConfig);
         List<String> topics = configuredTopics(testResourcesConfig);
         if (topics.isEmpty()) {
             return NO_TOPICS;
         }
+        int partitions = configuredPartitions(testResourcesConfig);
         return new TopicProvisioningConfiguration(topics, partitions);
     }
 

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -130,15 +130,9 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         adminClientConfiguration.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
         try (AdminClient adminClient = AdminClient.create(adminClientConfiguration)) {
             Set<String> existingTopics = adminClient.listTopics().names().get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            List<String> configuredExistingTopics = configuration.topics().stream()
+            verifyExistingTopicPartitions(adminClient, configuration.topics().stream()
                 .filter(existingTopics::contains)
-                .toList();
-            if (!configuredExistingTopics.isEmpty()) {
-                Map<String, TopicDescription> existingTopicDescriptions = adminClient.describeTopics(configuredExistingTopics)
-                    .allTopicNames()
-                    .get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                verifyExistingTopicPartitions(existingTopicDescriptions, configuration);
-            }
+                .toList(), configuration);
             List<NewTopic> topicsToCreate = configuration.topics().stream()
                 .filter(topic -> !existingTopics.contains(topic))
                 .map(topic -> new NewTopic(topic, configuration.partitions(), (short) 1))
@@ -146,16 +140,21 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
             if (topicsToCreate.isEmpty()) {
                 return;
             }
+            beforeCreateTopics(container, configuration, topicsToCreate);
             var createTopicsResult = adminClient.createTopics(topicsToCreate);
+            List<String> topicsToReverify = new java.util.ArrayList<String>();
             for (NewTopic topic : topicsToCreate) {
                 try {
                     createTopicsResult.values().get(topic.name()).get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 } catch (ExecutionException e) {
-                    if (!(e.getCause() instanceof TopicExistsException)) {
+                    if (e.getCause() instanceof TopicExistsException) {
+                        topicsToReverify.add(topic.name());
+                    } else {
                         throw e;
                     }
                 }
             }
+            verifyExistingTopicPartitions(adminClient, topicsToReverify, configuration);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new TestResourcesResolutionException("Interrupted while provisioning Kafka topics " + topicProvisioningDetails(configuration), e);
@@ -167,6 +166,24 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
                 e
             );
         }
+    }
+
+    protected void beforeCreateTopics(KafkaContainer container,
+                                      TopicProvisioningConfiguration configuration,
+                                      List<NewTopic> topicsToCreate) {
+        // Default no-op hook for tests that need to force a topic-creation race.
+    }
+
+    private void verifyExistingTopicPartitions(AdminClient adminClient,
+                                               List<String> topicNames,
+                                               TopicProvisioningConfiguration configuration) throws ExecutionException, InterruptedException, TimeoutException {
+        if (topicNames.isEmpty()) {
+            return;
+        }
+        Map<String, TopicDescription> existingTopicDescriptions = adminClient.describeTopics(topicNames)
+            .allTopicNames()
+            .get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        verifyExistingTopicPartitions(existingTopicDescriptions, configuration);
     }
 
     private static void verifyExistingTopicPartitions(Map<String, TopicDescription> existingTopicDescriptions,
@@ -188,11 +205,12 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     }
 
     private TopicProvisioningConfiguration topicProvisioningConfiguration(Map<String, Object> testResourcesConfig) {
+        int partitions = configuredPartitions(testResourcesConfig);
         List<String> topics = configuredTopics(testResourcesConfig);
         if (topics.isEmpty()) {
             return NO_TOPICS;
         }
-        return new TopicProvisioningConfiguration(topics, configuredPartitions(testResourcesConfig));
+        return new TopicProvisioningConfiguration(topics, partitions);
     }
 
     static List<String> configuredTopics(Map<String, Object> testResourcesConfig) {
@@ -241,6 +259,6 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         }
     }
 
-    private record TopicProvisioningConfiguration(List<String> topics, int partitions) {
+    protected record TopicProvisioningConfiguration(List<String> topics, int partitions) {
     }
 }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
@@ -53,9 +54,12 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     public static final String DISPLAY_NAME = "Kafka";
     public static final String SIMPLE_NAME = "kafka";
     private static final long ADMIN_TIMEOUT_SECONDS = 30;
+    private static final TopicProvisioningConfiguration NO_TOPICS =
+        new TopicProvisioningConfiguration(Collections.emptyList(), DEFAULT_PARTITIONS);
 
     private final Object topicProvisioningMonitor = new Object();
-    private final Map<KafkaContainer, TopicProvisioningConfiguration> topicProvisioningConfigurations =
+    private final ThreadLocal<TopicProvisioningConfiguration> requestedTopicProvisioningConfiguration = new ThreadLocal<>();
+    private final Map<KafkaContainer, Set<TopicProvisioningConfiguration>> provisionedTopicConfigurations =
         Collections.synchronizedMap(new WeakHashMap<>());
 
     @Override
@@ -80,15 +84,18 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
 
     @Override
     protected KafkaContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        KafkaContainer container = new KafkaContainer(imageName);
-        topicProvisioningConfigurations.put(container, topicProvisioningConfiguration(testResourcesConfig));
-        return container;
+        return new KafkaContainer(imageName);
     }
 
     @Override
     protected Optional<String> resolveProperty(String propertyName, KafkaContainer container) {
-        ensureTopicsExist(container);
-        return Optional.of(container.getBootstrapServers());
+        TopicProvisioningConfiguration configuration = Optional.ofNullable(requestedTopicProvisioningConfiguration.get()).orElse(NO_TOPICS);
+        try {
+            ensureTopicsExist(container, configuration);
+            return Optional.of(container.getBootstrapServers());
+        } finally {
+            requestedTopicProvisioningConfiguration.remove();
+        }
     }
 
     @Override
@@ -96,18 +103,24 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         return KAFKA_BOOTSTRAP_SERVERS.equals(propertyName);
     }
 
-    private void ensureTopicsExist(KafkaContainer container) {
-        TopicProvisioningConfiguration configuration = topicProvisioningConfigurations.get(container);
-        if (configuration == null || configuration.provisioned() || configuration.topics().isEmpty()) {
+    @Override
+    protected Optional<String> resolveWithoutContainer(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+        requestedTopicProvisioningConfiguration.set(topicProvisioningConfiguration(testResourcesConfig));
+        return Optional.empty();
+    }
+
+    private void ensureTopicsExist(KafkaContainer container, TopicProvisioningConfiguration configuration) {
+        if (configuration.topics().isEmpty()) {
             return;
         }
         synchronized (topicProvisioningMonitor) {
-            TopicProvisioningConfiguration currentConfiguration = topicProvisioningConfigurations.get(container);
-            if (currentConfiguration == null || currentConfiguration.provisioned() || currentConfiguration.topics().isEmpty()) {
+            Set<TopicProvisioningConfiguration> provisionedConfigurations =
+                provisionedTopicConfigurations.computeIfAbsent(container, ignored -> new HashSet<>());
+            if (provisionedConfigurations.contains(configuration)) {
                 return;
             }
-            provisionTopics(container, currentConfiguration);
-            topicProvisioningConfigurations.put(container, currentConfiguration.markProvisioned());
+            provisionTopics(container, configuration);
+            provisionedConfigurations.add(configuration);
         }
     }
 
@@ -153,9 +166,9 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     private TopicProvisioningConfiguration topicProvisioningConfiguration(Map<String, Object> testResourcesConfig) {
         List<String> topics = configuredTopics(testResourcesConfig);
         if (topics.isEmpty()) {
-            return new TopicProvisioningConfiguration(topics, DEFAULT_PARTITIONS, false);
+            return NO_TOPICS;
         }
-        return new TopicProvisioningConfiguration(topics, configuredPartitions(testResourcesConfig), false);
+        return new TopicProvisioningConfiguration(topics, configuredPartitions(testResourcesConfig));
     }
 
     static List<String> configuredTopics(Map<String, Object> testResourcesConfig) {
@@ -204,9 +217,6 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
         }
     }
 
-    private record TopicProvisioningConfiguration(List<String> topics, int partitions, boolean provisioned) {
-        private TopicProvisioningConfiguration markProvisioned() {
-            return new TopicProvisioningConfiguration(topics, partitions, true);
-        }
+    private record TopicProvisioningConfiguration(List<String> topics, int partitions) {
     }
 }

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -8,7 +8,6 @@ import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.admin.TopicDescription
-import spock.lang.Specification
 
 import java.util.Properties
 import java.util.concurrent.ExecutionException
@@ -159,14 +158,14 @@ class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
     }
 }
 
-class KafkaInvalidTopicProvisioningConfigTest extends Specification {
+class KafkaInvalidTopicProvisioningConfigTest extends AbstractKafkaSpec {
 
     def "ignores Kafka topic partitions when no topics are configured"() {
         given:
         def provider = new KafkaTestResourceProvider()
 
         when:
-        def bootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, [:], [
+        def bootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, properties, [
             (KafkaTestResourceProvider.KAFKA_PARTITIONS): "0"
         ]).orElseThrow()
 
@@ -180,7 +179,7 @@ class KafkaInvalidTopicProvisioningConfigTest extends Specification {
         def provider = new KafkaTestResourceProvider()
 
         when:
-        provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, [:], [
+        provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, properties, [
             (KafkaTestResourceProvider.KAFKA_TOPICS)    : "orders",
             (KafkaTestResourceProvider.KAFKA_PARTITIONS): "0"
         ])

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -2,6 +2,7 @@ package io.micronaut.testresources.kafka
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.core.TestResourcesResolutionException
 import jakarta.inject.Inject
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
@@ -117,6 +118,29 @@ class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvis
         then:
         bootstrapServers == reusedBootstrapServers
         topics.orders.partitions().size() == 2
+        listContainers().size() == 1
+    }
+
+    def "rejects conflicting Kafka partition requests when reusing a cached broker in the same scope"() {
+        given:
+        def provider = new KafkaTestResourceProvider()
+        def requestedProperties = properties
+
+        when:
+        def bootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [
+            (KafkaTestResourceProvider.KAFKA_TOPICS)    : "payments",
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "1"
+        ]).orElseThrow()
+        provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [
+            (KafkaTestResourceProvider.KAFKA_TOPICS)    : "payments",
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "3"
+        ]).orElseThrow()
+
+        then:
+        def e = thrown(TestResourcesResolutionException)
+        e.message.contains("already exists with 1 partitions")
+        e.message.contains("requested 3")
+        describeTopics(bootstrapServers, "payments").payments.partitions().size() == 1
         listContainers().size() == 1
     }
 }

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -9,8 +9,11 @@ import org.apache.kafka.clients.admin.TopicDescription
 import spock.lang.Specification
 
 import java.util.Properties
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 abstract class AbstractKafkaTopicProvisioningSpec extends AbstractKafkaSpec {
+    private static final long ADMIN_TIMEOUT_SECONDS = 30
 
     @Inject
     ApplicationContext applicationContext
@@ -25,7 +28,9 @@ abstract class AbstractKafkaTopicProvisioningSpec extends AbstractKafkaSpec {
         Properties properties = new Properties()
         properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
         try (AdminClient adminClient = AdminClient.create(properties)) {
-            return adminClient.describeTopics(topicNames.toList()).allTopicNames().get()
+            return adminClient.describeTopics(topicNames.toList()).allTopicNames().get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (TimeoutException e) {
+            throw new AssertionError("Timed out after ${ADMIN_TIMEOUT_SECONDS}s describing Kafka topics ${topicNames.toList()} for ${bootstrapServers}", e)
         }
     }
 }

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -99,6 +99,28 @@ class KafkaPartitionsWithoutTopicsTest extends AbstractKafkaTopicProvisioningSpe
     }
 }
 
+class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvisioningSpec {
+
+    def "provisions configured Kafka topics when reusing a cached broker in the same scope"() {
+        given:
+        def provider = new KafkaTestResourceProvider()
+        def requestedProperties = properties
+
+        when:
+        def bootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [:]).orElseThrow()
+        def reusedBootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [
+            (KafkaTestResourceProvider.KAFKA_TOPICS)    : "orders",
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "2"
+        ]).orElseThrow()
+        def topics = describeTopics(reusedBootstrapServers, "orders")
+
+        then:
+        bootstrapServers == reusedBootstrapServers
+        topics.orders.partitions().size() == 2
+        listContainers().size() == 1
+    }
+}
+
 class KafkaInvalidTopicProvisioningConfigTest extends Specification {
 
     def "rejects blank Kafka topic names"() {

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -6,10 +6,12 @@ import io.micronaut.testresources.core.TestResourcesResolutionException
 import jakarta.inject.Inject
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.admin.TopicDescription
 import spock.lang.Specification
 
 import java.util.Properties
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -80,26 +82,6 @@ class KafkaDefaultTopicPartitionsTest extends AbstractKafkaTopicProvisioningSpec
     }
 }
 
-@MicronautTest
-class KafkaPartitionsWithoutTopicsTest extends AbstractKafkaTopicProvisioningSpec {
-
-    @Override
-    Map<String, String> getProperties() {
-        super.properties + [
-            "test-resources.containers.kafka.partitions": "0"
-        ]
-    }
-
-    def "ignores Kafka topic partitions when no topics are configured"() {
-        when:
-        def bootstrapServers = resolveBootstrapServers()
-
-        then:
-        bootstrapServers
-        listContainers().size() == 1
-    }
-}
-
 class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvisioningSpec {
 
     def "provisions configured Kafka topics when reusing a cached broker in the same scope"() {
@@ -143,9 +125,55 @@ class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvis
         describeTopics(bootstrapServers, "payments").payments.partitions().size() == 1
         listContainers().size() == 1
     }
+
+    def "rejects partition mismatch when the topic appears between listing and create"() {
+        given:
+        def provider = new RacingKafkaTestResourceProvider()
+
+        when:
+        provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, properties, [
+            (KafkaTestResourceProvider.KAFKA_TOPICS)    : "race-topic",
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "3"
+        ]).orElseThrow()
+
+        then:
+        def e = thrown(TestResourcesResolutionException)
+        e.message.contains("already exists with 1 partitions")
+        e.message.contains("requested 3")
+    }
+}
+
+class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
+    @Override
+    protected void beforeCreateTopics(org.testcontainers.kafka.KafkaContainer container,
+                                      TopicProvisioningConfiguration configuration,
+                                      List<NewTopic> topicsToCreate) {
+        Properties properties = new Properties()
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.bootstrapServers)
+        try (AdminClient adminClient = AdminClient.create(properties)) {
+            NewTopic topic = new NewTopic(topicsToCreate.first().name(), 1, (short) 1)
+            adminClient.createTopics([topic]).all().get(30, TimeUnit.SECONDS)
+        } catch (ExecutionException e) {
+            throw new AssertionError("Failed to create the racing Kafka topic", e)
+        }
+    }
 }
 
 class KafkaInvalidTopicProvisioningConfigTest extends Specification {
+
+    def "rejects Kafka topic partitions even when no topics are configured"() {
+        given:
+        def provider = new KafkaTestResourceProvider()
+
+        when:
+        provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, [:], [
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "0"
+        ])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("greater than or equal to 1")
+    }
 
     def "rejects blank Kafka topic names"() {
         when:

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -161,12 +161,27 @@ class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
 
 class KafkaInvalidTopicProvisioningConfigTest extends Specification {
 
-    def "rejects Kafka topic partitions even when no topics are configured"() {
+    def "ignores Kafka topic partitions when no topics are configured"() {
+        given:
+        def provider = new KafkaTestResourceProvider()
+
+        when:
+        def bootstrapServers = provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, [:], [
+            (KafkaTestResourceProvider.KAFKA_PARTITIONS): "0"
+        ]).orElseThrow()
+
+        then:
+        noExceptionThrown()
+        bootstrapServers
+    }
+
+    def "rejects Kafka topic partitions lower than one when topics are configured"() {
         given:
         def provider = new KafkaTestResourceProvider()
 
         when:
         provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, [:], [
+            (KafkaTestResourceProvider.KAFKA_TOPICS)    : "orders",
             (KafkaTestResourceProvider.KAFKA_PARTITIONS): "0"
         ])
 
@@ -184,7 +199,7 @@ class KafkaInvalidTopicProvisioningConfigTest extends Specification {
         e.message.contains("must not be blank")
     }
 
-    def "rejects Kafka topic partitions lower than one"() {
+    def "rejects Kafka topic partitions lower than one when parsed directly"() {
         when:
         KafkaTestResourceProvider.configuredPartitions([(KafkaTestResourceProvider.KAFKA_PARTITIONS): 0])
 

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -1,0 +1,125 @@
+package io.micronaut.testresources.kafka
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.TopicDescription
+import spock.lang.Specification
+
+import java.util.Properties
+
+abstract class AbstractKafkaTopicProvisioningSpec extends AbstractKafkaSpec {
+
+    @Inject
+    ApplicationContext applicationContext
+
+    protected String resolveBootstrapServers() {
+        applicationContext.environment
+            .getProperty(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, String)
+            .orElseThrow()
+    }
+
+    protected static Map<String, TopicDescription> describeTopics(String bootstrapServers, String... topicNames) {
+        Properties properties = new Properties()
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        try (AdminClient adminClient = AdminClient.create(properties)) {
+            return adminClient.describeTopics(topicNames.toList()).allTopicNames().get()
+        }
+    }
+}
+
+@MicronautTest
+class KafkaTopicProvisioningTest extends AbstractKafkaTopicProvisioningSpec {
+
+    @Override
+    Map<String, String> getProperties() {
+        super.properties + [
+            "test-resources.containers.kafka.topics"    : "orders",
+            "test-resources.containers.kafka.partitions": "3"
+        ]
+    }
+
+    def "creates configured Kafka topics with configured partitions and repeated resolution stays safe"() {
+        when:
+        def bootstrapServers = resolveBootstrapServers()
+        def repeatedBootstrapServers = resolveBootstrapServers()
+        def topics = describeTopics(bootstrapServers, "orders")
+
+        then:
+        bootstrapServers == repeatedBootstrapServers
+        topics.orders.partitions().size() == 3
+        listContainers().size() == 1
+    }
+}
+
+@MicronautTest
+class KafkaDefaultTopicPartitionsTest extends AbstractKafkaTopicProvisioningSpec {
+
+    @Override
+    Map<String, String> getProperties() {
+        super.properties + [
+            "test-resources.containers.kafka.topics": "audit-events"
+        ]
+    }
+
+    def "defaults Kafka topic partitions to one when not configured"() {
+        when:
+        def bootstrapServers = resolveBootstrapServers()
+        def topics = describeTopics(bootstrapServers, "audit-events")
+
+        then:
+        topics["audit-events"].partitions().size() == 1
+    }
+}
+
+@MicronautTest
+class KafkaPartitionsWithoutTopicsTest extends AbstractKafkaTopicProvisioningSpec {
+
+    @Override
+    Map<String, String> getProperties() {
+        super.properties + [
+            "test-resources.containers.kafka.partitions": "0"
+        ]
+    }
+
+    def "ignores Kafka topic partitions when no topics are configured"() {
+        when:
+        def bootstrapServers = resolveBootstrapServers()
+
+        then:
+        bootstrapServers
+        listContainers().size() == 1
+    }
+}
+
+class KafkaInvalidTopicProvisioningConfigTest extends Specification {
+
+    def "rejects blank Kafka topic names"() {
+        when:
+        KafkaTestResourceProvider.configuredTopics([(KafkaTestResourceProvider.KAFKA_TOPICS): ["valid-topic", "   "]])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("must not be blank")
+    }
+
+    def "rejects Kafka topic partitions lower than one"() {
+        when:
+        KafkaTestResourceProvider.configuredPartitions([(KafkaTestResourceProvider.KAFKA_PARTITIONS): 0])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("greater than or equal to 1")
+    }
+
+    def "rejects Kafka topic partitions with a fractional numeric value"() {
+        when:
+        KafkaTestResourceProvider.configuredPartitions([(KafkaTestResourceProvider.KAFKA_PARTITIONS): 1.5])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("must be an integer")
+    }
+}


### PR DESCRIPTION
## Summary

- add opt-in Kafka topic provisioning for `test-resources.containers.kafka.topics`
- validate and document shared partition configuration, defaulting to `1`
- add Kafka provider tests covering configured topics, default partitions, opt-in behavior, and invalid config

## Verification

- `./gradlew :micronaut-test-resources-kafka:test --tests 'io.micronaut.testresources.kafka.KafkaTopicProvisioningTest' --tests 'io.micronaut.testresources.kafka.KafkaDefaultTopicPartitionsTest' --tests 'io.micronaut.testresources.kafka.KafkaPartitionsWithoutTopicsTest' --tests 'io.micronaut.testresources.kafka.KafkaInvalidTopicProvisioningConfigTest'`
- `./gradlew :micronaut-test-resources-kafka:check`

## Release Tracking

- QA intake selected Micronaut organization project `5.0.0 Release`
- Ambiguity note preserved from QA: `5.0.0-M3` may also be a plausible maintainer bucket if release tracking moved
- Project linkage could not be applied automatically in this environment because the available GitHub credentials do not simultaneously provide `read:org` and `read:project`

Closes #751
---
###### ✨ This message was AI-generated using gpt-5.4