### PR TITLE
docs: check contributing guidelines before PR handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ This file is intentionally durable: do not add generated timestamps, commit IDs,
 - Keep docs in `src/main/docs/guide`; this repository does not use a top-level `docs/` tree.
 - Remove stale nested agent guidance instead of letting old generated files override these root instructions.
 
+## Contributing Guidelines
+
+- Before opening or updating a pull request, read this repository's `CONTRIBUTING.md` and follow every repo-specific PR requirement it names.
+- Treat contributor-checklist items as handoff requirements. If a requirement is not applicable, state that explicitly in the PR description or handoff note.
+- For UI-visible changes, confirm whether screenshots or other visual evidence are required and include them in the PR description; if screenshots cannot be provided, explain why and describe the verification that was performed.
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` check to read repository `CONTRIBUTING.md` or maintainer contribution guidance before PR handoff.
- Require agents to treat contributor checklist items as handoff requirements.
- Call out UI-visible changes so screenshots or equivalent visual evidence are included when repository guidance requires them.

## Validation
- `git diff --check`

## CI
- Commit uses `[skip ci]` because this changes only Markdown agent guidance that repository builds do not exercise.

Paperclip: DEV-349

---
###### ✨ This message was AI-generated using gpt-5.5
