### PR TITLE
Disable Gradle parallelism

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ developers=Cédric Champeau
 
 
 org.gradle.caching=true
-org.gradle.parallel=true
+org.gradle.parallel=false
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
## Summary
- disable Gradle parallel project execution via `gradle.properties`
- leave the template-managed Java CI workflow unchanged so the fix survives the next Micronaut Project Template sync

## Evidence
Several recent Java CI runs were cancelled while the `🛠 Build with Gradle` step was still active after hours. Available logs show the build reaching the tail end of the container-backed modules (for example Solr/WireMock) and then making no further Gradle progress until cancellation/shutdown.

The same mitigation was first tried on PR #1069 by passing `--no-parallel` in the workflow; that run got past the Gradle build in about 25 minutes. This PR applies the same behavior in the repository-owned Gradle configuration instead of editing the template-managed workflow.

## Testing
- `git diff --check`
- `./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.IntellijIdeaDatasourceExporterStandaloneProjectTest --no-daemon --console=plain`
- Java CI on this PR: https://github.com/micronaut-projects/micronaut-test-resources/actions/runs/25907482547/job/76143566478

No UI changes; screenshots are not applicable.
