### PR TITLE
Add Kafka service test resources

### DIFF
--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -46,7 +46,26 @@ Each service depends on the Kafka broker container and uses the same test resour
 The returned values are host-accessible `http://` URLs using random Testcontainers host ports.
 The containers communicate with Kafka on an internal Docker network, so no fixed host port is required.
 
-Resolve one of the listed URL properties when a service should be started.
+Request one of the listed URL properties when a service should be started.
+For example, a test-only bean can require and inject the Schema Registry URL:
+
+[source,java]
+----
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "kafka.schema.registry.url")
+class SchemaRegistryClientConfiguration {
+
+    SchemaRegistryClientConfiguration(
+            @Value("${kafka.schema.registry.url}") String schemaRegistryUrl) {
+        // Configure a Schema Registry client for tests.
+    }
+}
+----
+
 Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 
 These REST APIs are intended for local test infrastructure.

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -49,22 +49,7 @@ The containers communicate with Kafka on an internal Docker network, so no fixed
 Request one of the listed URL properties when a service should be started.
 For example, a test-only bean can require and inject the Schema Registry URL:
 
-[source,java]
-----
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
-import jakarta.inject.Singleton;
-
-@Singleton
-@Requires(property = "kafka.schema.registry.url")
-class SchemaRegistryClientConfiguration {
-
-    SchemaRegistryClientConfiguration(
-            @Value("${kafka.schema.registry.url}") String schemaRegistryUrl) {
-        // Configure a Schema Registry client for tests.
-    }
-}
-----
+snippet::io.micronaut.testresources.kafka.SchemaRegistryClientConfiguration[project=test-resources-kafka,source=test,tags=clazz]
 
 Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -39,7 +39,7 @@ Each service depends on the Kafka broker container and uses the same test resour
 |`8083`
 
 |`kafka.ksqldb.url`
-|`confluentinc/ksqldb-server:0.29.0`
+|`confluentinc/cp-ksqldb-server:8.2.0`
 |`8088`
 |===
 
@@ -73,8 +73,8 @@ test-resources:
       image-name: confluentinc/cp-kafka-connect
       image-tag: 8.2.0
     kafka-ksqldb:
-      image-name: confluentinc/ksqldb-server
-      image-tag: 0.29.0
+      image-name: confluentinc/cp-ksqldb-server
+      image-tag: 8.2.0
 ----
 
 These REST APIs are intended for local test infrastructure.

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -46,19 +46,8 @@ Each service depends on the Kafka broker container and uses the same test resour
 The returned values are host-accessible `http://` URLs using random Testcontainers host ports.
 The containers communicate with Kafka on an internal Docker network, so no fixed host port is required.
 
-Declare the URL property in application configuration when a service should be started:
-
-[configuration]
-----
-kafka:
-  schema:
-    registry:
-      url: ${kafka.schema.registry.url}
-  connect:
-    url: ${kafka.connect.url}
-  ksqldb:
-    url: ${kafka.ksqldb.url}
-----
+Resolve one of the listed URL properties when a service should be started.
+Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 
 These REST APIs are intended for local test infrastructure.
 They are exposed without credentials on random localhost ports and should not be used as production service configuration.

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -31,15 +31,15 @@ Each service depends on the Kafka broker container and uses the same test resour
 |Resolved property |Default image |REST port
 
 |`kafka.schema.registry.url`
-|`confluentinc/cp-schema-registry:8.2.0`
+|`{default-image-kafka-schema-registry}`
 |`8081`
 
 |`kafka.connect.url`
-|`confluentinc/cp-kafka-connect:8.2.0`
+|`{default-image-kafka-connect}`
 |`8083`
 
 |`kafka.ksqldb.url`
-|`confluentinc/cp-ksqldb-server:8.2.0`
+|`{default-image-kafka-ksqldb}`
 |`8088`
 |===
 
@@ -58,23 +58,6 @@ kafka:
     url: ${kafka.connect.url}
   ksqldb:
     url: ${kafka.ksqldb.url}
-----
-
-Default images can be overwritten with the standard container image configuration:
-
-[configuration]
-----
-test-resources:
-  containers:
-    kafka-schema-registry:
-      image-name: confluentinc/cp-schema-registry
-      image-tag: 8.2.0
-    kafka-connect:
-      image-name: confluentinc/cp-kafka-connect
-      image-tag: 8.2.0
-    kafka-ksqldb:
-      image-name: confluentinc/cp-ksqldb-server
-      image-tag: 8.2.0
 ----
 
 These REST APIs are intended for local test infrastructure.

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -21,4 +21,63 @@ test-resources:
       partitions: 3
 ----
 
+== Kafka services
+
+The Kafka module can also start Confluent Schema Registry, Kafka Connect, and ksqlDB test containers.
+Each service depends on the Kafka broker container and uses the same test resources scope, so requesting a service URL starts Kafka if it is not already running and reuses the broker if `kafka.bootstrap.servers` was already resolved.
+
+[cols="1,1,1"]
+|===
+|Resolved property |Default image |REST port
+
+|`kafka.schema.registry.url`
+|`confluentinc/cp-schema-registry:8.2.0`
+|`8081`
+
+|`kafka.connect.url`
+|`confluentinc/cp-kafka-connect:8.2.0`
+|`8083`
+
+|`kafka.ksqldb.url`
+|`confluentinc/ksqldb-server:0.29.0`
+|`8088`
+|===
+
+The returned values are host-accessible `http://` URLs using random Testcontainers host ports.
+The containers communicate with Kafka on an internal Docker network, so no fixed host port is required.
+
+Declare the URL property in application configuration when a service should be started:
+
+[configuration]
+----
+kafka:
+  schema:
+    registry:
+      url: ${kafka.schema.registry.url}
+  connect:
+    url: ${kafka.connect.url}
+  ksqldb:
+    url: ${kafka.ksqldb.url}
+----
+
+Default images can be overwritten with the standard container image configuration:
+
+[configuration]
+----
+test-resources:
+  containers:
+    kafka-schema-registry:
+      image-name: confluentinc/cp-schema-registry
+      image-tag: 8.2.0
+    kafka-connect:
+      image-name: confluentinc/cp-kafka-connect
+      image-tag: 8.2.0
+    kafka-ksqldb:
+      image-name: confluentinc/ksqldb-server
+      image-tag: 0.29.0
+----
+
+These REST APIs are intended for local test infrastructure.
+They are exposed without credentials on random localhost ports and should not be used as production service configuration.
+
 TIP: See the guide for https://guides.micronaut.io/latest/testing-micronaut-kafka-listener-using-testcontainers.html[Testing Kafka Listener using Testcontainers with the Micronaut Framework] to learn more.

--- a/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
+++ b/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
@@ -37,6 +37,18 @@ FROM quay.io/infinispan/server:16.1.3 AS infinispan
 # property: test-resources.containers.kafka.image-name
 FROM apache/kafka:4.1.1 AS kafka
 
+# provider: kafka-schema-registry
+# property: test-resources.containers.kafka-schema-registry.image-name
+FROM confluentinc/cp-schema-registry:8.2.0 AS kafka_schema_registry
+
+# provider: kafka-connect
+# property: test-resources.containers.kafka-connect.image-name
+FROM confluentinc/cp-kafka-connect:8.2.0 AS kafka_connect
+
+# provider: kafka-ksqldb
+# property: test-resources.containers.kafka-ksqldb.image-name
+FROM confluentinc/cp-ksqldb-server:8.2.0 AS kafka_ksqldb
+
 # provider: keycloak
 # property: test-resources.containers.keycloak.image-name
 FROM quay.io/keycloak/keycloak:26.6.1 AS keycloak

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/DefaultTestResourceImagesTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/DefaultTestResourceImagesTest.groovy
@@ -32,6 +32,9 @@ class DefaultTestResourceImagesTest extends Specification {
         'hivemq',
         'infinispan',
         'kafka',
+        'kafka_schema_registry',
+        'kafka_connect',
+        'kafka_ksqldb',
         'keycloak',
         'localstack',
         'mailpit',
@@ -67,6 +70,9 @@ class DefaultTestResourceImagesTest extends Specification {
         DefaultTestResourceImages.DEFAULT_HIVEMQ_IMAGE == DefaultTestResourceImages.image('hivemq')
         DefaultTestResourceImages.DEFAULT_INFINISPAN_IMAGE == DefaultTestResourceImages.image('infinispan')
         DefaultTestResourceImages.DEFAULT_KAFKA_IMAGE == DefaultTestResourceImages.image('kafka')
+        DefaultTestResourceImages.DEFAULT_KAFKA_SCHEMA_REGISTRY_IMAGE == DefaultTestResourceImages.image('kafka_schema_registry')
+        DefaultTestResourceImages.DEFAULT_KAFKA_CONNECT_IMAGE == DefaultTestResourceImages.image('kafka_connect')
+        DefaultTestResourceImages.DEFAULT_KAFKA_KSQLDB_IMAGE == DefaultTestResourceImages.image('kafka_ksqldb')
         DefaultTestResourceImages.DEFAULT_KEYCLOAK_IMAGE == DefaultTestResourceImages.image('keycloak')
         DefaultTestResourceImages.DEFAULT_LOCALSTACK_IMAGE == DefaultTestResourceImages.image('localstack')
         DefaultTestResourceImages.DEFAULT_MAILPIT_IMAGE == DefaultTestResourceImages.image('mailpit')
@@ -129,7 +135,7 @@ class DefaultTestResourceImagesTest extends Specification {
             'modules-hashicorp-vault.adoc': ['vault'],
             'modules-hazelcast.adoc': ['hazelcast'],
             'modules-infinispan.adoc': ['infinispan'],
-            'modules-kafka.adoc': ['kafka'],
+            'modules-kafka.adoc': ['kafka', 'kafka_schema_registry', 'kafka_connect', 'kafka_ksqldb'],
             'modules-localstack.adoc': ['localstack'],
             'modules-mailpit.adoc': ['mailpit'],
             'modules-minio.adoc': ['minio'],

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/AbstractKafkaServiceTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/AbstractKafkaServiceTestResourceProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.kafka;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+abstract class AbstractKafkaServiceTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+    private final String displayName;
+    private final String simpleName;
+    private final String defaultImageName;
+    private final String propertyEntry;
+    private final String propertyName;
+    private final int port;
+    private final String readinessPath;
+
+    AbstractKafkaServiceTestResourceProvider(String displayName,
+                                             String simpleName,
+                                             String defaultImageName,
+                                             String propertyEntry,
+                                             String propertyName,
+                                             int port,
+                                             String readinessPath) {
+        this.displayName = displayName;
+        this.simpleName = simpleName;
+        this.defaultImageName = defaultImageName;
+        this.propertyEntry = propertyEntry;
+        this.propertyName = propertyName;
+        this.port = port;
+        this.readinessPath = readinessPath;
+    }
+
+    @Override
+    public final List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, propertyEntry, propertyName);
+    }
+
+    @Override
+    public final List<String> getRequiredPropertyEntries() {
+        return Collections.singletonList(propertyEntry);
+    }
+
+    @Override
+    public final String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    protected final String getSimpleName() {
+        return simpleName;
+    }
+
+    @Override
+    protected final String getDefaultImageName() {
+        return defaultImageName;
+    }
+
+    @Override
+    @SuppressWarnings("java:S2095") // AbstractTestContainersProvider owns and closes the returned container.
+    protected final GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
+        GenericContainer<?> container = new GenericContainer<>(imageName)
+            .withNetwork(KafkaServices.network(requestedProperties))
+            .withExposedPorts(port)
+            .dependsOn(kafka)
+            .waitingFor(Wait.forHttp(readinessPath).forPort(port));
+        configureService(container);
+        return container;
+    }
+
+    @Override
+    protected final Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
+        return Optional.of(KafkaServices.httpUrl(container, port));
+    }
+
+    @Override
+    protected final boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return this.propertyName.equals(propertyName);
+    }
+
+    protected abstract void configureService(GenericContainer<?> container);
+}

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.kafka;
 
+import io.micronaut.testresources.core.DefaultTestResourceImages;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -22,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class KafkaConnectTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_CONNECT_URL = "kafka.connect.url";
-    public static final String DEFAULT_IMAGE = "confluentinc/cp-kafka-connect:8.2.0";
+    public static final String DEFAULT_IMAGE = DefaultTestResourceImages.DEFAULT_KAFKA_CONNECT_IMAGE;
     public static final String DISPLAY_NAME = "Kafka Connect";
     public static final String SIMPLE_NAME = "kafka-connect";
     public static final int PORT = 8083;

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
@@ -15,22 +15,12 @@
  */
 package io.micronaut.testresources.kafka;
 
-import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.kafka.KafkaContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * A test resource provider which will spawn a Kafka Connect test container.
  */
-public class KafkaConnectTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+public class KafkaConnectTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_CONNECT_URL = "kafka.connect.url";
     public static final String DEFAULT_IMAGE = "confluentinc/cp-kafka-connect:8.2.0";
     public static final String DISPLAY_NAME = "Kafka Connect";
@@ -38,37 +28,13 @@ public class KafkaConnectTestResourceProvider extends AbstractTestContainersProv
     public static final int PORT = 8083;
     private static final String PROPERTY_ENTRY = "kafka.connect";
 
-    @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_CONNECT_URL);
+    public KafkaConnectTestResourceProvider() {
+        super(DISPLAY_NAME, SIMPLE_NAME, DEFAULT_IMAGE, PROPERTY_ENTRY, KAFKA_CONNECT_URL, PORT, "/connectors");
     }
 
     @Override
-    public List<String> getRequiredPropertyEntries() {
-        return Collections.singletonList(PROPERTY_ENTRY);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return DISPLAY_NAME;
-    }
-
-    @Override
-    protected String getSimpleName() {
-        return SIMPLE_NAME;
-    }
-
-    @Override
-    protected String getDefaultImageName() {
-        return DEFAULT_IMAGE;
-    }
-
-    @Override
-    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
-        return new GenericContainer<>(imageName)
-            .withNetwork(KafkaServices.network(requestedProperties))
-            .withExposedPorts(PORT)
+    protected void configureService(GenericContainer<?> container) {
+        container
             .withEnv("CONNECT_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS)
             .withEnv("CONNECT_GROUP_ID", "test-resources-connect")
             .withEnv("CONNECT_CONFIG_STORAGE_TOPIC", "test-resources-connect-config")
@@ -83,18 +49,6 @@ public class KafkaConnectTestResourceProvider extends AbstractTestContainersProv
             .withEnv("CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE", "false")
             .withEnv("CONNECT_REST_ADVERTISED_HOST_NAME", "connect")
             .withEnv("CONNECT_REST_PORT", String.valueOf(PORT))
-            .withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java,/usr/share/confluent-hub-components")
-            .dependsOn(kafka)
-            .waitingFor(Wait.forHttp("/connectors").forPort(PORT));
-    }
-
-    @Override
-    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
-        return Optional.of(KafkaServices.httpUrl(container, PORT));
-    }
-
-    @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return KAFKA_CONNECT_URL.equals(propertyName);
+            .withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java,/usr/share/confluent-hub-components");
     }
 }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaConnectTestResourceProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.kafka;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider which will spawn a Kafka Connect test container.
+ */
+public class KafkaConnectTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+    public static final String KAFKA_CONNECT_URL = "kafka.connect.url";
+    public static final String DEFAULT_IMAGE = "confluentinc/cp-kafka-connect:8.2.0";
+    public static final String DISPLAY_NAME = "Kafka Connect";
+    public static final String SIMPLE_NAME = "kafka-connect";
+    public static final int PORT = 8083;
+    private static final String PROPERTY_ENTRY = "kafka.connect";
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_CONNECT_URL);
+    }
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Collections.singletonList(PROPERTY_ENTRY);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return SIMPLE_NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
+        return new GenericContainer<>(imageName)
+            .withNetwork(KafkaServices.network(requestedProperties))
+            .withExposedPorts(PORT)
+            .withEnv("CONNECT_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS)
+            .withEnv("CONNECT_GROUP_ID", "test-resources-connect")
+            .withEnv("CONNECT_CONFIG_STORAGE_TOPIC", "test-resources-connect-config")
+            .withEnv("CONNECT_OFFSET_STORAGE_TOPIC", "test-resources-connect-offsets")
+            .withEnv("CONNECT_STATUS_STORAGE_TOPIC", "test-resources-connect-status")
+            .withEnv("CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_STATUS_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_KEY_CONVERTER", "org.apache.kafka.connect.json.JsonConverter")
+            .withEnv("CONNECT_VALUE_CONVERTER", "org.apache.kafka.connect.json.JsonConverter")
+            .withEnv("CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE", "false")
+            .withEnv("CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE", "false")
+            .withEnv("CONNECT_REST_ADVERTISED_HOST_NAME", "connect")
+            .withEnv("CONNECT_REST_PORT", String.valueOf(PORT))
+            .withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java,/usr/share/confluent-hub-components")
+            .dependsOn(kafka)
+            .waitingFor(Wait.forHttp("/connectors").forPort(PORT));
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
+        return Optional.of(KafkaServices.httpUrl(container, PORT));
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return KAFKA_CONNECT_URL.equals(propertyName);
+    }
+}

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  */
 public class KafkaKsqlDbTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
     public static final String KAFKA_KSQLDB_URL = "kafka.ksqldb.url";
-    public static final String DEFAULT_IMAGE = "confluentinc/ksqldb-server:0.29.0";
+    public static final String DEFAULT_IMAGE = "confluentinc/cp-ksqldb-server:8.2.0";
     public static final String DISPLAY_NAME = "Kafka ksqlDB";
     public static final String SIMPLE_NAME = "kafka-ksqldb";
     public static final int PORT = 8088;

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.kafka;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider which will spawn a ksqlDB test container.
+ */
+public class KafkaKsqlDbTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+    public static final String KAFKA_KSQLDB_URL = "kafka.ksqldb.url";
+    public static final String DEFAULT_IMAGE = "confluentinc/ksqldb-server:0.29.0";
+    public static final String DISPLAY_NAME = "Kafka ksqlDB";
+    public static final String SIMPLE_NAME = "kafka-ksqldb";
+    public static final int PORT = 8088;
+    private static final String PROPERTY_ENTRY = "kafka.ksqldb";
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_KSQLDB_URL);
+    }
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Collections.singletonList(PROPERTY_ENTRY);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return SIMPLE_NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
+        return new GenericContainer<>(imageName)
+            .withNetwork(KafkaServices.network(requestedProperties))
+            .withExposedPorts(PORT)
+            .withEnv("KSQL_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS)
+            .withEnv("KSQL_HOST_NAME", "ksqldb")
+            .withEnv("KSQL_LISTENERS", "http://0.0.0.0:" + PORT)
+            .withEnv("KSQL_KSQL_SERVICE_ID", "test-resources-ksqldb")
+            .dependsOn(kafka)
+            .waitingFor(Wait.forHttp("/info").forPort(PORT));
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
+        return Optional.of(KafkaServices.httpUrl(container, PORT));
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return KAFKA_KSQLDB_URL.equals(propertyName);
+    }
+}

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
@@ -15,22 +15,12 @@
  */
 package io.micronaut.testresources.kafka;
 
-import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.kafka.KafkaContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * A test resource provider which will spawn a ksqlDB test container.
  */
-public class KafkaKsqlDbTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+public class KafkaKsqlDbTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_KSQLDB_URL = "kafka.ksqldb.url";
     public static final String DEFAULT_IMAGE = "confluentinc/cp-ksqldb-server:8.2.0";
     public static final String DISPLAY_NAME = "Kafka ksqlDB";
@@ -38,52 +28,16 @@ public class KafkaKsqlDbTestResourceProvider extends AbstractTestContainersProvi
     public static final int PORT = 8088;
     private static final String PROPERTY_ENTRY = "kafka.ksqldb";
 
-    @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_KSQLDB_URL);
+    public KafkaKsqlDbTestResourceProvider() {
+        super(DISPLAY_NAME, SIMPLE_NAME, DEFAULT_IMAGE, PROPERTY_ENTRY, KAFKA_KSQLDB_URL, PORT, "/info");
     }
 
     @Override
-    public List<String> getRequiredPropertyEntries() {
-        return Collections.singletonList(PROPERTY_ENTRY);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return DISPLAY_NAME;
-    }
-
-    @Override
-    protected String getSimpleName() {
-        return SIMPLE_NAME;
-    }
-
-    @Override
-    protected String getDefaultImageName() {
-        return DEFAULT_IMAGE;
-    }
-
-    @Override
-    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
-        return new GenericContainer<>(imageName)
-            .withNetwork(KafkaServices.network(requestedProperties))
-            .withExposedPorts(PORT)
+    protected void configureService(GenericContainer<?> container) {
+        container
             .withEnv("KSQL_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS)
             .withEnv("KSQL_HOST_NAME", "ksqldb")
             .withEnv("KSQL_LISTENERS", "http://0.0.0.0:" + PORT)
-            .withEnv("KSQL_KSQL_SERVICE_ID", "test-resources-ksqldb")
-            .dependsOn(kafka)
-            .waitingFor(Wait.forHttp("/info").forPort(PORT));
-    }
-
-    @Override
-    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
-        return Optional.of(KafkaServices.httpUrl(container, PORT));
-    }
-
-    @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return KAFKA_KSQLDB_URL.equals(propertyName);
+            .withEnv("KSQL_KSQL_SERVICE_ID", "test-resources-ksqldb");
     }
 }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaKsqlDbTestResourceProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.kafka;
 
+import io.micronaut.testresources.core.DefaultTestResourceImages;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -22,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class KafkaKsqlDbTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_KSQLDB_URL = "kafka.ksqldb.url";
-    public static final String DEFAULT_IMAGE = "confluentinc/cp-ksqldb-server:8.2.0";
+    public static final String DEFAULT_IMAGE = DefaultTestResourceImages.DEFAULT_KAFKA_KSQLDB_IMAGE;
     public static final String DISPLAY_NAME = "Kafka ksqlDB";
     public static final String SIMPLE_NAME = "kafka-ksqldb";
     public static final int PORT = 8088;

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.testresources.kafka;
 
+import io.micronaut.testresources.core.DefaultTestResourceImages;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -22,7 +23,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class KafkaSchemaRegistryTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
-    public static final String DEFAULT_IMAGE = "confluentinc/cp-schema-registry:8.2.0";
+    public static final String DEFAULT_IMAGE = DefaultTestResourceImages.DEFAULT_KAFKA_SCHEMA_REGISTRY_IMAGE;
     public static final String DISPLAY_NAME = "Kafka Schema Registry";
     public static final String SIMPLE_NAME = "kafka-schema-registry";
     public static final int PORT = 8081;

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
@@ -15,22 +15,12 @@
  */
 package io.micronaut.testresources.kafka;
 
-import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.kafka.KafkaContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * A test resource provider which will spawn a Schema Registry test container.
  */
-public class KafkaSchemaRegistryTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+public class KafkaSchemaRegistryTestResourceProvider extends AbstractKafkaServiceTestResourceProvider {
     public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
     public static final String DEFAULT_IMAGE = "confluentinc/cp-schema-registry:8.2.0";
     public static final String DISPLAY_NAME = "Kafka Schema Registry";
@@ -38,51 +28,15 @@ public class KafkaSchemaRegistryTestResourceProvider extends AbstractTestContain
     public static final int PORT = 8081;
     private static final String PROPERTY_ENTRY = "kafka.schema.registry";
 
-    @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_SCHEMA_REGISTRY_URL);
+    public KafkaSchemaRegistryTestResourceProvider() {
+        super(DISPLAY_NAME, SIMPLE_NAME, DEFAULT_IMAGE, PROPERTY_ENTRY, KAFKA_SCHEMA_REGISTRY_URL, PORT, "/subjects");
     }
 
     @Override
-    public List<String> getRequiredPropertyEntries() {
-        return Collections.singletonList(PROPERTY_ENTRY);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return DISPLAY_NAME;
-    }
-
-    @Override
-    protected String getSimpleName() {
-        return SIMPLE_NAME;
-    }
-
-    @Override
-    protected String getDefaultImageName() {
-        return DEFAULT_IMAGE;
-    }
-
-    @Override
-    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
-        return new GenericContainer<>(imageName)
-            .withNetwork(KafkaServices.network(requestedProperties))
-            .withExposedPorts(PORT)
+    protected void configureService(GenericContainer<?> container) {
+        container
             .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
             .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + PORT)
-            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS_WITH_PROTOCOL)
-            .dependsOn(kafka)
-            .waitingFor(Wait.forHttp("/subjects").forPort(PORT));
-    }
-
-    @Override
-    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
-        return Optional.of(KafkaServices.httpUrl(container, PORT));
-    }
-
-    @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return KAFKA_SCHEMA_REGISTRY_URL.equals(propertyName);
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS_WITH_PROTOCOL);
     }
 }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaSchemaRegistryTestResourceProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.kafka;
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A test resource provider which will spawn a Schema Registry test container.
+ */
+public class KafkaSchemaRegistryTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+    public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
+    public static final String DEFAULT_IMAGE = "confluentinc/cp-schema-registry:8.2.0";
+    public static final String DISPLAY_NAME = "Kafka Schema Registry";
+    public static final String SIMPLE_NAME = "kafka-schema-registry";
+    public static final int PORT = 8081;
+    private static final String PROPERTY_ENTRY = "kafka.schema.registry";
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return KafkaServices.resolvablePropertyForUrlRequest(propertyEntries, PROPERTY_ENTRY, KAFKA_SCHEMA_REGISTRY_URL);
+    }
+
+    @Override
+    public List<String> getRequiredPropertyEntries() {
+        return Collections.singletonList(PROPERTY_ENTRY);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return SIMPLE_NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected GenericContainer<?> createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        KafkaContainer kafka = KafkaServices.startKafka(requestedProperties, testResourcesConfig);
+        return new GenericContainer<>(imageName)
+            .withNetwork(KafkaServices.network(requestedProperties))
+            .withExposedPorts(PORT)
+            .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+            .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + PORT)
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", KafkaServices.KAFKA_INTERNAL_BOOTSTRAP_SERVERS_WITH_PROTOCOL)
+            .dependsOn(kafka)
+            .waitingFor(Wait.forHttp("/subjects").forPort(PORT));
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, GenericContainer<?> container) {
+        return Optional.of(KafkaServices.httpUrl(container, PORT));
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return KAFKA_SCHEMA_REGISTRY_URL.equals(propertyName);
+    }
+}

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
@@ -43,7 +43,7 @@ final class KafkaServices {
             .withListener(KAFKA_INTERNAL_BOOTSTRAP_SERVERS);
     }
 
-    static KafkaContainer startKafka(Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+    static synchronized KafkaContainer startKafka(Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         new KafkaTestResourceProvider().resolve(
             KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS,
             requestedProperties,

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
@@ -63,7 +63,7 @@ final class KafkaServices {
 
     static Network network(Map<String, Object> requestedProperties) {
         String scope = Scope.from(requestedProperties).toString();
-        return TestContainers.network(scope.isEmpty() ? "kafka" : "kafka-" + scope);
+        return TestContainers.network(scope.isEmpty() ? KAFKA_NETWORK_ALIAS : KAFKA_NETWORK_ALIAS + "-" + scope);
     }
 
     static String httpUrl(GenericContainer<?> container, int port) {

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaServices.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.kafka;
+
+import io.micronaut.testresources.core.Scope;
+import io.micronaut.testresources.core.TestResourcesResolutionException;
+import io.micronaut.testresources.testcontainers.TestContainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+final class KafkaServices {
+    static final String KAFKA_NETWORK_ALIAS = "kafka";
+    static final int KAFKA_INTERNAL_PORT = 19092;
+    static final String KAFKA_INTERNAL_BOOTSTRAP_SERVERS = KAFKA_NETWORK_ALIAS + ":" + KAFKA_INTERNAL_PORT;
+    static final String KAFKA_INTERNAL_BOOTSTRAP_SERVERS_WITH_PROTOCOL = "PLAINTEXT://" + KAFKA_INTERNAL_BOOTSTRAP_SERVERS;
+
+    private KafkaServices() {
+    }
+
+    static KafkaContainer configureKafka(KafkaContainer container, Map<String, Object> requestedProperties) {
+        return container
+            .withNetwork(network(requestedProperties))
+            .withNetworkAliases(KAFKA_NETWORK_ALIAS)
+            .withListener(KAFKA_INTERNAL_BOOTSTRAP_SERVERS);
+    }
+
+    static KafkaContainer startKafka(Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        new KafkaTestResourceProvider().resolve(
+            KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS,
+            requestedProperties,
+            testResourcesConfig
+        );
+        Scope scope = Scope.from(requestedProperties);
+        List<GenericContainer<?>> containers = TestContainers.findByRequestedProperty(
+            scope,
+            KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS
+        );
+        return containers.stream()
+            .filter(KafkaContainer.class::isInstance)
+            .map(KafkaContainer.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new TestResourcesResolutionException("Kafka container could not be started"));
+    }
+
+    static Network network(Map<String, Object> requestedProperties) {
+        String scope = Scope.from(requestedProperties).toString();
+        return TestContainers.network(scope.isEmpty() ? "kafka" : "kafka-" + scope);
+    }
+
+    static String httpUrl(GenericContainer<?> container, int port) {
+        return "http://" + container.getHost() + ":" + container.getMappedPort(port);
+    }
+
+    static List<String> resolvablePropertyForUrlRequest(Map<String, Collection<String>> propertyEntries,
+                                                        String propertyEntry,
+                                                        String propertyName) {
+        if (propertyEntries.getOrDefault(propertyEntry, Collections.emptySet()).contains("url")) {
+            return Collections.singletonList(propertyName);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -26,20 +26,20 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.math.BigDecimal;
 
 
 /**
@@ -86,7 +86,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
 
     @Override
     protected KafkaContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new KafkaContainer(imageName);
+        return KafkaServices.configureKafka(new KafkaContainer(imageName), requestedProperties);
     }
 
     @Override

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -153,6 +153,8 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
                     } else {
                         throw e;
                     }
+                } catch (TimeoutException e) {
+                    topicsToReverify.add(topic.name());
                 }
             }
             verifyExistingTopicPartitions(adminClient, topicsToReverify, configuration);

--- a/test-resources-kafka/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-kafka/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,1 +1,4 @@
 io.micronaut.testresources.kafka.KafkaTestResourceProvider
+io.micronaut.testresources.kafka.KafkaSchemaRegistryTestResourceProvider
+io.micronaut.testresources.kafka.KafkaConnectTestResourceProvider
+io.micronaut.testresources.kafka.KafkaKsqlDbTestResourceProvider

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.testresources.kafka
 
+import io.micronaut.testresources.core.DefaultTestResourceImages
 import io.micronaut.testresources.core.Scope
 import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
 import io.micronaut.testresources.testcontainers.TestContainers
@@ -101,9 +102,9 @@ class KafkaServicesTest extends AbstractTestContainersSpec {
 
     def "declares default images"() {
         expect:
-        KafkaSchemaRegistryTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-schema-registry:8.2.0"
-        KafkaConnectTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-kafka-connect:8.2.0"
-        KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-ksqldb-server:8.2.0"
+        KafkaSchemaRegistryTestResourceProvider.DEFAULT_IMAGE == DefaultTestResourceImages.DEFAULT_KAFKA_SCHEMA_REGISTRY_IMAGE
+        KafkaConnectTestResourceProvider.DEFAULT_IMAGE == DefaultTestResourceImages.DEFAULT_KAFKA_CONNECT_IMAGE
+        KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE == DefaultTestResourceImages.DEFAULT_KAFKA_KSQLDB_IMAGE
     }
 
     def "only publishes service URL properties when requested"() {

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
@@ -1,0 +1,145 @@
+package io.micronaut.testresources.kafka
+
+import io.micronaut.testresources.core.Scope
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+import io.micronaut.testresources.testcontainers.TestContainers
+import spock.lang.Shared
+
+class KafkaServicesTest extends AbstractTestContainersSpec {
+
+    @Shared
+    Set<String> scopes = []
+
+    void cleanup() {
+        scopes.each { TestContainers.closeScope(it) }
+        scopes.clear()
+    }
+
+    def "resolves schema registry URL"() {
+        given:
+        def scope = "kafka-schema-registry"
+
+        when:
+        def url = resolve(new KafkaSchemaRegistryTestResourceProvider(), KafkaSchemaRegistryTestResourceProvider.KAFKA_SCHEMA_REGISTRY_URL, scope)
+
+        then:
+        url.toURI().scheme == "http"
+        url.toURI().port == serviceContainer(scope, KafkaSchemaRegistryTestResourceProvider.DEFAULT_IMAGE).getMappedPort(KafkaSchemaRegistryTestResourceProvider.PORT)
+        httpGet(url + "/subjects") == "[]"
+        kafkaContainers(scope).size() == 1
+    }
+
+    def "resolves kafka connect URL"() {
+        given:
+        def scope = "kafka-connect"
+
+        when:
+        def url = resolve(new KafkaConnectTestResourceProvider(), KafkaConnectTestResourceProvider.KAFKA_CONNECT_URL, scope)
+
+        then:
+        url.toURI().scheme == "http"
+        url.toURI().port == serviceContainer(scope, KafkaConnectTestResourceProvider.DEFAULT_IMAGE).getMappedPort(KafkaConnectTestResourceProvider.PORT)
+        httpGet(url + "/connectors") == "[]"
+        kafkaContainers(scope).size() == 1
+    }
+
+    def "resolves ksqldb URL"() {
+        given:
+        def scope = "kafka-ksqldb"
+
+        when:
+        def url = resolve(new KafkaKsqlDbTestResourceProvider(), KafkaKsqlDbTestResourceProvider.KAFKA_KSQLDB_URL, scope)
+
+        then:
+        url.toURI().scheme == "http"
+        url.toURI().port == serviceContainer(scope, KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE).getMappedPort(KafkaKsqlDbTestResourceProvider.PORT)
+        httpGet(url + "/info").contains("KsqlServerInfo")
+        kafkaContainers(scope).size() == 1
+    }
+
+    def "reuses kafka container for broker and service URLs"() {
+        given:
+        def scope = "kafka-reuse"
+        def requestedProperties = scopedProperties(scope)
+
+        when:
+        def bootstrapServers = new KafkaTestResourceProvider()
+                .resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [:])
+                .get()
+        def schemaRegistryUrl = new KafkaSchemaRegistryTestResourceProvider()
+                .resolve(KafkaSchemaRegistryTestResourceProvider.KAFKA_SCHEMA_REGISTRY_URL, requestedProperties, [:])
+                .get()
+        def connectUrl = new KafkaConnectTestResourceProvider()
+                .resolve(KafkaConnectTestResourceProvider.KAFKA_CONNECT_URL, requestedProperties, [:])
+                .get()
+
+        then:
+        bootstrapServers
+        schemaRegistryUrl
+        connectUrl
+        kafkaContainers(scope).size() == 1
+        TestContainers.listByScope(scope).get(Scope.of(scope)).size() == 3
+    }
+
+    def "supports image overrides for new providers"() {
+        given:
+        def scope = "kafka-schema-registry-custom-image"
+
+        when:
+        def url = new KafkaSchemaRegistryTestResourceProvider()
+                .resolve(
+                        KafkaSchemaRegistryTestResourceProvider.KAFKA_SCHEMA_REGISTRY_URL,
+                        scopedProperties(scope),
+                        ["containers.kafka-schema-registry.image-name": "confluentinc/cp-schema-registry"]
+                )
+                .get()
+
+        then:
+        url
+        serviceContainer(scope, "confluentinc/cp-schema-registry:latest").dockerImageName == "confluentinc/cp-schema-registry:latest"
+    }
+
+    def "declares default images"() {
+        expect:
+        KafkaSchemaRegistryTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-schema-registry:8.2.0"
+        KafkaConnectTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-kafka-connect:8.2.0"
+        KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE == "confluentinc/ksqldb-server:0.29.0"
+    }
+
+    def "only publishes service URL properties when requested"() {
+        expect:
+        new KafkaSchemaRegistryTestResourceProvider().getResolvableProperties([:], [:]).empty
+        new KafkaConnectTestResourceProvider().getResolvableProperties([:], [:]).empty
+        new KafkaKsqlDbTestResourceProvider().getResolvableProperties([:], [:]).empty
+
+        new KafkaSchemaRegistryTestResourceProvider().getResolvableProperties(["kafka.schema.registry": ["url"]], [:]) ==
+                [KafkaSchemaRegistryTestResourceProvider.KAFKA_SCHEMA_REGISTRY_URL]
+        new KafkaConnectTestResourceProvider().getResolvableProperties(["kafka.connect": ["url"]], [:]) ==
+                [KafkaConnectTestResourceProvider.KAFKA_CONNECT_URL]
+        new KafkaKsqlDbTestResourceProvider().getResolvableProperties(["kafka.ksqldb": ["url"]], [:]) ==
+                [KafkaKsqlDbTestResourceProvider.KAFKA_KSQLDB_URL]
+    }
+
+    private String resolve(provider, String property, String scope) {
+        provider.resolve(property, scopedProperties(scope), [:]).get()
+    }
+
+    private Map<String, Object> scopedProperties(String scope) {
+        scopes << scope
+        [(Scope.PROPERTY_KEY): scope]
+    }
+
+    private static List kafkaContainers(String scope) {
+        TestContainers.findByRequestedProperty(Scope.of(scope), KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS)
+    }
+
+    private static serviceContainer(String scope, String imageName) {
+        TestContainers.listByScope(scope)
+                .get(Scope.of(scope))
+                .find { it.dockerImageName == imageName }
+    }
+
+    private static String httpGet(String url) {
+        url.toURL().text
+    }
+}

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaServicesTest.groovy
@@ -103,7 +103,7 @@ class KafkaServicesTest extends AbstractTestContainersSpec {
         expect:
         KafkaSchemaRegistryTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-schema-registry:8.2.0"
         KafkaConnectTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-kafka-connect:8.2.0"
-        KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE == "confluentinc/ksqldb-server:0.29.0"
+        KafkaKsqlDbTestResourceProvider.DEFAULT_IMAGE == "confluentinc/cp-ksqldb-server:8.2.0"
     }
 
     def "only publishes service URL properties when requested"() {

--- a/test-resources-kafka/src/test/java/io/micronaut/testresources/kafka/SchemaRegistryClientConfiguration.java
+++ b/test-resources-kafka/src/test/java/io/micronaut/testresources/kafka/SchemaRegistryClientConfiguration.java
@@ -1,0 +1,17 @@
+package io.micronaut.testresources.kafka;
+
+// tag::clazz[]
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "kafka.schema.registry.url")
+class SchemaRegistryClientConfiguration {
+
+    SchemaRegistryClientConfiguration(
+            @Value("${kafka.schema.registry.url}") String schemaRegistryUrl) {
+        // Configure a Schema Registry client for tests.
+    }
+}
+// end::clazz[]


### PR DESCRIPTION
## Summary
- Add Kafka Test Resources providers for Confluent Schema Registry, Kafka Connect, and ksqlDB.
- Share the Kafka broker through an internal Docker-network listener while preserving `kafka.bootstrap.servers` and Kafka topic provisioning.
- Document the new URL properties, default images, image override keys, and local test-only REST API behavior.

## Verification
- `git fetch origin 4.0.x && git rebase origin/4.0.x`
- `git diff --check origin/4.0.x...HEAD`
- `./gradlew :micronaut-test-resources-kafka:check publishGuide`

## Project Routing
Selected Micronaut organization projects from QA intake: `5.0.0-M3` and `5.0.0 Release`.

Ambiguity note: no Test Resources-specific `4.0.0` organization project was visible during intake, so these are the earliest visible Micronaut Platform release boards selected upstream.

## PR Assets
No screenshots or binary artifacts are required; the change is provider code, tests, and AsciiDoc guide text.

Fixes #1078

---
###### ✨ This message was AI-generated using gpt-5
