### PR TITLE
Fix Sonar quality gate findings

### DIFF
--- a/test-resources-hivemq/src/main/java/io/micronaut/testresources/hivemq/HiveMQTestResourceProvider.java
+++ b/test-resources-hivemq/src/main/java/io/micronaut/testresources/hivemq/HiveMQTestResourceProvider.java
@@ -64,7 +64,9 @@ public class HiveMQTestResourceProvider extends AbstractTestContainersProvider<H
     }
 
     @Override
+    @SuppressWarnings("java:S2095")
     protected HiveMQContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        // The container lifecycle is owned by AbstractTestContainersProvider via TestContainers.getOrCreate.
         return new HiveMQContainer(imageName)
             .withStartupTimeout(Duration.ofMinutes(2));
     }

--- a/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
+++ b/test-resources-mongodb/src/main/java/io/micronaut/testresources/mongodb/MongoDBTestResourceProvider.java
@@ -71,11 +71,13 @@ public class MongoDBTestResourceProvider extends AbstractTestContainersProvider<
     }
 
     @Override
+    @SuppressWarnings("java:S2095")
     protected MongoDBContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         Object configuredDbName = testResourcesConfig.get(DB_NAME);
         if (configuredDbName != null) {
             this.dbName = configuredDbName.toString();
         }
+        // The container lifecycle is owned by AbstractTestContainersProvider via TestContainers.getOrCreate.
         return new MongoDBContainer(imageName).withReplicaSet();
     }
 

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/DockerSupport.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/DockerSupport.java
@@ -55,6 +55,14 @@ public final class DockerSupport {
             available = false;
         } finally {
             executor.shutdown();
+            try {
+                if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
         if (!available) {
             LOGGER.error("Docker support doesn't seem to be available, test resources will not work correctly. Please check your Docker install.");


### PR DESCRIPTION
## Summary
- fixes Sonar `java:S2095` findings for HiveMQ and MongoDB container factory ownership, preserving the Testcontainers lifecycle owner
- hardens Docker availability executor cleanup after timeout/interruption
- removes direct workflow edits because those files are managed by the Micronaut project template

## Verification
- `git rebase origin/4.0.x`
- `git diff --check origin/4.0.x...HEAD && git diff --check`
- `./gradlew :micronaut-test-resources-hivemq:compileJava :micronaut-test-resources-mongodb:compileJava :micronaut-test-resources-testcontainers:compileJava :micronaut-test-resources-hivemq:checkstyleMain :micronaut-test-resources-mongodb:checkstyleMain :micronaut-test-resources-testcontainers:checkstyleMain :micronaut-test-resources-hivemq:compileTestGroovy :micronaut-test-resources-mongodb:compileTestGroovy :micronaut-test-resources-testcontainers:compileTestGroovy`

## Security And Sonar Notes
- Security review found no changes-requesting vulnerability or insecure default introduced by the Java lifecycle changes.
- The workflow hotspots are no longer changed directly in this repository because `.github/workflows/release.yml` and `.github/workflows/update-gradle-wrapper.yml` are template-managed. They should be handled through the Micronaut project-template/source-of-truth path or reviewed in Sonar by maintainers with the appropriate permissions.
- The residual `verification-metadata.xml` hotspot is intentionally left as a Sonar UI/security-governance review item for this narrow PR. Maintainers with Sonar permissions may mark that hotspot reviewed; a full Gradle dependency-verification rollout should be tracked separately if desired.

## Issue And Release Routing
- Paperclip issue: DEV-703.
- GitHub closing keyword: not applicable; DEV-703 is a manual Paperclip/SonarCloud issue and no linked GitHub issue or reporter exists.
- Recommended Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`.
- Ambiguity note: no public open organization project specifically for Test Resources `4.0.0` was observed during QA intake; keep the `5.0.0-M3` plus `5.0.0 Release` mapping unless release owners direct a different board.
- PR-visible assets: not required; this changes Java lifecycle cleanup, not rendered output or generated review artifacts.

---
###### ✨ This message was AI-generated using gpt-5
