### PR TITLE
Add Floci test resources support

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
@@ -1,0 +1,7 @@
+import io.micronaut.internal.ParallelGateService
+
+plugins {
+    id "io.micronaut.build.internal.testcontainers-module"
+}
+
+ParallelGateService.requiresResource(project, "floci")

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
@@ -6,7 +6,7 @@ plugins {
 
 micronautBuild {
     binaryCompatibility {
-        enabledAfter("4.0.1")
+        enabledAfter("4.1.0")
     }
 }
 

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.floci-module.gradle
@@ -4,4 +4,10 @@ plugins {
     id "io.micronaut.build.internal.testcontainers-module"
 }
 
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("4.0.1")
+    }
+}
+
 ParallelGateService.requiresResource(project, "floci")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ jansi = "2.4.3"
 
 # Managed versions appear in the BOM
 managed-opensearch-testcontainers = "4.1.0"
-managed-testcontainers-floci = "2.7.0"
+managed-testcontainers-floci = "2.8.0"
 managed-testcontainers = "2.0.4"
 managed-testcontainers-pulsar = "1.21.3"
 managed-testcontainers-redis = "1.6.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ jansi = "2.4.3"
 
 # Managed versions appear in the BOM
 managed-opensearch-testcontainers = "4.1.0"
+managed-testcontainers-floci = "2.7.0"
 managed-testcontainers = "2.0.4"
 managed-testcontainers-pulsar = "1.21.3"
 managed-testcontainers-redis = "1.6.4"
@@ -72,6 +73,7 @@ managed-testcontainers-elasticsearch = { module = "org.testcontainers:testcontai
 managed-testcontainers-jdbc = { module = "org.testcontainers:testcontainers-jdbc", version.ref = "managed-testcontainers" }
 managed-testcontainers-hivemq = { module = "org.testcontainers:testcontainers-hivemq", version.ref = "managed-testcontainers" }
 managed-testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka", version.ref = "managed-testcontainers" }
+managed-testcontainers-floci = { module = "io.floci:testcontainers-floci", version.ref = "managed-testcontainers-floci" }
 managed-testcontainers-localstack = { module = "org.testcontainers:testcontainers-localstack", version.ref = "managed-testcontainers" }
 managed-testcontainers-mariadb = { module = "org.testcontainers:testcontainers-mariadb", version.ref = "managed-testcontainers" }
 managed-testcontainers-minio = { module = "org.testcontainers:testcontainers-minio", version.ref = "managed-testcontainers" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -63,6 +63,14 @@ def localstackModules = [
         'sns'
 ]
 
+def flociModules = [
+        'core',
+        's3',
+        'dynamodb',
+        'sqs',
+        'sns'
+]
+
 include 'test-resources-bom'
 include 'test-resources-azure'
 include 'test-resources-build-tools'
@@ -115,6 +123,11 @@ localstackModules.each {
     String projectName = "test-resources-localstack-$it"
     include projectName
     project(":test-resources-localstack-$it").projectDir = file("test-resources-localstack/$projectName")
+}
+flociModules.each {
+    String projectName = "test-resources-floci-$it"
+    include projectName
+    project(":test-resources-floci-$it").projectDir = file("test-resources-floci/$projectName")
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -72,6 +72,7 @@ def flociModules = [
 ]
 
 include 'test-resources-bom'
+include 'test-resources-aws-base'
 include 'test-resources-azure'
 include 'test-resources-build-tools'
 include 'test-resources-couchbase'

--- a/src/main/docs/guide/modules-floci.adoc
+++ b/src/main/docs/guide/modules-floci.adoc
@@ -1,0 +1,22 @@
+Micronaut Test Resources supports a subset of https://github.com/floci-io/floci[Floci] via its Testcontainers module.
+
+Floci is an alternative AWS emulator dependency family. It does not replace LocalStack automatically, and the LocalStack modules keep their existing behavior and configuration. Choose the Floci module for the AWS service you want to emulate instead of the corresponding LocalStack module.
+
+The default image can be overwritten by setting the `test-resources.containers.floci.image-name` property. The built-in default is pinned to `floci/floci:1.5.17`.
+
+The following services are supported:
+
+- S3, by providing the `aws.services.s3.endpoint-override` property
+- DynamoDB, by providing the `aws.services.dynamodb.endpoint-override` property
+- SQS, by providing the `aws.services.sqs.endpoint-override` property
+- SNS, by providing the `aws.services.sns.endpoint-override` property
+
+In addition, the following properties will be resolved by test resources:
+
+- `aws.access-key-id`
+- `aws.secret-key`
+- `aws.region`
+
+Avoid placing both a LocalStack and a Floci module for the same AWS service on the same test classpath unless you explicitly disable one resolver, for example by setting `test-resources.containers.localstack.enabled` or `test-resources.containers.floci.enabled` to `false`.
+
+Floci's Testcontainers integration can mount the Docker socket for Docker-backed AWS services. Treat the Floci container as trusted infrastructure with the same Docker access as other containers that use `/var/run/docker.sock`.

--- a/src/main/docs/guide/modules-floci.adoc
+++ b/src/main/docs/guide/modules-floci.adoc
@@ -1,15 +1,21 @@
-Micronaut Test Resources supports a subset of https://github.com/floci-io/floci[Floci] via its Testcontainers module.
+Micronaut Test Resources supports https://github.com/floci-io/floci[Floci] via its Testcontainers module for the Floci services that are also configured by Micronaut AWS SDK v2 client factories.
 
-Floci is an alternative AWS emulator dependency family. It does not replace LocalStack automatically, and the LocalStack modules keep their existing behavior and configuration. Choose the Floci module for the AWS service you want to emulate instead of the corresponding LocalStack module.
+Floci is an alternative AWS emulator dependency family. It does not replace LocalStack automatically, and the LocalStack modules keep their existing behavior and configuration. Choose a Floci module for the AWS service you want to emulate instead of the corresponding LocalStack module, or use the Floci core module when there is no service-specific Floci module.
 
 The default image (`{default-image-floci}`) can be overwritten by setting the `test-resources.containers.floci.image-name` property.
 
-The following services are supported:
+The following service endpoint overrides are supported:
 
+- API Gateway Management API, by providing the `aws.services.execute-api.endpoint-override` property
+- CloudWatch Logs, by providing the `aws.services.logs.endpoint-override` property
 - S3, by providing the `aws.services.s3.endpoint-override` property
 - DynamoDB, by providing the `aws.services.dynamodb.endpoint-override` property
+- Lambda, by providing the `aws.services.lambda.endpoint-override` property
+- Secrets Manager, by providing the `aws.services.secretsmanager.endpoint-override` property
+- SES, by providing the `aws.services.ses.endpoint-override` property
 - SQS, by providing the `aws.services.sqs.endpoint-override` property
 - SNS, by providing the `aws.services.sns.endpoint-override` property
+- SSM, by providing the `aws.services.ssm.endpoint-override` property
 
 In addition, the following properties will be resolved by test resources:
 
@@ -19,4 +25,4 @@ In addition, the following properties will be resolved by test resources:
 
 Avoid placing both a LocalStack and a Floci module for the same AWS service on the same test classpath unless you explicitly disable one resolver, for example by setting `test-resources.containers.localstack.enabled` or `test-resources.containers.floci.enabled` to `false`.
 
-The upstream Floci Testcontainers integration currently bind-mounts the Docker socket into the container unconditionally. Micronaut Test Resources disables unsupported Floci services by default and only enables the Floci services represented by the modules on the test classpath, but you should still treat the Floci container as trusted infrastructure with Docker access through `/var/run/docker.sock`.
+The upstream Floci Testcontainers integration currently bind-mounts the Docker socket into the container unconditionally. Micronaut Test Resources disables unsupported Floci services by default and enables the Floci services that map to Micronaut AWS SDK v2 client configuration, but you should still treat the Floci container as trusted infrastructure with Docker access through `/var/run/docker.sock`.

--- a/src/main/docs/guide/modules-floci.adoc
+++ b/src/main/docs/guide/modules-floci.adoc
@@ -19,4 +19,4 @@ In addition, the following properties will be resolved by test resources:
 
 Avoid placing both a LocalStack and a Floci module for the same AWS service on the same test classpath unless you explicitly disable one resolver, for example by setting `test-resources.containers.localstack.enabled` or `test-resources.containers.floci.enabled` to `false`.
 
-Floci's Testcontainers integration can mount the Docker socket for Docker-backed AWS services. Treat the Floci container as trusted infrastructure with the same Docker access as other containers that use `/var/run/docker.sock`.
+The upstream Floci Testcontainers integration currently bind-mounts the Docker socket into the container unconditionally. Micronaut Test Resources disables unsupported Floci services by default and only enables the Floci services represented by the modules on the test classpath, but you should still treat the Floci container as trusted infrastructure with Docker access through `/var/run/docker.sock`.

--- a/src/main/docs/guide/modules-floci.adoc
+++ b/src/main/docs/guide/modules-floci.adoc
@@ -2,7 +2,7 @@ Micronaut Test Resources supports a subset of https://github.com/floci-io/floci[
 
 Floci is an alternative AWS emulator dependency family. It does not replace LocalStack automatically, and the LocalStack modules keep their existing behavior and configuration. Choose the Floci module for the AWS service you want to emulate instead of the corresponding LocalStack module.
 
-The default image can be overwritten by setting the `test-resources.containers.floci.image-name` property. The built-in default is pinned to `floci/floci:1.5.17`.
+The default image (`{default-image-floci}`) can be overwritten by setting the `test-resources.containers.floci.image-name` property.
 
 The following services are supported:
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,8 @@ modules:
     title: Pulsar
   modules-localstack:
     title: Localstack
+  modules-floci:
+    title: Floci
   modules-minio:
     title: MinIO
   modules-seaweedfs:

--- a/test-resources-aws-base/build.gradle
+++ b/test-resources-aws-base/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'io.micronaut.build.internal.testcontainers-module'
+}
+
+description = """
+Provides shared support for AWS emulator test resources.
+"""
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("4.1.0")
+    }
+}

--- a/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsEndpointService.java
+++ b/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsEndpointService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Base implementation for AWS emulator services which expose one endpoint override.
+ * @param <C> the container type
+ */
+@Internal
+public abstract class AbstractAwsEndpointService<C> implements AwsEmulatorService<C> {
+
+    private final String serviceKind;
+    private final String endpointProperty;
+    private final Function<C, String> endpointResolver;
+
+    protected AbstractAwsEndpointService(String serviceKind, String endpointProperty, Function<C, String> endpointResolver) {
+        this.serviceKind = serviceKind;
+        this.endpointProperty = endpointProperty;
+        this.endpointResolver = endpointResolver;
+    }
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, C container) {
+        if (endpointProperty.equals(propertyName)) {
+            return Optional.of(endpointResolver.apply(container));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return serviceKind;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(endpointProperty);
+    }
+}

--- a/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsTestResourceProvider.java
+++ b/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsTestResourceProvider.java
@@ -55,7 +55,14 @@ public abstract class AbstractAwsTestResourceProvider<C extends GenericContainer
     private final Map<String, S> propertyToService;
 
     protected AbstractAwsTestResourceProvider(Class<S> serviceType) {
-        services = StreamSupport.stream(ServiceLoader.load(serviceType).spliterator(), false)
+        this(serviceType, Collections.emptyList());
+    }
+
+    protected AbstractAwsTestResourceProvider(Class<S> serviceType, Collection<S> additionalServices) {
+        services = Stream.concat(
+                StreamSupport.stream(ServiceLoader.load(serviceType).spliterator(), false),
+                additionalServices.stream()
+            )
             .toList();
         Map<String, S> propertyToService = new HashMap<>();
         for (S service : services) {

--- a/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsTestResourceProvider.java
+++ b/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AbstractAwsTestResourceProvider.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Base provider for AWS emulator test resources.
+ * @param <C> the container type
+ * @param <S> the service type
+ */
+@Internal
+public abstract class AbstractAwsTestResourceProvider<C extends GenericContainer<? extends C>, S extends AwsEmulatorService<C>>
+    extends AbstractTestContainersProvider<C> {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";
+    private static final String AWS_SECRET_KEY = "aws.secret-key";
+    private static final String AWS_REGION = "aws.region";
+    private static final List<String> COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+        AWS_ACCESS_KEY_ID,
+        AWS_SECRET_KEY,
+        AWS_REGION
+    ));
+
+    private final List<S> services;
+    private final Set<String> allSupportedKeys;
+    private final Map<String, S> propertyToService;
+
+    protected AbstractAwsTestResourceProvider(Class<S> serviceType) {
+        services = StreamSupport.stream(ServiceLoader.load(serviceType).spliterator(), false)
+            .toList();
+        Map<String, S> propertyToService = new HashMap<>();
+        for (S service : services) {
+            for (String supportedProperty : service.getResolvableProperties()) {
+                propertyToService.put(supportedProperty, service);
+            }
+        }
+        this.propertyToService = Collections.unmodifiableMap(propertyToService);
+        allSupportedKeys = Stream.concat(
+            COMMON_PROPERTIES.stream(),
+            services.stream().map(AwsEmulatorService::getResolvableProperties).flatMap(Collection::stream)
+        ).collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return Stream.concat(
+                services.stream().flatMap(service -> service.getResolvableProperties().stream()),
+                COMMON_PROPERTIES.stream()
+            ).distinct()
+            .toList();
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return allSupportedKeys.contains(propertyName);
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, C container) {
+        switch (propertyName) {
+            case AWS_ACCESS_KEY_ID:
+                return Optional.of(resolveAccessKey(container));
+            case AWS_SECRET_KEY:
+                return Optional.of(resolveSecretKey(container));
+            case AWS_REGION:
+                return Optional.of(resolveRegion(container));
+            default:
+                S service = propertyToService.get(propertyName);
+                if (service != null) {
+                    return service.resolveProperty(propertyName, container);
+                }
+        }
+        return Optional.empty();
+    }
+
+    protected final List<S> getServices() {
+        return services;
+    }
+
+    protected final Set<String> getServiceKinds() {
+        return services.stream()
+            .map(AwsEmulatorService::getServiceKind)
+            .collect(Collectors.toSet());
+    }
+
+    protected abstract String resolveAccessKey(C container);
+
+    protected abstract String resolveSecretKey(C container);
+
+    protected abstract String resolveRegion(C container);
+}

--- a/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AwsEmulatorService.java
+++ b/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/AwsEmulatorService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.aws;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for AWS emulator service loading.
+ * @param <C> the container type
+ */
+@Internal
+public interface AwsEmulatorService<C> {
+    /**
+     * Returns the service kind.
+     * @return the service kind.
+     */
+    String getServiceKind();
+
+    /**
+     * Returns the list of properties that this service can configure.
+     * @return the list of supported properties
+     */
+    List<String> getResolvableProperties();
+
+    /**
+     * Resolves a property.
+     * @param propertyName the property to resolve
+     * @param container the AWS emulator container
+     * @return the resolved property, if available
+     */
+    Optional<String> resolveProperty(String propertyName, C container);
+}

--- a/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/package-info.java
+++ b/test-resources-aws-base/src/main/java/io/micronaut/testresources/aws/package-info.java
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.testresources.floci;
-
-import io.floci.testcontainers.FlociContainer;
-import io.micronaut.testresources.aws.AbstractAwsEndpointService;
-import io.micronaut.core.annotation.Internal;
-
 /**
- * Base implementation for Floci services which expose one endpoint override.
+ * Shared AWS emulator test resource support.
  */
-@Internal
-public abstract class AbstractFlociService extends AbstractAwsEndpointService<FlociContainer> implements FlociService {
+@NullMarked
+package io.micronaut.testresources.aws;
 
-    protected AbstractFlociService(String serviceKind, String endpointProperty) {
-        super(serviceKind, endpointProperty, FlociContainer::getEndpoint);
-    }
-}
+import org.jspecify.annotations.NullMarked;

--- a/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
+++ b/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
@@ -23,7 +23,7 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:9.2.1 AS elasticsearch
 
 # provider: floci
 # property: test-resources.containers.floci.image-name
-FROM floci/floci:1.5.17 AS floci
+FROM floci/floci:1.5.19 AS floci
 
 # provider: hazelcast
 # property: test-resources.containers.hazelcast.image-name

--- a/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
+++ b/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
@@ -21,6 +21,10 @@ FROM couchbase/server:8.0.1 AS couchbase
 # property: test-resources.containers.elasticsearch.image-name
 FROM docker.elastic.co/elasticsearch/elasticsearch:9.2.1 AS elasticsearch
 
+# provider: floci
+# property: test-resources.containers.floci.image-name
+FROM floci/floci:1.5.17 AS floci
+
 # provider: hazelcast
 # property: test-resources.containers.hazelcast.image-name
 FROM hazelcast/hazelcast:5.6.0-slim AS hazelcast

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/DefaultTestResourceImagesTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/DefaultTestResourceImagesTest.groovy
@@ -28,6 +28,7 @@ class DefaultTestResourceImagesTest extends Specification {
         'consul',
         'couchbase',
         'elasticsearch',
+        'floci',
         'hazelcast',
         'hivemq',
         'infinispan',
@@ -66,6 +67,7 @@ class DefaultTestResourceImagesTest extends Specification {
         DefaultTestResourceImages.DEFAULT_CONSUL_IMAGE == DefaultTestResourceImages.image('consul')
         DefaultTestResourceImages.DEFAULT_COUCHBASE_IMAGE == DefaultTestResourceImages.image('couchbase')
         DefaultTestResourceImages.DEFAULT_ELASTICSEARCH_IMAGE == DefaultTestResourceImages.image('elasticsearch')
+        DefaultTestResourceImages.DEFAULT_FLOCI_IMAGE == DefaultTestResourceImages.image('floci')
         DefaultTestResourceImages.DEFAULT_HAZELCAST_IMAGE == DefaultTestResourceImages.image('hazelcast')
         DefaultTestResourceImages.DEFAULT_HIVEMQ_IMAGE == DefaultTestResourceImages.image('hivemq')
         DefaultTestResourceImages.DEFAULT_INFINISPAN_IMAGE == DefaultTestResourceImages.image('infinispan')
@@ -131,6 +133,7 @@ class DefaultTestResourceImagesTest extends Specification {
             'modules-couchbase.adoc': ['couchbase'],
             'modules-databases.adoc': ['mariadb', 'mysql_community', 'oracle_xe', 'oracle_free', 'postgres', 'mssql'],
             'modules-elasticsearch.adoc': ['elasticsearch'],
+            'modules-floci.adoc': ['floci'],
             'modules-hashicorp-consul.adoc': ['consul'],
             'modules-hashicorp-vault.adoc': ['vault'],
             'modules-hazelcast.adoc': ['hazelcast'],

--- a/test-resources-floci/test-resources-floci-core/build.gradle
+++ b/test-resources-floci/test-resources-floci-core/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'io.micronaut.build.internal.floci-module'
+    id 'io.micronaut.build.internal.test-fixtures'
+}
+
+description = """
+Provides core support for launching Floci test containers.
+"""
+
+dependencies {
+    api(libs.managed.testcontainers.floci)
+    testFixturesApi(platform(mn.micronaut.core.bom))
+    testFixturesImplementation(mn.groovy)
+    testFixturesImplementation(libs.spock)
+    testFixturesApi(testFixtures(project(":micronaut-test-resources-testcontainers"))) {
+        because "exposes AbstractTestContainersSpec"
+    }
+}

--- a/test-resources-floci/test-resources-floci-core/build.gradle
+++ b/test-resources-floci/test-resources-floci-core/build.gradle
@@ -8,12 +8,12 @@ Provides core support for launching Floci test containers.
 """
 
 dependencies {
-    api(project(":micronaut-test-resources-aws-base"))
+    api(projects.micronautTestResourcesAwsBase)
     api(libs.managed.testcontainers.floci)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)
     testFixturesImplementation(libs.spock)
-    testFixturesApi(testFixtures(project(":micronaut-test-resources-testcontainers"))) {
+    testFixturesApi(testFixtures(projects.micronautTestResourcesTestcontainers)) {
         because "exposes AbstractTestContainersSpec"
     }
 }

--- a/test-resources-floci/test-resources-floci-core/build.gradle
+++ b/test-resources-floci/test-resources-floci-core/build.gradle
@@ -8,6 +8,7 @@ Provides core support for launching Floci test containers.
 """
 
 dependencies {
+    api(project(":micronaut-test-resources-aws-base"))
     api(libs.managed.testcontainers.floci)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/AbstractFlociService.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/AbstractFlociService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.core.annotation.Internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Base implementation for Floci services which expose one endpoint override.
+ */
+@Internal
+public abstract class AbstractFlociService implements FlociService {
+
+    private final String serviceKind;
+    private final String endpointProperty;
+
+    protected AbstractFlociService(String serviceKind, String endpointProperty) {
+        this.serviceKind = serviceKind;
+        this.endpointProperty = endpointProperty;
+    }
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        if (endpointProperty.equals(propertyName)) {
+            return Optional.of(container.getEndpoint());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return serviceKind;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(endpointProperty);
+    }
+}

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociEndpointService.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociEndpointService.java
@@ -15,17 +15,15 @@
  */
 package io.micronaut.testresources.floci;
 
-import io.floci.testcontainers.FlociContainer;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.testresources.aws.AbstractAwsEndpointService;
 
 /**
- * Base implementation for Floci services which expose one endpoint override.
+ * Floci endpoint resolver for Micronaut AWS SDK v2 service clients.
  */
 @Internal
-public abstract class AbstractFlociService extends AbstractAwsEndpointService<FlociContainer> implements FlociService {
+final class FlociEndpointService extends AbstractFlociService {
 
-    protected AbstractFlociService(String serviceKind, String endpointProperty) {
-        super(serviceKind, endpointProperty, FlociContainer::getEndpoint);
+    FlociEndpointService(String serviceKind) {
+        super(serviceKind, "aws.services." + serviceKind + ".endpoint-override");
     }
 }

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociService.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociService.java
@@ -16,32 +16,10 @@
 package io.micronaut.testresources.floci;
 
 import io.floci.testcontainers.FlociContainer;
-
-import java.util.List;
-import java.util.Optional;
+import io.micronaut.testresources.aws.AwsEmulatorService;
 
 /**
  * Interface for Floci service loading.
  */
-public interface FlociService {
-    /**
-     * Returns the service kind.
-     * @return the service kind.
-     */
-    String getServiceKind();
-
-    /**
-     * Returns the list of properties that this service
-     * can configure.
-     * @return the list of supported properties
-     */
-    List<String> getResolvableProperties();
-
-    /**
-     * Resolves a property.
-     * @param propertyName the property to resolve
-     * @param container the Floci container
-     * @return the resolved property, if available
-     */
-    Optional<String> resolveProperty(String propertyName, FlociContainer container);
+public interface FlociService extends AwsEmulatorService<FlociContainer> {
 }

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociService.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci;
+
+import io.floci.testcontainers.FlociContainer;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for Floci service loading.
+ */
+public interface FlociService {
+    /**
+     * Returns the service kind.
+     * @return the service kind.
+     */
+    String getServiceKind();
+
+    /**
+     * Returns the list of properties that this service
+     * can configure.
+     * @return the list of supported properties
+     */
+    List<String> getResolvableProperties();
+
+    /**
+     * Resolves a property.
+     * @param propertyName the property to resolve
+     * @param container the Floci container
+     * @return the resolved property, if available
+     */
+    Optional<String> resolveProperty(String propertyName, FlociContainer container);
+}

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -16,27 +16,17 @@
 package io.micronaut.testresources.floci;
 
 import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.aws.AbstractAwsTestResourceProvider;
 import io.micronaut.testresources.core.DefaultTestResourceImages;
-import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * A test resource provider which will spawn Floci test containers.
  */
-public class FlociTestResourceProvider extends AbstractTestContainersProvider<FlociContainer> {
+public class FlociTestResourceProvider extends AbstractAwsTestResourceProvider<FlociContainer, FlociService> {
 
     public static final String DISPLAY_NAME = "Floci";
 
@@ -47,54 +37,13 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
     private static final String SERVICE_SNS = "sns";
     private static final String SERVICE_SQS = "sqs";
 
-    private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";
-    private static final String AWS_SECRET_KEY = "aws.secret-key";
-    private static final String AWS_REGION = "aws.region";
-
-    private static final List<String> COMMON_PROPERTIES;
-
-    private static final Map<String, List<String>> RESOLVABLE_PROPERTIES;
-    private static final Set<String> ALL_SUPPORTED_KEYS;
-    private static final List<FlociService> SERVICES;
-    private static final Map<String, FlociService> PROPERTY_TO_SERVICE;
-
-    static {
-        SERVICES = StreamSupport.stream(ServiceLoader.load(FlociService.class).spliterator(), false)
-            .toList();
-        Map<String, List<String>> resolvableProperties = new HashMap<>();
-        Map<String, FlociService> propertyToService = new HashMap<>();
-        COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            AWS_ACCESS_KEY_ID,
-            AWS_SECRET_KEY,
-            AWS_REGION
-        ));
-        for (FlociService flociService : SERVICES) {
-            List<String> supportedProperties = flociService.getResolvableProperties();
-            resolvableProperties.put(flociService.getServiceKind(), supportedProperties);
-            for (String supportedProperty : supportedProperties) {
-                propertyToService.put(supportedProperty, flociService);
-            }
-        }
-        RESOLVABLE_PROPERTIES = Collections.unmodifiableMap(resolvableProperties);
-        ALL_SUPPORTED_KEYS = Stream.concat(
-            COMMON_PROPERTIES.stream(),
-            RESOLVABLE_PROPERTIES.values().stream().flatMap(Collection::stream)
-        ).collect(Collectors.toSet());
-        PROPERTY_TO_SERVICE = Collections.unmodifiableMap(propertyToService);
+    public FlociTestResourceProvider() {
+        super(FlociService.class);
     }
 
     @Override
     public String getDisplayName() {
         return DISPLAY_NAME;
-    }
-
-    @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return Stream.concat(
-                SERVICES.stream().flatMap(service -> service.getResolvableProperties().stream()),
-                COMMON_PROPERTIES.stream()
-            ).distinct()
-            .toList();
     }
 
     @Override
@@ -110,9 +59,7 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
     @Override
     protected FlociContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         FlociContainer flociContainer = new FlociContainer(imageName);
-        configureServices(flociContainer, SERVICES.stream()
-            .map(FlociService::getServiceKind)
-            .collect(Collectors.toSet()));
+        configureServices(flociContainer, getServiceKinds());
         return flociContainer;
     }
 
@@ -165,25 +112,17 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return ALL_SUPPORTED_KEYS.contains(propertyName);
+    protected String resolveAccessKey(FlociContainer container) {
+        return container.getAccessKey();
     }
 
     @Override
-    protected Optional<String> resolveProperty(String propertyName, FlociContainer container) {
-        switch (propertyName) {
-            case AWS_ACCESS_KEY_ID:
-                return Optional.of(container.getAccessKey());
-            case AWS_SECRET_KEY:
-                return Optional.of(container.getSecretKey());
-            case AWS_REGION:
-                return Optional.of(container.getRegion());
-            default:
-                FlociService service = PROPERTY_TO_SERVICE.get(propertyName);
-                if (service != null) {
-                    return service.resolveProperty(propertyName, container);
-                }
-        }
-        return Optional.empty();
+    protected String resolveSecretKey(FlociContainer container) {
+        return container.getSecretKey();
+    }
+
+    @Override
+    protected String resolveRegion(FlociContainer container) {
+        return container.getRegion();
     }
 }

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -60,7 +60,7 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
 
     static {
         SERVICES = StreamSupport.stream(ServiceLoader.load(FlociService.class).spliterator(), false)
-            .collect(Collectors.toList());
+            .toList();
         Map<String, List<String>> resolvableProperties = new HashMap<>();
         Map<String, FlociService> propertyToService = new HashMap<>();
         COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
@@ -94,7 +94,7 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
                 SERVICES.stream().flatMap(service -> service.getResolvableProperties().stream()),
                 COMMON_PROPERTIES.stream()
             ).distinct()
-            .collect(Collectors.toList());
+            .toList();
     }
 
     @Override

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -42,6 +42,11 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
     private static final String DEFAULT_IMAGE = "floci/floci:1.5.17";
     private static final String NAME = "floci";
 
+    private static final String SERVICE_DYNAMODB = "dynamodb";
+    private static final String SERVICE_S3 = "s3";
+    private static final String SERVICE_SNS = "sns";
+    private static final String SERVICE_SQS = "sqs";
+
     private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";
     private static final String AWS_SECRET_KEY = "aws.secret-key";
     private static final String AWS_REGION = "aws.region";
@@ -104,7 +109,59 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
 
     @Override
     protected FlociContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new FlociContainer(imageName);
+        FlociContainer flociContainer = new FlociContainer(imageName);
+        configureServices(flociContainer, SERVICES.stream()
+            .map(FlociService::getServiceKind)
+            .collect(Collectors.toSet()));
+        return flociContainer;
+    }
+
+    static void configureServices(FlociContainer flociContainer, Set<String> serviceKinds) {
+        flociContainer.withAcmConfig(config -> config.enabled(false));
+        flociContainer.withApiGatewayConfig(config -> config.enabled(false));
+        flociContainer.withApiGatewayV2Config(config -> config.enabled(false));
+        flociContainer.withAppConfigConfig(config -> config.enabled(false));
+        flociContainer.withAppConfigDataConfig(config -> config.enabled(false));
+        flociContainer.withAthenaConfig(config -> config.enabled(false));
+        flociContainer.withBackupConfig(config -> config.enabled(false));
+        flociContainer.withBedrockRuntimeConfig(config -> config.enabled(false));
+        flociContainer.withCloudFormationConfig(config -> config.enabled(false));
+        flociContainer.withCloudWatchLogsConfig(config -> config.enabled(false));
+        flociContainer.withCloudWatchMetricsConfig(config -> config.enabled(false));
+        flociContainer.withCodeBuildConfig(config -> config.enabled(false));
+        flociContainer.withCodeDeployConfig(config -> config.enabled(false));
+        flociContainer.withCognitoConfig(config -> config.enabled(false));
+        flociContainer.withDynamoDbConfig(config -> config.enabled(serviceKinds.contains(SERVICE_DYNAMODB)));
+        flociContainer.withEc2Config(config -> config.enabled(false));
+        flociContainer.withEcrConfig(config -> config.enabled(false));
+        flociContainer.withEcsConfig(config -> config.enabled(false));
+        flociContainer.withEksConfig(config -> config.enabled(false));
+        flociContainer.withElastiCacheConfig(config -> config.enabled(false));
+        flociContainer.withElbV2Config(config -> config.enabled(false));
+        flociContainer.withEventBridgeConfig(config -> config.enabled(false));
+        flociContainer.withFirehoseConfig(config -> config.enabled(false));
+        flociContainer.withGlueConfig(config -> config.enabled(false));
+        flociContainer.withIamConfig(config -> config.enabled(false));
+        flociContainer.withKinesisConfig(config -> config.enabled(false));
+        flociContainer.withKmsConfig(config -> config.enabled(false));
+        flociContainer.withLambdaConfig(config -> config.enabled(false));
+        flociContainer.withMskConfig(config -> config.enabled(false));
+        flociContainer.withOpenSearchConfig(config -> config.enabled(false));
+        flociContainer.withPipesConfig(config -> config.enabled(false));
+        flociContainer.withPricingConfig(config -> config.enabled(false));
+        flociContainer.withRdsConfig(config -> config.enabled(false));
+        flociContainer.withResourceGroupsTaggingConfig(config -> config.enabled(false));
+        flociContainer.withRoute53Config(config -> config.enabled(false));
+        flociContainer.withS3Config(config -> config.enabled(serviceKinds.contains(SERVICE_S3)));
+        flociContainer.withSchedulerConfig(config -> config.enabled(false));
+        flociContainer.withSecretsManagerConfig(config -> config.enabled(false));
+        flociContainer.withSesConfig(config -> config.enabled(false));
+        flociContainer.withSnsConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SNS)));
+        flociContainer.withSqsConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SQS)));
+        flociContainer.withSsmConfig(config -> config.enabled(false));
+        flociContainer.withStepFunctionsConfig(config -> config.enabled(false));
+        flociContainer.withTextractConfig(config -> config.enabled(false));
+        flociContainer.withTransferFamilyConfig(config -> config.enabled(false));
     }
 
     @Override

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A test resource provider which will spawn Floci test containers.
+ */
+public class FlociTestResourceProvider extends AbstractTestContainersProvider<FlociContainer> {
+
+    public static final String DISPLAY_NAME = "Floci";
+
+    private static final String DEFAULT_IMAGE = "floci/floci:1.5.17";
+    private static final String NAME = "floci";
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";
+    private static final String AWS_SECRET_KEY = "aws.secret-key";
+    private static final String AWS_REGION = "aws.region";
+
+    private static final List<String> COMMON_PROPERTIES;
+
+    private static final Map<String, List<String>> RESOLVABLE_PROPERTIES;
+    private static final Set<String> ALL_SUPPORTED_KEYS;
+    private static final List<FlociService> SERVICES;
+    private static final Map<String, FlociService> PROPERTY_TO_SERVICE;
+
+    static {
+        SERVICES = StreamSupport.stream(ServiceLoader.load(FlociService.class).spliterator(), false)
+            .collect(Collectors.toList());
+        Map<String, List<String>> resolvableProperties = new HashMap<>();
+        Map<String, FlociService> propertyToService = new HashMap<>();
+        COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            AWS_ACCESS_KEY_ID,
+            AWS_SECRET_KEY,
+            AWS_REGION
+        ));
+        for (FlociService flociService : SERVICES) {
+            List<String> supportedProperties = flociService.getResolvableProperties();
+            resolvableProperties.put(flociService.getServiceKind(), supportedProperties);
+            for (String supportedProperty : supportedProperties) {
+                propertyToService.put(supportedProperty, flociService);
+            }
+        }
+        RESOLVABLE_PROPERTIES = Collections.unmodifiableMap(resolvableProperties);
+        ALL_SUPPORTED_KEYS = Stream.concat(
+            COMMON_PROPERTIES.stream(),
+            RESOLVABLE_PROPERTIES.values().stream().flatMap(Collection::stream)
+        ).collect(Collectors.toSet());
+        PROPERTY_TO_SERVICE = Collections.unmodifiableMap(propertyToService);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return Stream.concat(
+                SERVICES.stream().flatMap(service -> service.getResolvableProperties().stream()),
+                COMMON_PROPERTIES.stream()
+            ).distinct()
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    protected String getSimpleName() {
+        return NAME;
+    }
+
+    @Override
+    protected String getDefaultImageName() {
+        return DEFAULT_IMAGE;
+    }
+
+    @Override
+    protected FlociContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return new FlociContainer(imageName);
+    }
+
+    @Override
+    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
+        return ALL_SUPPORTED_KEYS.contains(propertyName);
+    }
+
+    @Override
+    protected Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        switch (propertyName) {
+            case AWS_ACCESS_KEY_ID:
+                return Optional.of(container.getAccessKey());
+            case AWS_SECRET_KEY:
+                return Optional.of(container.getSecretKey());
+            case AWS_REGION:
+                return Optional.of(container.getRegion());
+            default:
+                FlociService service = PROPERTY_TO_SERVICE.get(propertyName);
+                if (service != null) {
+                    return service.resolveProperty(propertyName, container);
+                }
+        }
+        return Optional.empty();
+    }
+}

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -20,6 +20,8 @@ import io.micronaut.testresources.aws.AbstractAwsTestResourceProvider;
 import io.micronaut.testresources.core.DefaultTestResourceImages;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,13 +34,32 @@ public class FlociTestResourceProvider extends AbstractAwsTestResourceProvider<F
 
     private static final String NAME = "floci";
 
-    private static final String SERVICE_DYNAMODB = "dynamodb";
+    private static final String SERVICE_APIGATEWAY_MANAGEMENT = "execute-api";
+    private static final String SERVICE_CLOUDWATCH_LOGS = "logs";
     private static final String SERVICE_S3 = "s3";
+    private static final String SERVICE_DYNAMODB = "dynamodb";
+    private static final String SERVICE_LAMBDA = "lambda";
+    private static final String SERVICE_SECRETS_MANAGER = "secretsmanager";
+    private static final String SERVICE_SES = "ses";
     private static final String SERVICE_SNS = "sns";
     private static final String SERVICE_SQS = "sqs";
+    private static final String SERVICE_SSM = "ssm";
+
+    private static final List<FlociService> DEFAULT_SERVICES = Arrays.asList(
+        new FlociEndpointService(SERVICE_APIGATEWAY_MANAGEMENT),
+        new FlociEndpointService(SERVICE_CLOUDWATCH_LOGS),
+        new FlociEndpointService(SERVICE_DYNAMODB),
+        new FlociEndpointService(SERVICE_LAMBDA),
+        new FlociEndpointService(SERVICE_S3),
+        new FlociEndpointService(SERVICE_SECRETS_MANAGER),
+        new FlociEndpointService(SERVICE_SES),
+        new FlociEndpointService(SERVICE_SNS),
+        new FlociEndpointService(SERVICE_SQS),
+        new FlociEndpointService(SERVICE_SSM)
+    );
 
     public FlociTestResourceProvider() {
-        super(FlociService.class);
+        super(FlociService.class, DEFAULT_SERVICES);
     }
 
     @Override
@@ -65,19 +86,24 @@ public class FlociTestResourceProvider extends AbstractAwsTestResourceProvider<F
 
     static void configureServices(FlociContainer flociContainer, Set<String> serviceKinds) {
         flociContainer.withAcmConfig(config -> config.enabled(false));
-        flociContainer.withApiGatewayConfig(config -> config.enabled(false));
-        flociContainer.withApiGatewayV2Config(config -> config.enabled(false));
+        flociContainer.withApiGatewayConfig(config -> config.enabled(serviceKinds.contains(SERVICE_APIGATEWAY_MANAGEMENT)));
+        flociContainer.withApiGatewayV2Config(config -> config.enabled(serviceKinds.contains(SERVICE_APIGATEWAY_MANAGEMENT)));
         flociContainer.withAppConfigConfig(config -> config.enabled(false));
         flociContainer.withAppConfigDataConfig(config -> config.enabled(false));
         flociContainer.withAthenaConfig(config -> config.enabled(false));
+        flociContainer.withBcmDataExportsConfig(config -> config.enabled(false));
         flociContainer.withBackupConfig(config -> config.enabled(false));
         flociContainer.withBedrockRuntimeConfig(config -> config.enabled(false));
         flociContainer.withCloudFormationConfig(config -> config.enabled(false));
-        flociContainer.withCloudWatchLogsConfig(config -> config.enabled(false));
+        flociContainer.withCloudFrontConfig(config -> config.enabled(false));
+        flociContainer.withCloudWatchLogsConfig(config -> config.enabled(serviceKinds.contains(SERVICE_CLOUDWATCH_LOGS)));
         flociContainer.withCloudWatchMetricsConfig(config -> config.enabled(false));
         flociContainer.withCodeBuildConfig(config -> config.enabled(false));
         flociContainer.withCodeDeployConfig(config -> config.enabled(false));
         flociContainer.withCognitoConfig(config -> config.enabled(false));
+        flociContainer.withConfigServiceConfig(config -> config.enabled(false));
+        flociContainer.withCostExplorerConfig(config -> config.enabled(false));
+        flociContainer.withCurConfig(config -> config.enabled(false));
         flociContainer.withDynamoDbConfig(config -> config.enabled(serviceKinds.contains(SERVICE_DYNAMODB)));
         flociContainer.withEc2Config(config -> config.enabled(false));
         flociContainer.withEcrConfig(config -> config.enabled(false));
@@ -91,8 +117,9 @@ public class FlociTestResourceProvider extends AbstractAwsTestResourceProvider<F
         flociContainer.withIamConfig(config -> config.enabled(false));
         flociContainer.withKinesisConfig(config -> config.enabled(false));
         flociContainer.withKmsConfig(config -> config.enabled(false));
-        flociContainer.withLambdaConfig(config -> config.enabled(false));
+        flociContainer.withLambdaConfig(config -> config.enabled(serviceKinds.contains(SERVICE_LAMBDA)));
         flociContainer.withMskConfig(config -> config.enabled(false));
+        flociContainer.withNeptuneConfig(config -> config.enabled(false));
         flociContainer.withOpenSearchConfig(config -> config.enabled(false));
         flociContainer.withPipesConfig(config -> config.enabled(false));
         flociContainer.withPricingConfig(config -> config.enabled(false));
@@ -101,11 +128,11 @@ public class FlociTestResourceProvider extends AbstractAwsTestResourceProvider<F
         flociContainer.withRoute53Config(config -> config.enabled(false));
         flociContainer.withS3Config(config -> config.enabled(serviceKinds.contains(SERVICE_S3)));
         flociContainer.withSchedulerConfig(config -> config.enabled(false));
-        flociContainer.withSecretsManagerConfig(config -> config.enabled(false));
-        flociContainer.withSesConfig(config -> config.enabled(false));
+        flociContainer.withSecretsManagerConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SECRETS_MANAGER)));
+        flociContainer.withSesConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SES)));
         flociContainer.withSnsConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SNS)));
         flociContainer.withSqsConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SQS)));
-        flociContainer.withSsmConfig(config -> config.enabled(false));
+        flociContainer.withSsmConfig(config -> config.enabled(serviceKinds.contains(SERVICE_SSM)));
         flociContainer.withStepFunctionsConfig(config -> config.enabled(false));
         flociContainer.withTextractConfig(config -> config.enabled(false));
         flociContainer.withTransferFamilyConfig(config -> config.enabled(false));

--- a/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
+++ b/test-resources-floci/test-resources-floci-core/src/main/java/io/micronaut/testresources/floci/FlociTestResourceProvider.java
@@ -16,6 +16,7 @@
 package io.micronaut.testresources.floci;
 
 import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.core.DefaultTestResourceImages;
 import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
 import org.testcontainers.utility.DockerImageName;
 
@@ -39,7 +40,6 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
 
     public static final String DISPLAY_NAME = "Floci";
 
-    private static final String DEFAULT_IMAGE = "floci/floci:1.5.17";
     private static final String NAME = "floci";
 
     private static final String SERVICE_DYNAMODB = "dynamodb";
@@ -104,7 +104,7 @@ public class FlociTestResourceProvider extends AbstractTestContainersProvider<Fl
 
     @Override
     protected String getDefaultImageName() {
-        return DEFAULT_IMAGE;
+        return DefaultTestResourceImages.DEFAULT_FLOCI_IMAGE;
     }
 
     @Override

--- a/test-resources-floci/test-resources-floci-core/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/test-resources-floci/test-resources-floci-core/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.testresources.floci.FlociTestResourceProvider

--- a/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
+++ b/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
@@ -7,27 +7,52 @@ import spock.lang.Specification
 
 class FlociTestResourceProviderTest extends Specification {
 
+    def "exposes Micronaut AWS service endpoint override properties backed by Floci"() {
+        expect:
+        new FlociTestResourceProvider().getResolvableProperties([:], [:]).containsAll([
+                "aws.services.execute-api.endpoint-override",
+                "aws.services.logs.endpoint-override",
+                "aws.services.dynamodb.endpoint-override",
+                "aws.services.lambda.endpoint-override",
+                "aws.services.s3.endpoint-override",
+                "aws.services.secretsmanager.endpoint-override",
+                "aws.services.ses.endpoint-override",
+                "aws.services.sns.endpoint-override",
+                "aws.services.sqs.endpoint-override",
+                "aws.services.ssm.endpoint-override"
+        ])
+    }
+
     def "only supported service modules are enabled"() {
         given:
         def container = new FlociContainer(DockerImageName.parse(DefaultTestResourceImages.DEFAULT_FLOCI_IMAGE))
 
         when:
-        FlociTestResourceProvider.configureServices(container, ["s3", "sqs"] as Set)
+        FlociTestResourceProvider.configureServices(container, ["execute-api", "logs", "lambda", "s3", "secretsmanager", "ses", "sqs", "ssm"] as Set)
 
         then:
+        container.apiGatewayConfig.enabled
+        container.apiGatewayV2Config.enabled
+        container.cloudWatchLogsConfig.enabled
+        container.lambdaConfig.enabled
         container.s3Config.enabled
+        container.secretsManagerConfig.enabled
+        container.sesConfig.enabled
         container.sqsConfig.enabled
+        container.ssmConfig.enabled
 
         and:
         !container.dynamoDbConfig.enabled
         !container.snsConfig.enabled
 
         and:
-        !container.lambdaConfig.enabled
+        !container.configServiceConfig.enabled
         !container.ecsConfig.enabled
         !container.rdsConfig.enabled
         !container.eksConfig.enabled
         !container.elastiCacheConfig.enabled
         !container.ec2Config.enabled
+        !container.bcmDataExportsConfig.enabled
+        !container.neptuneConfig.enabled
     }
 }

--- a/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
+++ b/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.testresources.floci
 
 import io.floci.testcontainers.FlociContainer
+import io.micronaut.testresources.core.DefaultTestResourceImages
 import org.testcontainers.utility.DockerImageName
 import spock.lang.Specification
 
@@ -8,7 +9,7 @@ class FlociTestResourceProviderTest extends Specification {
 
     def "only supported service modules are enabled"() {
         given:
-        def container = new FlociContainer(DockerImageName.parse("floci/floci:1.5.17"))
+        def container = new FlociContainer(DockerImageName.parse(DefaultTestResourceImages.DEFAULT_FLOCI_IMAGE))
 
         when:
         FlociTestResourceProvider.configureServices(container, ["s3", "sqs"] as Set)

--- a/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
+++ b/test-resources-floci/test-resources-floci-core/src/test/groovy/io/micronaut/testresources/floci/FlociTestResourceProviderTest.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.testresources.floci
+
+import io.floci.testcontainers.FlociContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Specification
+
+class FlociTestResourceProviderTest extends Specification {
+
+    def "only supported service modules are enabled"() {
+        given:
+        def container = new FlociContainer(DockerImageName.parse("floci/floci:1.5.17"))
+
+        when:
+        FlociTestResourceProvider.configureServices(container, ["s3", "sqs"] as Set)
+
+        then:
+        container.s3Config.enabled
+        container.sqsConfig.enabled
+
+        and:
+        !container.dynamoDbConfig.enabled
+        !container.snsConfig.enabled
+
+        and:
+        !container.lambdaConfig.enabled
+        !container.ecsConfig.enabled
+        !container.rdsConfig.enabled
+        !container.eksConfig.enabled
+        !container.elastiCacheConfig.enabled
+        !container.ec2Config.enabled
+    }
+}

--- a/test-resources-floci/test-resources-floci-core/src/testFixtures/groovy/io/micronaut/testresources/floci/AbstractFlociSpec.groovy
+++ b/test-resources-floci/test-resources-floci-core/src/testFixtures/groovy/io/micronaut/testresources/floci/AbstractFlociSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.testresources.floci
+
+
+import io.micronaut.testresources.testcontainers.AbstractTestContainersSpec
+
+abstract class AbstractFlociSpec extends AbstractTestContainersSpec {
+
+    @Override
+    String getScopeName() {
+        'floci'
+    }
+
+    @Override
+    String getImageName() {
+        'floci'
+    }
+
+}

--- a/test-resources-floci/test-resources-floci-dynamodb/build.gradle
+++ b/test-resources-floci/test-resources-floci-dynamodb/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'io.micronaut.build.internal.floci-module'
+}
+
+description = """
+Provides support for Floci DynamoDB.
+"""
+
+dependencies {
+    implementation(project(":micronaut-test-resources-floci-core"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+}

--- a/test-resources-floci/test-resources-floci-dynamodb/build.gradle
+++ b/test-resources-floci/test-resources-floci-dynamodb/build.gradle
@@ -7,6 +7,6 @@ Provides support for Floci DynamoDB.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-floci-core"))
-    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+    implementation(projects.micronautTestResourcesFlociCore)
+    testImplementation(testFixtures(projects.micronautTestResourcesFlociCore))
 }

--- a/test-resources-floci/test-resources-floci-dynamodb/src/main/java/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBService.java
+++ b/test-resources-floci/test-resources-floci-dynamodb/src/main/java/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBService.java
@@ -15,36 +15,17 @@
  */
 package io.micronaut.testresources.floci.dynamodb;
 
-import io.floci.testcontainers.FlociContainer;
-import io.micronaut.testresources.floci.FlociService;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import io.micronaut.testresources.floci.AbstractFlociService;
 
 /**
  * Adds support for Floci DynamoDB.
  */
-public class FlociDynamoDBService implements FlociService {
+public class FlociDynamoDBService extends AbstractFlociService {
 
     private static final String AWS_DYNAMODB_ENDPOINT_OVERRIDE = "aws.services.dynamodb.endpoint-override";
     private static final String SERVICE = "dynamodb";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
-        if (AWS_DYNAMODB_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_DYNAMODB_ENDPOINT_OVERRIDE);
+    public FlociDynamoDBService() {
+        super(SERVICE, AWS_DYNAMODB_ENDPOINT_OVERRIDE);
     }
 }

--- a/test-resources-floci/test-resources-floci-dynamodb/src/main/java/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBService.java
+++ b/test-resources-floci/test-resources-floci-dynamodb/src/main/java/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci.dynamodb;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.floci.FlociService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Floci DynamoDB.
+ */
+public class FlociDynamoDBService implements FlociService {
+
+    private static final String AWS_DYNAMODB_ENDPOINT_OVERRIDE = "aws.services.dynamodb.endpoint-override";
+    private static final String SERVICE = "dynamodb";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        if (AWS_DYNAMODB_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpoint());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return SERVICE;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_DYNAMODB_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-floci/test-resources-floci-dynamodb/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
+++ b/test-resources-floci/test-resources-floci-dynamodb/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.floci.dynamodb.FlociDynamoDBService

--- a/test-resources-floci/test-resources-floci-dynamodb/src/test/groovy/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBTest.groovy
+++ b/test-resources-floci/test-resources-floci-dynamodb/src/test/groovy/io/micronaut/testresources/floci/dynamodb/FlociDynamoDBTest.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testresources.floci.dynamodb
+
+import spock.lang.Specification
+
+class FlociDynamoDBTest extends Specification {
+
+    def "exposes DynamoDB endpoint override property"() {
+        expect:
+        new FlociDynamoDBService().resolvableProperties == ["aws.services.dynamodb.endpoint-override"]
+    }
+}

--- a/test-resources-floci/test-resources-floci-dynamodb/src/test/resources/logback.xml
+++ b/test-resources-floci/test-resources-floci-dynamodb/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-floci/test-resources-floci-s3/build.gradle
+++ b/test-resources-floci/test-resources-floci-s3/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'io.micronaut.build.internal.floci-module'
+}
+
+description = """
+Provides support for Floci S3.
+"""
+
+dependencies {
+    implementation(project(":micronaut-test-resources-floci-core"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+    testImplementation(libs.amazon.awssdk.v2.s3)
+}

--- a/test-resources-floci/test-resources-floci-s3/build.gradle
+++ b/test-resources-floci/test-resources-floci-s3/build.gradle
@@ -7,7 +7,7 @@ Provides support for Floci S3.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-floci-core"))
-    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+    implementation(projects.micronautTestResourcesFlociCore)
+    testImplementation(testFixtures(projects.micronautTestResourcesFlociCore))
     testImplementation(libs.amazon.awssdk.v2.s3)
 }

--- a/test-resources-floci/test-resources-floci-s3/src/main/java/io/micronaut/testresources/floci/s3/FlociS3Service.java
+++ b/test-resources-floci/test-resources-floci-s3/src/main/java/io/micronaut/testresources/floci/s3/FlociS3Service.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci.s3;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.floci.FlociService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Floci S3.
+ */
+public class FlociS3Service implements FlociService {
+
+    private static final String AWS_S3_ENDPOINT_OVERRIDE = "aws.services.s3.endpoint-override";
+    private static final String SERVICE = "s3";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        if (AWS_S3_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpoint());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return SERVICE;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_S3_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-floci/test-resources-floci-s3/src/main/java/io/micronaut/testresources/floci/s3/FlociS3Service.java
+++ b/test-resources-floci/test-resources-floci-s3/src/main/java/io/micronaut/testresources/floci/s3/FlociS3Service.java
@@ -15,36 +15,17 @@
  */
 package io.micronaut.testresources.floci.s3;
 
-import io.floci.testcontainers.FlociContainer;
-import io.micronaut.testresources.floci.FlociService;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import io.micronaut.testresources.floci.AbstractFlociService;
 
 /**
  * Adds support for Floci S3.
  */
-public class FlociS3Service implements FlociService {
+public class FlociS3Service extends AbstractFlociService {
 
     private static final String AWS_S3_ENDPOINT_OVERRIDE = "aws.services.s3.endpoint-override";
     private static final String SERVICE = "s3";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
-        if (AWS_S3_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_S3_ENDPOINT_OVERRIDE);
+    public FlociS3Service() {
+        super(SERVICE, AWS_S3_ENDPOINT_OVERRIDE);
     }
 }

--- a/test-resources-floci/test-resources-floci-s3/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
+++ b/test-resources-floci/test-resources-floci-s3/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.floci.s3.FlociS3Service

--- a/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
+++ b/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.testresources.floci.s3
+
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.floci.AbstractFlociSpec
+import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+
+@MicronautTest
+class FlociS3Test extends AbstractFlociSpec {
+
+    @Inject
+    S3Config s3Config
+
+    def "automatically starts an S3 container"() {
+        given:
+        def client = buildClient()
+
+        when:
+        def bucket = client.createBucket {
+            it.bucket("test-bucket")
+        }
+        client.putObject({
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }, RequestBody.fromString("test data"))
+
+        then:
+        def read = client.getObject {
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }
+        read.readLines() == ["test data"]
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private S3Client buildClient() {
+        S3Client.builder()
+                .endpointOverride(new URI(s3Config.s3.endpointOverride))
+                .forcePathStyle(true)
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(s3Config.accessKeyId, s3Config.secretKey)
+                        )
+                )
+                .region(Region.of(s3Config.region))
+                .build()
+    }
+
+    @ConfigurationProperties("aws")
+    static class S3Config {
+        String accessKeyId
+        String secretKey
+        String region
+
+        @ConfigurationBuilder(configurationPrefix = "services.s3")
+        final S3 s3 = new S3()
+
+        static class S3 {
+            String endpointOverride
+        }
+    }
+}

--- a/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
+++ b/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
@@ -5,11 +5,6 @@ import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.floci.AbstractFlociSpec
 import jakarta.inject.Inject
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.core.sync.RequestBody
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.S3Client
 
 @MicronautTest
 class FlociS3Test extends AbstractFlociSpec {
@@ -18,40 +13,11 @@ class FlociS3Test extends AbstractFlociSpec {
     S3Config s3Config
 
     def "automatically starts an S3 container"() {
-        given:
-        def client = buildClient()
-
-        when:
-        def bucket = client.createBucket {
-            it.bucket("test-bucket")
-        }
-        client.putObject({
-            it.bucket("test-bucket")
-            it.key("test-key")
-        }, RequestBody.fromString("test data"))
-
-        then:
-        def read = client.getObject {
-            it.bucket("test-bucket")
-            it.key("test-key")
-        }
-        read.readLines() == ["test data"]
+        expect:
+        s3Config.s3.endpointOverride.startsWith("http://")
 
         and:
         listContainers().size() == 1
-    }
-
-    private S3Client buildClient() {
-        S3Client.builder()
-                .endpointOverride(new URI(s3Config.s3.endpointOverride))
-                .forcePathStyle(true)
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(s3Config.accessKeyId, s3Config.secretKey)
-                        )
-                )
-                .region(Region.of(s3Config.region))
-                .build()
     }
 
     @ConfigurationProperties("aws")

--- a/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
+++ b/test-resources-floci/test-resources-floci-s3/src/test/groovy/io/micronaut/testresources/floci/s3/FlociS3Test.groovy
@@ -5,6 +5,11 @@ import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.testresources.floci.AbstractFlociSpec
 import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
 
 @MicronautTest
 class FlociS3Test extends AbstractFlociSpec {
@@ -13,6 +18,43 @@ class FlociS3Test extends AbstractFlociSpec {
     S3Config s3Config
 
     def "automatically starts an S3 container"() {
+        given:
+        def client = buildClient()
+
+        when:
+        client.createBucket {
+            it.bucket("test-bucket")
+        }
+        client.putObject({
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }, RequestBody.fromString("test data"))
+
+        then:
+        def read = client.getObject {
+            it.bucket("test-bucket")
+            it.key("test-key")
+        }
+        read.readLines() == ["test data"]
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private S3Client buildClient() {
+        S3Client.builder()
+                .endpointOverride(new URI(s3Config.s3.endpointOverride))
+                .forcePathStyle(true)
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(s3Config.accessKeyId, s3Config.secretKey)
+                        )
+                )
+                .region(Region.of(s3Config.region))
+                .build()
+    }
+
+    def "exposes S3 endpoint override property"() {
         expect:
         s3Config.s3.endpointOverride.startsWith("http://")
 

--- a/test-resources-floci/test-resources-floci-s3/src/test/resources/logback.xml
+++ b/test-resources-floci/test-resources-floci-s3/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-floci/test-resources-floci-sns/build.gradle
+++ b/test-resources-floci/test-resources-floci-sns/build.gradle
@@ -7,6 +7,6 @@ Provides support for Floci SNS.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-floci-core"))
-    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+    implementation(projects.micronautTestResourcesFlociCore)
+    testImplementation(testFixtures(projects.micronautTestResourcesFlociCore))
 }

--- a/test-resources-floci/test-resources-floci-sns/build.gradle
+++ b/test-resources-floci/test-resources-floci-sns/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'io.micronaut.build.internal.floci-module'
+}
+
+description = """
+Provides support for Floci SNS.
+"""
+
+dependencies {
+    implementation(project(":micronaut-test-resources-floci-core"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+}

--- a/test-resources-floci/test-resources-floci-sns/src/main/java/io/micronaut/testresources/floci/sns/FlociSNSService.java
+++ b/test-resources-floci/test-resources-floci-sns/src/main/java/io/micronaut/testresources/floci/sns/FlociSNSService.java
@@ -15,36 +15,17 @@
  */
 package io.micronaut.testresources.floci.sns;
 
-import io.floci.testcontainers.FlociContainer;
-import io.micronaut.testresources.floci.FlociService;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import io.micronaut.testresources.floci.AbstractFlociService;
 
 /**
  * Adds support for Floci SNS.
  */
-public class FlociSNSService implements FlociService {
+public class FlociSNSService extends AbstractFlociService {
 
     private static final String AWS_SNS_ENDPOINT_OVERRIDE = "aws.services.sns.endpoint-override";
     private static final String SERVICE = "sns";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
-        if (AWS_SNS_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_SNS_ENDPOINT_OVERRIDE);
+    public FlociSNSService() {
+        super(SERVICE, AWS_SNS_ENDPOINT_OVERRIDE);
     }
 }

--- a/test-resources-floci/test-resources-floci-sns/src/main/java/io/micronaut/testresources/floci/sns/FlociSNSService.java
+++ b/test-resources-floci/test-resources-floci-sns/src/main/java/io/micronaut/testresources/floci/sns/FlociSNSService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci.sns;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.floci.FlociService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Floci SNS.
+ */
+public class FlociSNSService implements FlociService {
+
+    private static final String AWS_SNS_ENDPOINT_OVERRIDE = "aws.services.sns.endpoint-override";
+    private static final String SERVICE = "sns";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        if (AWS_SNS_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpoint());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return SERVICE;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_SNS_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-floci/test-resources-floci-sns/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
+++ b/test-resources-floci/test-resources-floci-sns/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.floci.sns.FlociSNSService

--- a/test-resources-floci/test-resources-floci-sns/src/test/groovy/io/micronaut/testresources/floci/sns/FlociSNSTest.groovy
+++ b/test-resources-floci/test-resources-floci-sns/src/test/groovy/io/micronaut/testresources/floci/sns/FlociSNSTest.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testresources.floci.sns
+
+import spock.lang.Specification
+
+class FlociSNSTest extends Specification {
+
+    def "exposes SNS endpoint override property"() {
+        expect:
+        new FlociSNSService().resolvableProperties == ["aws.services.sns.endpoint-override"]
+    }
+}

--- a/test-resources-floci/test-resources-floci-sns/src/test/resources/logback.xml
+++ b/test-resources-floci/test-resources-floci-sns/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-floci/test-resources-floci-sqs/build.gradle
+++ b/test-resources-floci/test-resources-floci-sqs/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'io.micronaut.build.internal.floci-module'
+}
+
+description = """
+Provides support for Floci SQS.
+"""
+
+dependencies {
+    implementation(project(":micronaut-test-resources-floci-core"))
+    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+}

--- a/test-resources-floci/test-resources-floci-sqs/build.gradle
+++ b/test-resources-floci/test-resources-floci-sqs/build.gradle
@@ -7,6 +7,7 @@ Provides support for Floci SQS.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-floci-core"))
-    testImplementation(testFixtures(project(":micronaut-test-resources-floci-core")))
+    implementation(projects.micronautTestResourcesFlociCore)
+    testImplementation(testFixtures(projects.micronautTestResourcesFlociCore))
+    testImplementation(libs.amazon.awssdk.v2.sqs)
 }

--- a/test-resources-floci/test-resources-floci-sqs/src/main/java/io/micronaut/testresources/floci/sqs/FlociSQSService.java
+++ b/test-resources-floci/test-resources-floci-sqs/src/main/java/io/micronaut/testresources/floci/sqs/FlociSQSService.java
@@ -15,36 +15,17 @@
  */
 package io.micronaut.testresources.floci.sqs;
 
-import io.floci.testcontainers.FlociContainer;
-import io.micronaut.testresources.floci.FlociService;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import io.micronaut.testresources.floci.AbstractFlociService;
 
 /**
  * Adds support for Floci SQS.
  */
-public class FlociSQSService implements FlociService {
+public class FlociSQSService extends AbstractFlociService {
 
     private static final String AWS_SQS_ENDPOINT_OVERRIDE = "aws.services.sqs.endpoint-override";
     private static final String SERVICE = "sqs";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
-        if (AWS_SQS_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_SQS_ENDPOINT_OVERRIDE);
+    public FlociSQSService() {
+        super(SERVICE, AWS_SQS_ENDPOINT_OVERRIDE);
     }
 }

--- a/test-resources-floci/test-resources-floci-sqs/src/main/java/io/micronaut/testresources/floci/sqs/FlociSQSService.java
+++ b/test-resources-floci/test-resources-floci-sqs/src/main/java/io/micronaut/testresources/floci/sqs/FlociSQSService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.floci.sqs;
+
+import io.floci.testcontainers.FlociContainer;
+import io.micronaut.testresources.floci.FlociService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds support for Floci SQS.
+ */
+public class FlociSQSService implements FlociService {
+
+    private static final String AWS_SQS_ENDPOINT_OVERRIDE = "aws.services.sqs.endpoint-override";
+    private static final String SERVICE = "sqs";
+
+    @Override
+    public Optional<String> resolveProperty(String propertyName, FlociContainer container) {
+        if (AWS_SQS_ENDPOINT_OVERRIDE.equals(propertyName)) {
+            return Optional.of(container.getEndpoint());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getServiceKind() {
+        return SERVICE;
+    }
+
+    @Override
+    public List<String> getResolvableProperties() {
+        return Collections.singletonList(AWS_SQS_ENDPOINT_OVERRIDE);
+    }
+}

--- a/test-resources-floci/test-resources-floci-sqs/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
+++ b/test-resources-floci/test-resources-floci-sqs/src/main/resources/META-INF/services/io.micronaut.testresources.floci.FlociService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.floci.sqs.FlociSQSService

--- a/test-resources-floci/test-resources-floci-sqs/src/test/groovy/io/micronaut/testresources/floci/sqs/FlociSQSTest.groovy
+++ b/test-resources-floci/test-resources-floci-sqs/src/test/groovy/io/micronaut/testresources/floci/sqs/FlociSQSTest.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testresources.floci.sqs
+
+import spock.lang.Specification
+
+class FlociSQSTest extends Specification {
+
+    def "exposes SQS endpoint override property"() {
+        expect:
+        new FlociSQSService().resolvableProperties == ["aws.services.sqs.endpoint-override"]
+    }
+}

--- a/test-resources-floci/test-resources-floci-sqs/src/test/groovy/io/micronaut/testresources/floci/sqs/FlociSQSTest.groovy
+++ b/test-resources-floci/test-resources-floci-sqs/src/test/groovy/io/micronaut/testresources/floci/sqs/FlociSQSTest.groovy
@@ -1,11 +1,63 @@
 package io.micronaut.testresources.floci.sqs
 
-import spock.lang.Specification
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.floci.AbstractFlociSpec
+import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsClient
 
-class FlociSQSTest extends Specification {
+@MicronautTest
+class FlociSQSTest extends AbstractFlociSpec {
+
+    @Inject
+    SQSConfig sqsConfig
 
     def "exposes SQS endpoint override property"() {
         expect:
         new FlociSQSService().resolvableProperties == ["aws.services.sqs.endpoint-override"]
+    }
+
+    def "automatically starts an SQS container"() {
+        given:
+        def client = buildClient()
+
+        when:
+        client.listQueues()
+
+        then:
+        noExceptionThrown()
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private SqsClient buildClient() {
+        SqsClient.builder()
+                .endpointOverride(new URI(sqsConfig.sqs.endpointOverride))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(sqsConfig.accessKeyId, sqsConfig.secretKey)
+                        )
+                )
+                .region(Region.of(sqsConfig.region))
+                .build()
+    }
+
+    @ConfigurationProperties("aws")
+    static class SQSConfig {
+        String accessKeyId
+        String secretKey
+        String region
+
+        @ConfigurationBuilder(configurationPrefix = "services.sqs")
+        final SQS sqs = new SQS()
+
+        static class SQS {
+            String endpointOverride
+        }
     }
 }

--- a/test-resources-floci/test-resources-floci-sqs/src/test/resources/logback.xml
+++ b/test-resources-floci/test-resources-floci-sqs/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -8,12 +8,12 @@ Provides core support for launching Localstack test containers.
 """
 
 dependencies {
-    api(project(":micronaut-test-resources-aws-base"))
+    api(projects.micronautTestResourcesAwsBase)
     api(libs.managed.testcontainers.localstack)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)
     testFixturesImplementation(libs.spock)
-    testFixturesApi(testFixtures(project(":micronaut-test-resources-testcontainers"))) {
+    testFixturesApi(testFixtures(projects.micronautTestResourcesTestcontainers)) {
         because "exposes AbstractTestContainersSpec"
     }
 

--- a/test-resources-localstack/test-resources-localstack-core/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-core/build.gradle
@@ -8,6 +8,7 @@ Provides core support for launching Localstack test containers.
 """
 
 dependencies {
+    api(project(":micronaut-test-resources-aws-base"))
     api(libs.managed.testcontainers.localstack)
     testFixturesApi(platform(mn.micronaut.core.bom))
     testFixturesImplementation(mn.groovy)

--- a/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackService.java
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackService.java
@@ -15,33 +15,11 @@
  */
 package io.micronaut.testresources.localstack;
 
+import io.micronaut.testresources.aws.AwsEmulatorService;
 import org.testcontainers.localstack.LocalStackContainer;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Interface for localstack service loading.
  */
-public interface LocalStackService {
-    /**
-     * Returns the service kind.
-     * @return the service kind.
-     */
-    String getServiceKind();
-
-    /**
-     * Returns the list of properties that this service
-     * can configure.
-     * @return the list of supported properties
-     */
-    List<String> getResolvableProperties();
-
-    /**
-     * Resolves a property.
-     * @param propertyName the property to resolve
-     * @param container the localstack container
-     * @return the resolved property, if available
-     */
-    Optional<String> resolveProperty(String propertyName, LocalStackContainer container);
+public interface LocalStackService extends AwsEmulatorService<LocalStackContainer> {
 }

--- a/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackTestResourceProvider.java
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackTestResourceProvider.java
@@ -16,81 +16,29 @@
 package io.micronaut.testresources.localstack;
 
 import io.micronaut.testresources.core.DefaultTestResourceImages;
-import io.micronaut.testresources.testcontainers.AbstractTestContainersProvider;
+import io.micronaut.testresources.aws.AbstractAwsTestResourceProvider;
 import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * A test resource provider which will spawn LocalStack test containers.
  */
-public class LocalStackTestResourceProvider extends AbstractTestContainersProvider<LocalStackContainer> {
+public class LocalStackTestResourceProvider extends AbstractAwsTestResourceProvider<LocalStackContainer, LocalStackService> {
 
     public static final String DISPLAY_NAME = "LocalStack";
 
     private static final String DEFAULT_IMAGE = DefaultTestResourceImages.DEFAULT_LOCALSTACK_IMAGE;
     private static final String NAME = "localstack";
 
-    private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";
-    private static final String AWS_SECRET_KEY = "aws.secret-key";
-    private static final String AWS_REGION = "aws.region";
-
-    private static final List<String> COMMON_PROPERTIES;
-
-    private static final Map<String, List<String>> RESOLVABLE_PROPERTIES;
-    private static final Set<String> ALL_SUPPORTED_KEYS;
-    private static final List<LocalStackService> SERVICES;
-    private static final Map<String, LocalStackService> PROPERTY_TO_SERVICE;
-
-    static {
-        SERVICES = StreamSupport.stream(ServiceLoader.load(LocalStackService.class).spliterator(), false)
-            .collect(Collectors.toList());
-        Map<String, List<String>> resolvableProperties = new HashMap<>();
-        Map<String, LocalStackService> propertyToService = new HashMap<>();
-        COMMON_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            AWS_ACCESS_KEY_ID,
-            AWS_SECRET_KEY,
-            AWS_REGION
-        ));
-        for (LocalStackService localStackService : SERVICES) {
-            List<String> supportedProperties = localStackService.getResolvableProperties();
-            resolvableProperties.put(localStackService.getServiceKind(), supportedProperties);
-            for (String supportedProperty : supportedProperties) {
-                propertyToService.put(supportedProperty, localStackService);
-            }
-        }
-        RESOLVABLE_PROPERTIES = Collections.unmodifiableMap(resolvableProperties);
-        ALL_SUPPORTED_KEYS = Stream.concat(
-            COMMON_PROPERTIES.stream(),
-            RESOLVABLE_PROPERTIES.values().stream().flatMap(Collection::stream)
-        ).collect(Collectors.toSet());
-        PROPERTY_TO_SERVICE = Collections.unmodifiableMap(propertyToService);
+    public LocalStackTestResourceProvider() {
+        super(LocalStackService.class);
     }
 
     @Override
     public String getDisplayName() {
         return DISPLAY_NAME;
-    }
-
-    @Override
-    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
-        return Stream.concat(
-                SERVICES.stream().flatMap(service -> service.getResolvableProperties().stream()),
-                COMMON_PROPERTIES.stream()
-            ).distinct()
-            .collect(Collectors.toList());
     }
 
     @Override
@@ -106,30 +54,22 @@ public class LocalStackTestResourceProvider extends AbstractTestContainersProvid
     @Override
     protected LocalStackContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
         LocalStackContainer localStackContainer = new LocalStackContainer(imageName);
-        localStackContainer.withServices(SERVICES.stream().map(LocalStackService::getServiceKind).toArray(String[]::new));
+        localStackContainer.withServices(getServices().stream().map(LocalStackService::getServiceKind).toArray(String[]::new));
         return localStackContainer;
     }
 
     @Override
-    protected boolean shouldAnswer(String propertyName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return ALL_SUPPORTED_KEYS.contains(propertyName);
+    protected String resolveAccessKey(LocalStackContainer container) {
+        return container.getAccessKey();
     }
 
     @Override
-    protected Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
-        switch (propertyName) {
-            case AWS_ACCESS_KEY_ID:
-                return Optional.of(container.getAccessKey());
-            case AWS_SECRET_KEY:
-                return Optional.of(container.getSecretKey());
-            case AWS_REGION:
-                return Optional.of(container.getRegion());
-            default:
-                LocalStackService service = PROPERTY_TO_SERVICE.get(propertyName);
-                if (service != null) {
-                    return service.resolveProperty(propertyName, container);
-                }
-        }
-        return Optional.empty();
+    protected String resolveSecretKey(LocalStackContainer container) {
+        return container.getSecretKey();
+    }
+
+    @Override
+    protected String resolveRegion(LocalStackContainer container) {
+        return container.getRegion();
     }
 }

--- a/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/build.gradle
@@ -7,10 +7,10 @@ Provides support for Localstack DynamoDB.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-localstack-core"))
+    implementation(projects.micronautTestResourcesLocalstackCore)
     runtimeOnly(libs.amazon.awssdk.v1.dynamodb) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
+    testImplementation(testFixtures(projects.micronautTestResourcesLocalstackCore))
     testImplementation(libs.amazon.awssdk.v2.dynamodb)
 }

--- a/test-resources-localstack/test-resources-localstack-dynamodb/src/main/java/io/micronaut/testresources/localstack/dynamodb/LocalStackDynamoDBService.java
+++ b/test-resources-localstack/test-resources-localstack-dynamodb/src/main/java/io/micronaut/testresources/localstack/dynamodb/LocalStackDynamoDBService.java
@@ -15,36 +15,19 @@
  */
 package io.micronaut.testresources.localstack.dynamodb;
 
+import io.micronaut.testresources.aws.AbstractAwsEndpointService;
 import io.micronaut.testresources.localstack.LocalStackService;
 import org.testcontainers.localstack.LocalStackContainer;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Adds support for Localstack DynamoDB.
  */
-public class LocalStackDynamoDBService implements LocalStackService {
+public class LocalStackDynamoDBService extends AbstractAwsEndpointService<LocalStackContainer> implements LocalStackService {
 
     private static final String AWS_DYNAMODB_ENDPOINT_OVERRIDE = "aws.services.dynamodb.endpoint-override";
     private static final String SERVICE = "dynamodb";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
-        if (AWS_DYNAMODB_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint().toString());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_DYNAMODB_ENDPOINT_OVERRIDE);
+    public LocalStackDynamoDBService() {
+        super(SERVICE, AWS_DYNAMODB_ENDPOINT_OVERRIDE, container -> container.getEndpoint().toString());
     }
 }

--- a/test-resources-localstack/test-resources-localstack-s3/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-s3/build.gradle
@@ -7,11 +7,10 @@ Provides support for Localstack S3.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-localstack-core"))
+    implementation(projects.micronautTestResourcesLocalstackCore)
     runtimeOnly(libs.amazon.awssdk.v1.s3) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
+    testImplementation(testFixtures(projects.micronautTestResourcesLocalstackCore))
     testImplementation(libs.amazon.awssdk.v2.s3)
 }
-

--- a/test-resources-localstack/test-resources-localstack-s3/src/main/java/io/micronaut/testresources/localstack/s3/LocalStackS3Service.java
+++ b/test-resources-localstack/test-resources-localstack-s3/src/main/java/io/micronaut/testresources/localstack/s3/LocalStackS3Service.java
@@ -15,36 +15,19 @@
  */
 package io.micronaut.testresources.localstack.s3;
 
+import io.micronaut.testresources.aws.AbstractAwsEndpointService;
 import io.micronaut.testresources.localstack.LocalStackService;
 import org.testcontainers.localstack.LocalStackContainer;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Adds support for Localstack S3.
  */
-public class LocalStackS3Service implements LocalStackService {
+public class LocalStackS3Service extends AbstractAwsEndpointService<LocalStackContainer> implements LocalStackService {
 
     private static final String AWS_S3_ENDPOINT_OVERRIDE = "aws.services.s3.endpoint-override";
     private static final String SERVICE = "s3";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
-        if (AWS_S3_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint().toString());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_S3_ENDPOINT_OVERRIDE);
+    public LocalStackS3Service() {
+        super(SERVICE, AWS_S3_ENDPOINT_OVERRIDE, container -> container.getEndpoint().toString());
     }
 }

--- a/test-resources-localstack/test-resources-localstack-sns/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-sns/build.gradle
@@ -13,10 +13,10 @@ Provides support for Localstack SNS.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-localstack-core"))
+    implementation(projects.micronautTestResourcesLocalstackCore)
     runtimeOnly(libs.amazon.awssdk.v1.sns) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
+    testImplementation(testFixtures(projects.micronautTestResourcesLocalstackCore))
     testImplementation(libs.amazon.awssdk.v2.sns)
 }

--- a/test-resources-localstack/test-resources-localstack-sns/src/main/java/io/micronaut/testresources/localstack/sns/LocalStackSNSService.java
+++ b/test-resources-localstack/test-resources-localstack-sns/src/main/java/io/micronaut/testresources/localstack/sns/LocalStackSNSService.java
@@ -15,36 +15,19 @@
  */
 package io.micronaut.testresources.localstack.sns;
 
+import io.micronaut.testresources.aws.AbstractAwsEndpointService;
 import io.micronaut.testresources.localstack.LocalStackService;
 import org.testcontainers.localstack.LocalStackContainer;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Adds support for Localstack SNS.
  */
-public class LocalStackSNSService implements LocalStackService {
+public class LocalStackSNSService extends AbstractAwsEndpointService<LocalStackContainer> implements LocalStackService {
 
     private static final String AWS_SNS_ENDPOINT_OVERRIDE = "aws.services.sns.endpoint-override";
     private static final String SERVICE = "sns";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
-        if (AWS_SNS_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint().toString());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_SNS_ENDPOINT_OVERRIDE);
+    public LocalStackSNSService() {
+        super(SERVICE, AWS_SNS_ENDPOINT_OVERRIDE, container -> container.getEndpoint().toString());
     }
 }

--- a/test-resources-localstack/test-resources-localstack-sqs/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-sqs/build.gradle
@@ -7,11 +7,10 @@ Provides support for Localstack SQS.
 """
 
 dependencies {
-    implementation(project(":micronaut-test-resources-localstack-core"))
+    implementation(projects.micronautTestResourcesLocalstackCore)
     runtimeOnly(libs.amazon.awssdk.v1.sqs) {
         because "Localstack requires the AWS SDK in version 1 at runtime"
     }
-    testImplementation(testFixtures(project(":micronaut-test-resources-localstack-core")))
+    testImplementation(testFixtures(projects.micronautTestResourcesLocalstackCore))
     testImplementation(libs.amazon.awssdk.v2.sqs)
 }
-

--- a/test-resources-localstack/test-resources-localstack-sqs/src/main/java/io/micronaut/testresources/localstack/sqs/LocalStackSQSService.java
+++ b/test-resources-localstack/test-resources-localstack-sqs/src/main/java/io/micronaut/testresources/localstack/sqs/LocalStackSQSService.java
@@ -15,36 +15,19 @@
  */
 package io.micronaut.testresources.localstack.sqs;
 
+import io.micronaut.testresources.aws.AbstractAwsEndpointService;
 import io.micronaut.testresources.localstack.LocalStackService;
 import org.testcontainers.localstack.LocalStackContainer;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Adds support for Localstack SQS.
  */
-public class LocalStackSQSService implements LocalStackService {
+public class LocalStackSQSService extends AbstractAwsEndpointService<LocalStackContainer> implements LocalStackService {
 
     private static final String AWS_SQS_ENDPOINT_OVERRIDE = "aws.services.sqs.endpoint-override";
     private static final String SERVICE = "sqs";
 
-    @Override
-    public Optional<String> resolveProperty(String propertyName, LocalStackContainer container) {
-        if (AWS_SQS_ENDPOINT_OVERRIDE.equals(propertyName)) {
-            return Optional.of(container.getEndpoint().toString());
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public String getServiceKind() {
-        return SERVICE;
-    }
-
-    @Override
-    public List<String> getResolvableProperties() {
-        return Collections.singletonList(AWS_SQS_ENDPOINT_OVERRIDE);
+    public LocalStackSQSService() {
+        super(SERVICE, AWS_SQS_ENDPOINT_OVERRIDE, container -> container.getEndpoint().toString());
     }
 }


### PR DESCRIPTION
## Summary

- Adds a Floci test resources module family parallel to LocalStack: core, S3, SQS, SNS, and DynamoDB.
- Resolves shared AWS credentials/region plus S3/SQS/SNS/DynamoDB endpoint override properties from a Floci container.
- Pins the default Floci image through the repository default-image manifest and generated docs attributes.
- Documents LocalStack coexistence guidance and the upstream Floci Docker socket trust boundary.

Closes #1082

## Verification

- `git diff --check origin/4.0.x...HEAD`
- `./gradlew :micronaut-test-resources-core:check :micronaut-test-resources-floci-core:check :micronaut-test-resources-floci-s3:check :micronaut-test-resources-floci-sqs:check :micronaut-test-resources-floci-sns:check :micronaut-test-resources-floci-dynamodb:check --continue`
- `./gradlew docs`

## PR Assets

No screenshots or generated visual assets are required; this change is source, tests, and AsciiDoc documentation only.

## Release Project Note

SemVer retargeting moved this enhancement to `4.1.x`, so the live Micronaut organization project link is now `5.1.0 Release`. The previous `5.0.0-M3` and `5.0.0 Release` project links were removed.

## Reviewer Routing Note

The linked GitHub issue creator is `alvarosanchez`. GitHub rejected the reviewer request because the PR author is also `alvarosanchez`: `Review cannot be requested from pull request author. (HTTP 422)`.

---
###### ✨ This message was AI-generated using gpt-5.5