### PR TITLE
docs: refresh test resources quick start

### DIFF
--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -1,6 +1,6 @@
 In addition to traditional JDBC support, Micronaut Test Resources also supports R2DBC databases.
 
-The following properties will automatically be set when using a JDBC database:
+The following properties will automatically be set when using an R2DBC database:
 
 - `r2dbc.datasources.*.url`
 - `r2dbc.datasources.*.username`

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -49,7 +49,10 @@ The containers communicate with Kafka on an internal Docker network, so no fixed
 Request one of the listed URL properties when a service should be started.
 For example, a test-only bean can require and inject the Schema Registry URL:
 
-snippet::io.micronaut.testresources.kafka.SchemaRegistryClientConfiguration[project=test-resources-kafka,source=test,tags=clazz]
+[source,java]
+----
+include::test-resources-kafka/src/test/java/io/micronaut/testresources/kafka/SchemaRegistryClientConfiguration.java[tags=clazz]
+----
 
 Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 

--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -49,10 +49,7 @@ The containers communicate with Kafka on an internal Docker network, so no fixed
 Request one of the listed URL properties when a service should be started.
 For example, a test-only bean can require and inject the Schema Registry URL:
 
-[source,java]
-----
-include::test-resources-kafka/src/test/java/io/micronaut/testresources/kafka/SchemaRegistryClientConfiguration.java[tags=clazz]
-----
+snippet::io.micronaut.testresources.kafka.SchemaRegistryClientConfiguration[project=test-resources-kafka,source=test,tags=clazz]
 
 Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -2,14 +2,15 @@ Micronaut Test Resources are integrated via build plugins.
 
 The recommended approach to get started is to use https://micronaut.io/launch[Micronaut Launch] and select the `test-resources` feature.
 
-If you wanted to integrate it manually, for Gradle you can use the `micronaut-test-resources` plugin:
+If you want to integrate it manually, for Gradle you can use the `micronaut-test-resources` plugin.
+Use the same Micronaut Gradle plugin version for `io.micronaut.test-resources` and `io.micronaut.application`:
 
 .Gradle
 [source,groovy,subs="verbatim,attributes"]
 ----
 plugins {
-    id 'io.micronaut.test-resources' version '4.4.4' // get latest version from https://plugins.gradle.org/plugin/io.micronaut.test-resources
-    id 'io.micronaut.application' version '4.4.4' // get latest version from https://plugins.gradle.org/plugin/io.micronaut.application 
+    id 'io.micronaut.test-resources' version '<micronaut-gradle-plugin-version>'
+    id 'io.micronaut.application' version '<micronaut-gradle-plugin-version>'
 }
 ----
 


### PR DESCRIPTION
## Summary

- Correct the R2DBC database guide wording so the generated properties section says R2DBC, not JDBC.
- Replace the stale hard-coded Gradle plugin versions in the quick-start example with a shared Micronaut Gradle plugin version placeholder.

## Validation

- `./gradlew publishGuide`
- `./gradlew publishGuide --rerun-tasks`
- `git diff --check`
- Verified rendered raw guide output under `build/working/02-docs-raw/all/guide/` contains the updated quick-start placeholder and R2DBC wording.

Paperclip subtask: https://cliponaut.micronaut.fun/issues/DEV-795

---
###### ✨ This message was AI-generated using gpt-5.5