### PR TITLE
docs: fix test resources guide typos

### DIFF
--- a/src/main/docs/guide/modules-hashicorp-consul.adoc
+++ b/src/main/docs/guide/modules-hashicorp-consul.adoc
@@ -1,8 +1,8 @@
-Consul support will automatically start a https://www.consul.io/[Hashicorp Consul container] and provide the values of the `consul.client.host`, `consul.client.port`, and `consul.client.default-zone` properties.
+Consul support will automatically start a https://www.consul.io/[HashiCorp Consul container] and provide the values of the `consul.client.host`, `consul.client.port`, and `consul.client.default-zone` properties.
 
 The default image (`{default-image-consul}`) can be overwritten by setting the `test-resources.containers.hashicorp-consul.image-name` property.
 
-Key/value pairs can be inserted into Hashicorp Consul at startup with the `test-resources.containers.hashicorp-consul.kv-properties` property:
+Key/value pairs can be inserted into HashiCorp Consul at startup with the `test-resources.containers.hashicorp-consul.kv-properties` property:
 
 [configuration]
 ----

--- a/src/main/docs/guide/modules-hashicorp-vault.adoc
+++ b/src/main/docs/guide/modules-hashicorp-vault.adoc
@@ -1,8 +1,8 @@
-Vault support will automatically start a https://www.vaultproject.io/[Hashicorp Vault container] and provide the value of `vault.client.uri` property.
+Vault support will automatically start a https://www.vaultproject.io/[HashiCorp Vault container] and provide the value of `vault.client.uri` property.
 
 - The default image (`{default-image-vault}`) can be overwritten by setting the `test-resources.containers.hashicorp-vault.image-name` property.
 - The default Vault access token is `vault-token` but this can be overridden by setting the `test-resources.containers.hashicorp-vault.token` property.
-- Secrets should be inserted into Hashicorp Vault at startup by adding the config:
+- Secrets should be inserted into HashiCorp Vault at startup by adding the config:
 
 [configuration]
 ----

--- a/src/main/docs/guide/modules-mongodb.adoc
+++ b/src/main/docs/guide/modules-mongodb.adoc
@@ -8,7 +8,7 @@ The default database name can be overwritten by setting the `test-resources.cont
 
 Alternatively, if you have multiple MongoDB servers declared in your configuration, the test resources service will supply a different replica set for each database.
 
-For example, if you have `mongodb.servers.users` and `mongodb.servers.books` defined, then the test resources service will supply the `mongodb.servers.users.uri` and `mondodb.servers.books.uri` properties.
+For example, if you have `mongodb.servers.users` and `mongodb.servers.books` defined, then the test resources service will supply the `mongodb.servers.users.uri` and `mongodb.servers.books.uri` properties.
 
 Note that in this case, a _single_ server is used, the value of `test-resources.containers.mongodb.db-name` is ignored, and the database name is set to the name of the database you declared (in this example, this would be respectively `users` and `books`).
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -53,9 +53,9 @@ modules:
   modules-oauth2:
     title: OAuth2 / Keycloak
   modules-hashicorp-vault:
-    title: Hashicorp Vault
+    title: HashiCorp Vault
   modules-hashicorp-consul:
-    title: Hashicorp Consul
+    title: HashiCorp Consul
   modules-solr:
     title: Solr
   modules-testcontainers:


### PR DESCRIPTION
## Summary

- Fix HashiCorp capitalization in the Test Resources guide navigation and Consul section.
- Correct the MongoDB multi-server property example from `mondodb.servers.books.uri` to `mongodb.servers.books.uri`.

## Validation

- `./gradlew publishGuide`
- `./gradlew :micronaut-test-resources-hashicorp-consul:testClasses :micronaut-test-resources-mongodb:testClasses :micronaut-test-resources-r2dbc-core:testClasses`

Notes: `publishGuide` succeeds on the current `4.0.x` base. It still emits pre-existing warnings for missing Kafka schema registry snippets and a configuration conversion parse warning outside this focused typo/capitalization change.

Paperclip: DEV-545

---
###### ✨ This message was AI-generated using gpt-5