### PR TITLE
docs: fix test resources guide rendering

### DIFF
--- a/src/main/docs/guide/modules-kafka.adoc
+++ b/src/main/docs/guide/modules-kafka.adoc
@@ -49,7 +49,10 @@ The containers communicate with Kafka on an internal Docker network, so no fixed
 Request one of the listed URL properties when a service should be started.
 For example, a test-only bean can require and inject the Schema Registry URL:
 
-snippet::io.micronaut.testresources.kafka.SchemaRegistryClientConfiguration[project=test-resources-kafka,source=test,tags=clazz]
+[source,java]
+----
+include::test-resources-kafka/src/test/java/io/micronaut/testresources/kafka/SchemaRegistryClientConfiguration.java[tag=clazz]
+----
 
 Test Resources will provide the URL value for the matching service and start Kafka as a dependency.
 

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -164,17 +164,17 @@ It is possible to let containers communicate with each other by declaring the ne
 test-resources:
   containers:
     producer:
-      image-name: alpine:3.14
-      command: top
-      network: custom
-      network-aliases: bob
-      hostnames: producer.host
+      image-name: "alpine:3.14"
+      command: "top"
+      network: "custom"
+      network-aliases: "bob"
+      hostnames: "producer.host"
     consumer:
-      image-name: alpine:3.14
-      command: top
-      network: custom
-      network-aliases: alice
-      hostnames: consumer.host
+      image-name: "alpine:3.14"
+      command: "top"
+      network: "custom"
+      network-aliases: "alice"
+      hostnames: "consumer.host"
 ----
 
 The `network` key is used to declare the network containers use.
@@ -221,7 +221,7 @@ test-resources:
     mycontainer:
         image-name: my/container
         wait-strategy:
-            port:
+            port: {}
             log:
                 regex: ".*Started.*"
 ----
@@ -235,7 +235,7 @@ test-resources:
     mycontainer:
         image-name: my/container
         wait-strategy:
-            port:
+            port: {}
             log:
                 regex: ".*Started.*"
             all:

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -212,6 +212,8 @@ The following wait strategies are supported:
 - `port` strategy
 - `healthcheck`: Docker healthcheck strategy
 
+When combining optionless strategies, such as `port` or `healthcheck`, with other wait strategies in a nested configuration block, set the optionless strategy key to a scalar value such as `true` so the key is preserved.
+
 Multiple strategies can be configured, in which case they are all applied (waits until all conditions are met):
 
 [configuration]
@@ -221,7 +223,7 @@ test-resources:
     mycontainer:
         image-name: my/container
         wait-strategy:
-            port: {}
+            port: true
             log:
                 regex: ".*Started.*"
 ----
@@ -235,7 +237,7 @@ test-resources:
     mycontainer:
         image-name: my/container
         wait-strategy:
-            port: {}
+            port: true
             log:
                 regex: ".*Started.*"
             all:


### PR DESCRIPTION
## Summary

- Render the Kafka Schema Registry example from the existing Java test source instead of asking the snippet macro for missing language variants.
- Make generic Testcontainers configuration examples explicit enough for the multi-format configuration renderer.

## Validation

- `./gradlew publishGuide`
- `./gradlew :micronaut-test-resources-kafka:compileTestJava`
- `git diff --check`
- Inspected generated guide output for the Kafka snippet and Testcontainers examples under `build/working/02-docs-raw/all/guide/`.

---
###### ✨ This message was AI-generated using openai/gpt-5.5