### PR TITLE
docs: refresh test resources guide review findings

### DIFF
--- a/src/main/docs/guide/implementing-test-resources.adoc
+++ b/src/main/docs/guide/implementing-test-resources.adoc
@@ -35,7 +35,7 @@ At this stage, we know _all properties_ that resolvers are able to resolve.
 So whenever Micronaut will encounter a property without value, it will ask the resolvers to resolve it.
 This is done in 2 steps:
 
-1. the `TestResourceResolver#getRequiredProperties` is called with the expression being resolved. It gives a chance to the resolver to tell what other properties it needs to read _before_ resolving the expression. For example, a database resolver may need to read the `datasources.default.db-type` property before it can resolve the `datasources.default.url` property, so that it can tell if it's actually capable of handling that database type or not.
+1. the `TestResourcesResolver#getRequiredProperties` is called with the expression being resolved. It gives a chance to the resolver to tell what other properties it needs to read _before_ resolving the expression. For example, a database resolver may need to read the `datasources.default.db-type` property before it can resolve the `datasources.default.url` property, so that it can tell if it's actually capable of handling that database type or not.
 2. the `resolve` method is called with the expression being resolved, the map of resolved properties from 1. and the whole configuration map of the `test-resources` from the application.
 
 It is the responsibility of the `TestResourcesResolver` to check, when `resolve` is called, that it can actually resolve the supplied expression. Do **not** assume that it will be called with an expression that it can resolve.

--- a/src/main/docs/guide/modules-couchbase.adoc
+++ b/src/main/docs/guide/modules-couchbase.adoc
@@ -15,4 +15,4 @@ test-resources:
 
 If you explicitly map any of those same properties through generic Testcontainers support, the dedicated Couchbase provider stands down for the full `couchbase.uri` / `couchbase.username` / `couchbase.password` connection set so values never come from mixed containers.
 
-For unsupported Couchbase topologies or additional property shapes, continue using xref:modules-testcontainers.adoc[generic Testcontainers support].
+For unsupported Couchbase topologies or additional property shapes, continue using xref:modules.adoc#modules-testcontainers[generic Testcontainers support].

--- a/src/main/docs/guide/modules-databases-jdbc.adoc
+++ b/src/main/docs/guide/modules-databases-jdbc.adoc
@@ -10,7 +10,7 @@ https://dev.mysql.com/doc/connector-j/en/connector-j-using-xdevapi.html[MySQL X 
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `h2`, `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgres`)
+- `datasources.*.db-type`: the kind of database (preferred, one of `h2`, `mariadb`, `mysql`, `mssql`, `oracle`, `oracle-test-pilot`, `oracle-xe`, `postgres`, `postgresql`, `pg`)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 
 Most JDBC databases are started via Testcontainers, so `datasources.*.driver-class-name` should usually be left empty because the JDBC driver from Testcontainers has to be used for URIs like `jdbc:tc:postgres:14:///db`.

--- a/src/main/docs/guide/modules-databases-r2dbc.adoc
+++ b/src/main/docs/guide/modules-databases-r2dbc.adoc
@@ -8,19 +8,17 @@ The following properties will automatically be set when using an R2DBC database:
 
 In order for the database to be properly detected, _one of_ the following properties has to be set:
 
-- `r2dbc.datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgresql`)
+- `r2dbc.datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `mssql`, `oracle`, `postgres`, `postgresql`, `pg`)
 - `r2dbc.datasources.*.driverClassName`: the class name of the driver (fallback)
 - `r2dbc.datasources.*.dialect`: the dialect to use for the database (fallback)
 
 In addition, R2DBC databases can be configured simply by reading the traditional JDBC properties:
 
-- `datasources.*.db-type`: the kind of database (preferred, one of `mariadb`, `mysql`, `oracle`, `oracle-xe`, `postgresql`)
-- `datasources.*.driverClassName`: the class name of the driver (fallback)
+- `datasources.*.db-type`: the kind of JDBC database to share with the R2DBC datasource (preferred, one of `mariadb`, `mysql`, `mssql`, `oracle`, `oracle-xe`, `postgres`, `postgresql`, `pg`)
 - `datasources.*.dialect`: the dialect to use for the database (fallback)
 - `datasources.*.db-name`: overrides the default test database name
-- `datasources.*.username`: overrides the default test user
-- `datasources.*.password`: overrides the default test password
-- `datasources.*.init-script-path`: a path to a SQL file on classpath, which will be executed at container startup
+
+Container-level settings such as `username`, `password`, and `init-script-path` use the `test-resources.containers.[db-type].*` properties described in the database module section.
 
 In which case, the name of the datasource must match the name of the R2DBC datasource.
 This can be useful when using modules like Flyway which only support JDBC for updating schemas, but still have your application use R2DBC: in this case the container which will be used for R2DBC and JDBC will be the same.

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -11,6 +11,7 @@ Micronaut Test Resources provides support for the following databases:
 | https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `{default-image-mysql-community}`
 | https://www.oracle.com/database/free/[Oracle Database Free] | Yes | Yes | `oracle` | `{default-image-oracle-free}`
 | https://www.oracle.com/database/technologies/appdev/xe.html[Oracle Database XE] | Yes | Yes | `oracle-xe` | `{default-image-oracle-xe}`
+| Oracle Test Pilot for Third-Party Software | Yes | No | `oracle-test-pilot` | n/a
 | https://www.postgresql.org/[PostgreSQL] | Yes | Yes | `postgres` | `{default-image-postgres}`
 | https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | `mssql` | `{default-image-mssql}`
 

--- a/src/main/docs/guide/modules-databases.adoc
+++ b/src/main/docs/guide/modules-databases.adoc
@@ -9,8 +9,8 @@ Micronaut Test Resources provides support for the following databases:
 | https://www.h2database.com/html/main.html[H2] | Yes | No | `h2` | n/a
 | https://mariadb.org/[MariaDB] | Yes | Yes | `mariadb` | `{default-image-mariadb}`
 | https://www.mysql.com/[MySQL] | Yes | Yes | `mysql` | `{default-image-mysql-community}`
-| https://www.oracle.com/database/technologies/appdev/xe.html[Oracle Database XE] | Yes | Yes | `oracle-xe` | `{default-image-oracle-xe}`
 | https://www.oracle.com/database/free/[Oracle Database Free] | Yes | Yes | `oracle` | `{default-image-oracle-free}`
+| https://www.oracle.com/database/technologies/appdev/xe.html[Oracle Database XE] | Yes | Yes | `oracle-xe` | `{default-image-oracle-xe}`
 | https://www.postgresql.org/[PostgreSQL] | Yes | Yes | `postgres` | `{default-image-postgres}`
 | https://www.microsoft.com/sql-server[Microsoft SQL Server] | Yes | Yes | `mssql` | `{default-image-mssql}`
 
@@ -19,6 +19,9 @@ Micronaut Test Resources provides support for the following databases:
 Most databases are supplied via a https://www.testcontainers.com/[Testcontainers] container.
 H2 is containerless and starts a loopback-only in-memory TCP server for the lifetime of the test-resources process.
 Shared or remote H2 test resources are not supported at this time, so the H2 resolver stays disabled when `micronaut.test.resources.server.uri` is configured.
+For new Oracle database tests, prefer the `oracle` identifier for Oracle Database Free.
+The `oracle-xe` identifier remains available for compatibility with Oracle Database XE and is deprecated for removal.
+For JDBC tests that run against Oracle Test Pilot, use the `oracle-test-pilot` identifier; it resolves the JDBC URL, username, and password from the `TESTPILOT_CONNECTION_STRING_SUFFIX`, `TESTPILOT_USERNAME`, and `TESTPILOT_PASSWORD` environment variables.
 It is possible to override the default image of the container by setting the following property in your application configuration:
 
 - `test-resources.containers.[db-type].image-name`

--- a/src/main/docs/guide/modules-mailpit.adoc
+++ b/src/main/docs/guide/modules-mailpit.adoc
@@ -72,4 +72,4 @@ URI mailpitApiUrl;
 HttpRequest<?> request = HttpRequest.GET(mailpitApiUrl.resolve("/api/v1/messages"));
 ----
 
-For custom SMTP containers or non-JavaMail configuration, use <<modules-testcontainers,Generic Testcontainers support>>.
+For custom SMTP containers or non-JavaMail configuration, use xref:modules.adoc#modules-testcontainers[Generic Testcontainers support].

--- a/src/main/docs/guide/modules-testcontainers.adoc
+++ b/src/main/docs/guide/modules-testcontainers.adoc
@@ -4,7 +4,7 @@ For example, you may need a container image or protocol mapping that is not cove
 In this case, Micronaut Test Resources provide generic support for starting arbitrary test containers.
 Unlike the other resources, this will require adding configuration to your application to make it work.
 
-TIP: For Micronaut Email JavaMail applications that need a local SMTP capture server, prefer the dedicated <<modules-mailpit,Mailpit support>>.
+TIP: For Micronaut Email JavaMail applications that need a local SMTP capture server, prefer the dedicated xref:modules.adoc#modules-mailpit[Mailpit support].
 
 Let's illustrate how we can declare an SMTP test container (here using YAML configuration) for use with https://micronaut-projects.github.io/micronaut-email[Micronaut Email]:
 
@@ -151,7 +151,7 @@ test-resources:
       startup-timeout: 120s
 ----
 
-Please refer to the <<configurationreference#io.micronaut.testresources.testcontainers.TestContainersConfiguration,configuration properties reference>> for details.
+The examples above use the same `test-resources.containers.<name>` metadata that the generic container provider reads when it prepares the container.
 
 [[advanced-networking]]
 == Advanced networking

--- a/src/main/docs/guide/modules-wiremock.adoc
+++ b/src/main/docs/guide/modules-wiremock.adoc
@@ -44,7 +44,7 @@ test-resources:
 ----
 
 The same metadata can also copy files from host paths.
-See <<modules-testcontainers,Generic Testcontainers support>> for the full list of container metadata options.
+See xref:modules.adoc#modules-testcontainers[Generic Testcontainers support] for the full list of container metadata options.
 
 Resolved properties:
 


### PR DESCRIPTION
## Summary

- Prefer Oracle Database Free (`oracle`) over deprecated Oracle XE for new database tests and document the Oracle Test Pilot JDBC identifier.
- Align JDBC/R2DBC database identifier guidance with the provider set, including MSSQL and PostgreSQL aliases.
- Fix cross-guide links from provider pages to Generic Testcontainers and Mailpit sections so generated pages point at stable targets.
- Remove a stale generated configuration-reference link from the Generic Testcontainers page and fix the `TestResourcesResolver` API name typo.

## Validation

- `git fetch origin 4.0.x && git rebase origin/4.0.x`
- `./gradlew publishGuide --rerun-tasks`
- `./gradlew docs`
- `git diff --check`

Notes: `publishGuide` still emits the pre-existing multi-language snippet warnings for the Kafka Schema Registry example because only the Java snippet source exists; the Java snippet renders correctly. `docs` completes successfully with existing Javadoc/Error Prone warnings unrelated to these guide-only changes.

Paperclip subtask: DEV-1307 Weekly User Guide Review: micronaut-test-resources

---
###### ✨ This message was AI-generated using gpt-5.5
