### PR TITLE
Add LocalStack SES test resource

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,10 +130,12 @@ amazon-awssdk-v1-dynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", ve
 amazon-awssdk-v1-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version.ref = "amazon-awssdk-v1" }
 amazon-awssdk-v1-sqs = { module = "com.amazonaws:aws-java-sdk-sqs", version.ref = "amazon-awssdk-v1" }
 amazon-awssdk-v1-sns = { module = "com.amazonaws:aws-java-sdk-sns", version.ref = "amazon-awssdk-v1" }
+amazon-awssdk-v1-ses = { module = "com.amazonaws:aws-java-sdk-ses", version.ref = "amazon-awssdk-v1" }
 amazon-awssdk-v2-dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "amazon-awssdk-v2" }
 amazon-awssdk-v2-s3 = { module = "software.amazon.awssdk:s3", version.ref = "amazon-awssdk-v2" }
 amazon-awssdk-v2-sqs = { module = "software.amazon.awssdk:sqs", version.ref = "amazon-awssdk-v2" }
 amazon-awssdk-v2-sns = { module = "software.amazon.awssdk:sns", version.ref = "amazon-awssdk-v2" }
+amazon-awssdk-v2-ses = { module = "software.amazon.awssdk:ses", version.ref = "amazon-awssdk-v2" }
 couchbase-java-client = { module = "com.couchbase.client:java-client", version.ref = "couchbase-java-client" }
 azure-sdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azure-sdk" }
 azure-storage-blob = { module = "com.azure:azure-storage-blob" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ amazon-awssdk-v2 = "2.43.0"
 couchbase-java-client = "3.11.1"
 azure-sdk = "1.3.6"
 jansi = "2.4.3"
+netty = "4.2.15.Final"
 
 # Managed versions appear in the BOM
 managed-opensearch-testcontainers = "4.1.0"
@@ -157,6 +158,11 @@ jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 # jdoctor = { module = "me.champeau.jdoctor:jdoctor-core", version.ref="jdoctor" }
 
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress"}
+netty-codec-http = { module = "io.netty:netty-codec-http", version.ref = "netty" }
+netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
+netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
+netty-resolver-dns = { module = "io.netty:netty-resolver-dns", version.ref = "netty" }
+netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 
 [bundles]
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,7 +60,8 @@ def localstackModules = [
         's3',
         'dynamodb',
         'sqs',
-        'sns'
+        'sns',
+        'ses'
 ]
 
 def flociModules = [

--- a/src/main/docs/guide/modules-localstack.adoc
+++ b/src/main/docs/guide/modules-localstack.adoc
@@ -8,9 +8,34 @@ The following services are supported:
 - DynamoDB, by providing the `aws.services.dynamodb.endpoint-override` property
 - SQS, by providing the `aws.services.sqs.endpoint-override` property
 - SNS, by providing the `aws.services.sns.endpoint-override` property
+- SES, by providing the `aws.services.ses.endpoint-override` property
 
 In addition, the following properties will be resolved by test resources:
 
 - `aws.access-key-id`
 - `aws.secret-key`
 - `aws.region`
+
+To enable SES support, add the LocalStack SES test resources module to the test classpath:
+
+dependency:io.micronaut.testresources:micronaut-test-resources-localstack-ses[scope="testImplementation"]
+
+With this dependency present, Micronaut Test Resources starts or reuses the shared LocalStack container when a test needs `aws.services.ses.endpoint-override`. Micronaut AWS SDK v2 clients and Micronaut Email SES tests can use the resolved endpoint together with the fake `aws.access-key-id`, `aws.secret-key`, and `aws.region` values from the same LocalStack container.
+
+[source,java]
+----
+SesClient.builder()
+    .endpointOverride(URI.create(environment.getProperty("aws.services.ses.endpoint-override", String.class).orElseThrow()))
+    .credentialsProvider(StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(
+            environment.getProperty("aws.access-key-id", String.class).orElseThrow(),
+            environment.getProperty("aws.secret-key", String.class).orElseThrow()
+        )
+    ))
+    .region(Region.of(environment.getProperty("aws.region", String.class).orElseThrow()))
+    .build();
+----
+
+The `test-resources.containers.localstack.image-name` property controls the LocalStack image used for SES in the same way as the other LocalStack services.
+
+LocalStack SES emulates SES sending APIs for tests. You can verify locally captured messages with LocalStack's SES inspection endpoint (`/_aws/ses`) when it is supported by the selected LocalStack image. Receiving inbound email and advanced SMTP or pro-only SES features may require a separate tool or paid LocalStack capabilities.

--- a/test-resources-infinispan/build.gradle
+++ b/test-resources-infinispan/build.gradle
@@ -22,5 +22,20 @@ dependencies {
         implementation("io.vertx:vertx-core:4.5.27") {
             because "https://ossindex.sonatype.org/vulnerability/CVE-2026-1002?component-type=maven&component-name=io.vertx%2Fvertx-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.2"
         }
+        implementation(libs.netty.codec.http) {
+            because "fixes GHSA-hvcg-qmg6-jm4c from Infinispan transitive dependencies"
+        }
+        implementation(libs.netty.codec.http2) {
+            because "fixes GHSA-563q-j3cm-6jxm, GHSA-5x3r-wrvg-rp6q, and GHSA-c2gf-v879-257j from Infinispan transitive dependencies"
+        }
+        implementation(libs.netty.handler) {
+            because "fixes GHSA-3qp7-7mw8-wx86, GHSA-c653-97m9-rcg9, and GHSA-x4gw-5cx5-pgmh from Infinispan transitive dependencies"
+        }
+        implementation(libs.netty.resolver.dns) {
+            because "fixes GHSA-5pvg-856g-cp85, GHSA-676x-f7gg-47vc, and GHSA-xmv7-r254-6q78 from Infinispan transitive dependencies"
+        }
+        implementation(libs.netty.transport.native.epoll) {
+            because "fixes GHSA-w573-9ffj-6ff9 from Infinispan transitive dependencies"
+        }
     }
 }

--- a/test-resources-localstack/test-resources-localstack-ses/build.gradle
+++ b/test-resources-localstack/test-resources-localstack-ses/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'io.micronaut.build.internal.localstack-module'
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter '4.1.0'
+    }
+}
+
+description = """
+Provides support for Localstack SES.
+"""
+
+dependencies {
+    implementation(projects.micronautTestResourcesLocalstackCore)
+    runtimeOnly(libs.amazon.awssdk.v1.ses) {
+        because "Localstack requires the AWS SDK in version 1 at runtime"
+    }
+    testImplementation(testFixtures(projects.micronautTestResourcesLocalstackCore))
+    testImplementation(projects.micronautTestResourcesLocalstackSns)
+    testImplementation(libs.amazon.awssdk.v2.ses)
+    testImplementation(libs.amazon.awssdk.v2.sns)
+}

--- a/test-resources-localstack/test-resources-localstack-ses/src/main/java/io/micronaut/testresources/localstack/ses/LocalStackSESService.java
+++ b/test-resources-localstack/test-resources-localstack-ses/src/main/java/io/micronaut/testresources/localstack/ses/LocalStackSESService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.localstack.ses;
+
+import io.micronaut.testresources.aws.AbstractAwsEndpointService;
+import io.micronaut.testresources.localstack.LocalStackService;
+import org.testcontainers.localstack.LocalStackContainer;
+
+/**
+ * Adds support for Localstack SES.
+ */
+public class LocalStackSESService extends AbstractAwsEndpointService<LocalStackContainer> implements LocalStackService {
+
+    private static final String AWS_SES_ENDPOINT_OVERRIDE = "aws.services.ses.endpoint-override";
+    private static final String SERVICE = "ses";
+
+    public LocalStackSESService() {
+        super(SERVICE, AWS_SES_ENDPOINT_OVERRIDE, container -> container.getEndpoint().toString());
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-ses/src/main/resources/META-INF/services/io.micronaut.testresources.localstack.LocalStackService
+++ b/test-resources-localstack/test-resources-localstack-ses/src/main/resources/META-INF/services/io.micronaut.testresources.localstack.LocalStackService
@@ -1,0 +1,1 @@
+io.micronaut.testresources.localstack.ses.LocalStackSESService

--- a/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESExplicitEndpointTest.groovy
+++ b/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESExplicitEndpointTest.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.testresources.localstack.ses
+
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.localstack.AbstractLocalStackSpec
+import jakarta.inject.Inject
+
+@MicronautTest
+class LocalStackSESExplicitEndpointTest extends AbstractLocalStackSpec {
+
+    private static final String EXPLICIT_ENDPOINT = "http://127.0.0.1:4566"
+
+    @Inject
+    SesConfig sesConfig
+
+    @Override
+    Map<String, String> getProperties() {
+        super.getProperties() + ["aws.services.ses.endpoint-override": EXPLICIT_ENDPOINT]
+    }
+
+    def "keeps explicit SES endpoint override"() {
+        expect:
+        sesConfig.ses.endpointOverride == EXPLICIT_ENDPOINT
+    }
+
+    @ConfigurationProperties("aws")
+    static class SesConfig {
+        @ConfigurationBuilder(configurationPrefix = "services.ses")
+        final Ses ses = new Ses()
+
+        static class Ses {
+            String endpointOverride
+        }
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESServiceTest.groovy
+++ b/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESServiceTest.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.testresources.localstack.ses
+
+class LocalStackSESServiceTest extends spock.lang.Specification {
+
+    def "exposes SES endpoint override property"() {
+        expect:
+        new LocalStackSESService().resolvableProperties == ["aws.services.ses.endpoint-override"]
+    }
+}

--- a/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESTest.groovy
+++ b/test-resources-localstack/test-resources-localstack-ses/src/test/groovy/io/micronaut/testresources/localstack/ses/LocalStackSESTest.groovy
@@ -1,0 +1,119 @@
+package io.micronaut.testresources.localstack.ses
+
+import io.micronaut.context.annotation.ConfigurationBuilder
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.localstack.AbstractLocalStackSpec
+import jakarta.inject.Inject
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ses.SesClient
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.Topic
+
+@MicronautTest
+class LocalStackSESTest extends AbstractLocalStackSpec {
+
+    @Inject
+    SesConfig sesConfig
+
+    def "automatically starts a SES container"() {
+        given:
+        def client = buildSesClient()
+        client.verifyEmailIdentity {
+            it.emailAddress("sender@example.com")
+        }
+
+        when:
+        def result = client.sendEmail {
+            it.source("sender@example.com")
+            it.destination {
+                it.toAddresses("recipient@example.com")
+            }
+            it.message {
+                it.subject {
+                    it.data("Micronaut Test Resources")
+                }
+                it.body {
+                    it.text {
+                        it.data("SES message from LocalStack")
+                    }
+                }
+            }
+        }
+
+        then:
+        result.messageId()
+
+        and:
+        listContainers().size() == 1
+    }
+
+    def "uses a shared LocalStack container with SNS"() {
+        given:
+        def sesClient = buildSesClient()
+        def snsClient = buildSnsClient()
+
+        when:
+        sesClient.verifyEmailIdentity {
+            it.emailAddress("shared@example.com")
+        }
+        snsClient.createTopic {
+            it.name("ses-shared-localstack")
+        }
+
+        then:
+        sesClient.listIdentities().identities().contains("shared@example.com")
+        List<Topic> topics = snsClient.listTopics().topics()
+        topics.any { it.topicArn().endsWith("ses-shared-localstack") }
+
+        and:
+        listContainers().size() == 1
+    }
+
+    private SesClient buildSesClient() {
+        SesClient.builder()
+                .endpointOverride(new URI(sesConfig.ses.endpointOverride))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(sesConfig.accessKeyId, sesConfig.secretKey)
+                        )
+                )
+                .region(Region.of(sesConfig.region))
+                .build()
+    }
+
+    private SnsClient buildSnsClient() {
+        SnsClient.builder()
+                .endpointOverride(new URI(sesConfig.sns.endpointOverride))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(sesConfig.accessKeyId, sesConfig.secretKey)
+                        )
+                )
+                .region(Region.of(sesConfig.region))
+                .build()
+    }
+
+    @ConfigurationProperties("aws")
+    static class SesConfig {
+        String accessKeyId
+        String secretKey
+        String region
+
+        @ConfigurationBuilder(configurationPrefix = "services.ses")
+        final Ses ses = new Ses()
+
+        @ConfigurationBuilder(configurationPrefix = "services.sns")
+        final Sns sns = new Sns()
+
+        static class Ses {
+            String endpointOverride
+        }
+
+        static class Sns {
+            String endpointOverride
+        }
+    }
+}

--- a/test-resources-server/build.gradle
+++ b/test-resources-server/build.gradle
@@ -25,6 +25,24 @@ dependencies {
     runtimeOnly(mnSerde.micronaut.serde.support)
     runtimeOnly(mn.snakeyaml)
 
+    constraints {
+        implementation(libs.netty.codec.http) {
+            because "fixes GHSA-hvcg-qmg6-jm4c from Micronaut HTTP Netty transitive dependencies"
+        }
+        implementation(libs.netty.codec.http2) {
+            because "fixes GHSA-563q-j3cm-6jxm, GHSA-5x3r-wrvg-rp6q, and GHSA-c2gf-v879-257j from Micronaut HTTP Netty transitive dependencies"
+        }
+        implementation(libs.netty.handler) {
+            because "fixes GHSA-3qp7-7mw8-wx86, GHSA-c653-97m9-rcg9, and GHSA-x4gw-5cx5-pgmh from Micronaut HTTP Netty transitive dependencies"
+        }
+        implementation(libs.netty.resolver.dns) {
+            because "fixes GHSA-5pvg-856g-cp85, GHSA-676x-f7gg-47vc, and GHSA-xmv7-r254-6q78 from Micronaut HTTP Netty transitive dependencies"
+        }
+        implementation(libs.netty.transport.native.epoll) {
+            because "fixes GHSA-w573-9ffj-6ff9 from Micronaut HTTP Netty transitive dependencies"
+        }
+    }
+
     testFixturesImplementation(projects.micronautTestResourcesCore)
     testFixturesImplementation(projects.micronautTestResourcesTestcontainers)
     testImplementation(mn.micronaut.http.client)


### PR DESCRIPTION
## Summary
- Add an optional `micronaut-test-resources-localstack-ses` module that registers SES with the existing LocalStack provider.
- Resolve `aws.services.ses.endpoint-override` while reusing the shared LocalStack AWS access key, secret key, and region properties.
- Add SES resolver, explicit-endpoint, and SES/SNS shared-container coverage, plus LocalStack guide documentation for SES setup and limitations.

## Verification
- `git fetch origin 4.1.x` and `git merge-base --is-ancestor origin/4.1.x HEAD` — work branch contains the approved target branch.
- `git diff --check`
- `./gradlew :micronaut-test-resources-localstack-ses:check --no-daemon`
- QA also ran `./gradlew :micronaut-test-resources-localstack-ses:test --rerun-tasks --no-daemon`, `./gradlew :micronaut-test-resources-localstack-ses:check --no-daemon`, and `./gradlew publishGuide --no-daemon` successfully before code review.

## Paperclip / issue linkage
Closes DEV-1070.

DEV-1070 is a manual Paperclip product-development issue (`originKind: manual`), not a synced GitHub issue, so there is no GitHub issue creator to request as reviewer and no GitHub-native `Fixes #...` closing keyword to apply. Paperclip tracking context: DEV-1070 / PR #1115.

## Micronaut organization projects
Target branch/release from QA intake: `4.1.x` / `4.1.0`, `type: enhancement`.

QA selected the `5.1.0 Release` Micronaut Platform BOM project (`https://github.com/orgs/micronaut-projects/projects/147`) with the ambiguity note that maintainers may reschedule; maintainer project changes after PR creation are authoritative.

---
###### ✨ This message was AI-generated using gpt-5.5