### PR TITLE
Allow disabling test resources at runtime

### DIFF
--- a/src/main/docs/guide/architecture-client.adoc
+++ b/src/main/docs/guide/architecture-client.adoc
@@ -23,3 +23,7 @@ NOTE: If Micronaut Test Resources unexpectedly connects to an old server or fail
 
 The remote transport is a small binary protocol shared with the server.
 That protocol is intentionally limited to the value shapes used by the RPC layer: strings, booleans, integral numbers, lists, maps, and `null`.
+
+== Disabling test resources for application startup
+
+When the Test Resources client is on an application runtime classpath, for example during a Gradle `run` task, Test Resources can be disabled for that JVM with the `micronaut.test.resources.enabled=false` system property. When disabled, the client does not contribute the lazy Test Resources property source or resolve `auto.test.resources.*` expressions.

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -128,7 +128,6 @@ public final class TestResourcesClientFactory {
         }
         boolean enabled = Boolean.parseBoolean(System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.ENABLED), "true"));
         if (!enabled) {
-            System.err.println("Test resources are disabled");
             return Optional.of(NoOpClient.INSTANCE);
         }
         String serverUri = System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.SERVER_URI));

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
@@ -40,7 +40,7 @@ public class LazyTestResourcesExpressionResolver implements PropertyExpressionRe
                                    ConversionService conversionService,
                                    String expression,
                                    Class<T> requiredType) {
-        if (TestResourcesConfiguration.isDisabled()) {
+        if (TestResourcesConfiguration.isDisabled(propertyResolver)) {
             return Optional.empty();
         }
         if (expression.startsWith(PLACEHOLDER_PREFIX)) {

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
@@ -40,6 +40,9 @@ public class LazyTestResourcesExpressionResolver implements PropertyExpressionRe
                                    ConversionService conversionService,
                                    String expression,
                                    Class<T> requiredType) {
+        if (TestResourcesConfiguration.isDisabled()) {
+            return Optional.empty();
+        }
         if (expression.startsWith(PLACEHOLDER_PREFIX)) {
             String eagerExpression = expression.substring(PLACEHOLDER_PREFIX.length());
             var resolved = delegate.resolve(propertyResolver, conversionService, eagerExpression,

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -48,7 +48,8 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
 
     @Override
     public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader) {
-        if (TestResourcesConfiguration.isDisabled()) {
+        if (TestResourcesConfiguration.isDisabled()
+                || resourceLoader instanceof PropertyResolver propertyResolver && TestResourcesConfiguration.isDisabled(propertyResolver)) {
             return Optional.empty();
         }
         return Optional.of(new LazyPropertySource(resourceLoader));
@@ -98,6 +99,11 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
         private void computeKeys() {
             if (!keysComputed) {
                 if (resourceLoader instanceof PropertyResolver propertyResolver) {
+                    if (TestResourcesConfiguration.isDisabled(propertyResolver)) {
+                        keys = Collections.emptyList();
+                        keysComputed = true;
+                        return;
+                    }
                     Map<String, Collection<String>> entries = producer.getPropertyEntries()
                         .stream()
                         .collect(Collectors.toMap(k -> k, propertyResolver::getPropertyEntries));

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -48,8 +48,7 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
 
     @Override
     public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader) {
-        if (TestResourcesConfiguration.isDisabled()
-                || resourceLoader instanceof PropertyResolver propertyResolver && TestResourcesConfiguration.isDisabled(propertyResolver)) {
+        if (TestResourcesConfiguration.isDisabled()) {
             return Optional.empty();
         }
         return Optional.of(new LazyPropertySource(resourceLoader));
@@ -99,11 +98,6 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
         private void computeKeys() {
             if (!keysComputed) {
                 if (resourceLoader instanceof PropertyResolver propertyResolver) {
-                    if (TestResourcesConfiguration.isDisabled(propertyResolver)) {
-                        keys = Collections.emptyList();
-                        keysComputed = true;
-                        return;
-                    }
                     Map<String, Collection<String>> entries = producer.getPropertyEntries()
                         .stream()
                         .collect(Collectors.toMap(k -> k, propertyResolver::getPropertyEntries));

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -48,6 +48,9 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
 
     @Override
     public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader) {
+        if (TestResourcesConfiguration.isDisabled()) {
+            return Optional.empty();
+        }
         return Optional.of(new LazyPropertySource(resourceLoader));
     }
 

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.testresources.core;
 
+import io.micronaut.core.value.PropertyResolver;
+
 /**
  * Shared Test Resources configuration keys.
  */
@@ -32,5 +34,14 @@ public final class TestResourcesConfiguration {
      */
     public static boolean isDisabled() {
         return "false".equalsIgnoreCase(System.getProperty(ENABLED));
+    }
+
+    /**
+     * @param propertyResolver The property resolver to inspect
+     * @return {@code true} when Test Resources have been disabled for the current application.
+     */
+    public static boolean isDisabled(PropertyResolver propertyResolver) {
+        return propertyResolver != null && propertyResolver.getProperty(ENABLED, Boolean.class).map(enabled -> !enabled).orElse(false)
+            || isDisabled();
     }
 }

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.core;
+
+/**
+ * Shared Test Resources configuration keys.
+ */
+public final class TestResourcesConfiguration {
+    /**
+     * System property used by an application runtime to disable Test Resources.
+     */
+    public static final String ENABLED = "micronaut.test.resources.enabled";
+
+    private TestResourcesConfiguration() {
+    }
+
+    /**
+     * @return {@code true} when Test Resources have been disabled for the current JVM.
+     */
+    public static boolean isDisabled() {
+        return "false".equalsIgnoreCase(System.getProperty(ENABLED));
+    }
+}

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.testresources.core
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.PropertyExpressionResolver
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
@@ -39,5 +40,33 @@ class TestResourcesConfigurationTest extends Specification {
 
         expect:
         loader.load("application", null).present
+    }
+
+    void "application config disables lazy property keys"() {
+        given:
+        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
+        def loader = new LazyTestResourcesPropertySourceLoader({ resourceLoader, propertyEntries, testResourcesConfig ->
+            throw new AssertionError("producer should not be used")
+        } as PropertyExpressionProducer)
+
+        expect:
+        loader.load(context.environment).empty
+
+        cleanup:
+        context.close()
+    }
+
+    void "application config disables lazy resolution"() {
+        given:
+        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
+        def resolver = new LazyTestResourcesExpressionResolver({ propertyResolver, conversionService, expression, requiredType ->
+            throw new AssertionError("delegate should not be used")
+        } as PropertyExpressionResolver)
+
+        expect:
+        resolver.resolve(context, null, "${LazyTestResourcesExpressionResolver.PLACEHOLDER_PREFIX}datasources.default.url", String).empty
+
+        cleanup:
+        context.close()
     }
 }

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.testresources.core
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.PropertyExpressionResolver
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
@@ -39,5 +40,33 @@ class TestResourcesConfigurationTest extends Specification {
 
         expect:
         loader.load("application", null).present
+    }
+
+    void "application config disables lazy property keys"() {
+        given:
+        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
+        def loader = new LazyTestResourcesPropertySourceLoader({ resourceLoader, propertyEntries, testResourcesConfig ->
+            throw new AssertionError("producer should not be used")
+        } as PropertyExpressionProducer)
+
+        expect:
+        loader.load("application", context.environment).empty
+
+        cleanup:
+        context.close()
+    }
+
+    void "application config disables lazy resolution"() {
+        given:
+        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
+        def resolver = new LazyTestResourcesExpressionResolver({ propertyResolver, conversionService, expression, requiredType ->
+            throw new AssertionError("delegate should not be used")
+        } as PropertyExpressionResolver)
+
+        expect:
+        resolver.resolve(context, null, "${LazyTestResourcesExpressionResolver.PLACEHOLDER_PREFIX}datasources.default.url", String).empty
+
+        cleanup:
+        context.close()
     }
 }

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.testresources.core
+
+import io.micronaut.context.env.PropertyExpressionResolver
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class TestResourcesConfigurationTest extends Specification {
+
+    @RestoreSystemProperties
+    void "system property disables lazy property source loading"() {
+        given:
+        System.setProperty(TestResourcesConfiguration.ENABLED, "false")
+        def loader = new LazyTestResourcesPropertySourceLoader({ resourceLoader, propertyEntries, testResourcesConfig ->
+            throw new AssertionError("producer should not be used")
+        } as PropertyExpressionProducer)
+
+        expect:
+        loader.load("application", null).empty
+    }
+
+    @RestoreSystemProperties
+    void "system property disables lazy expression resolution"() {
+        given:
+        System.setProperty(TestResourcesConfiguration.ENABLED, "false")
+        def resolver = new LazyTestResourcesExpressionResolver({ propertyResolver, conversionService, expression, requiredType ->
+            throw new AssertionError("delegate should not be used")
+        } as PropertyExpressionResolver)
+
+        expect:
+        resolver.resolve(null, null, "${LazyTestResourcesExpressionResolver.PLACEHOLDER_PREFIX}datasources.default.url", String).empty
+    }
+
+    @RestoreSystemProperties
+    void "lazy property source loading stays enabled by default"() {
+        given:
+        def loader = new LazyTestResourcesPropertySourceLoader({ resourceLoader, propertyEntries, testResourcesConfig ->
+            []
+        } as PropertyExpressionProducer)
+
+        expect:
+        loader.load("application", null).present
+    }
+}

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/TestResourcesConfigurationTest.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.testresources.core
 
-import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.PropertyExpressionResolver
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
@@ -40,33 +39,5 @@ class TestResourcesConfigurationTest extends Specification {
 
         expect:
         loader.load("application", null).present
-    }
-
-    void "application config disables lazy property keys"() {
-        given:
-        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
-        def loader = new LazyTestResourcesPropertySourceLoader({ resourceLoader, propertyEntries, testResourcesConfig ->
-            throw new AssertionError("producer should not be used")
-        } as PropertyExpressionProducer)
-
-        expect:
-        loader.load("application", context.environment).empty
-
-        cleanup:
-        context.close()
-    }
-
-    void "application config disables lazy resolution"() {
-        given:
-        def context = ApplicationContext.run([(TestResourcesConfiguration.ENABLED): false])
-        def resolver = new LazyTestResourcesExpressionResolver({ propertyResolver, conversionService, expression, requiredType ->
-            throw new AssertionError("delegate should not be used")
-        } as PropertyExpressionResolver)
-
-        expect:
-        resolver.resolve(context, null, "${LazyTestResourcesExpressionResolver.PLACEHOLDER_PREFIX}datasources.default.url", String).empty
-
-        cleanup:
-        context.close()
     }
 }


### PR DESCRIPTION
## Summary
- Add a JVM-level `micronaut.test.resources.enabled=false` switch for application/runtime startup.
- Skip lazy Test Resources property source loading and `auto.test.resources.*` expression resolution when disabled.
- Document the runtime disable switch for Gradle `run`/local application startup.

## Verification
- `./gradlew :micronaut-test-resources-core:test --tests io.micronaut.testresources.core.TestResourcesConfigurationTest`
- `./gradlew :micronaut-test-resources-core:check`
- `./gradlew docs`
- `./gradlew :micronaut-test-resources-client:check`

Fixes micronaut-projects/micronaut-test-resources#185

---
###### ✨ This message was AI-generated using gpt-5.5
