### PR TITLE
Allow disabling runtime test resources resolution

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -16,6 +16,8 @@ plugins {
 
 Please refer to the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#test-resources[Gradle plugin's Test Resources documentation] for more information about configuring the test resources plugin.
 
+When the Test Resources client is on the application runtime classpath but should not resolve runtime application properties, set `test-resources.enabled=false` in application configuration or `micronaut.test.resources.enabled=false` as a system property. Test execution remains enabled by default.
+
 In the case of Maven, you can enable test resources support simply by setting the property `micronaut.test.resources.enabled` (either in your
 POM or via the command-line).
 

--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/TestResourcesClientFactory.java
@@ -122,14 +122,14 @@ public final class TestResourcesClientFactory {
      * @return a new test resources client, if system properties were found.
      */
     public static Optional<TestResourcesClient> fromSystemProperties() {
-        var client = cachedClient != null ? cachedClient.get() : null;
-        if (client != null) {
-            return Optional.of(client);
-        }
         boolean enabled = Boolean.parseBoolean(System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.ENABLED), "true"));
         if (!enabled) {
             System.err.println("Test resources are disabled");
             return Optional.of(NoOpClient.INSTANCE);
+        }
+        var client = cachedClient != null ? cachedClient.get() : null;
+        if (client != null) {
+            return Optional.of(client);
         }
         String serverUri = System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.SERVER_URI));
         if (serverUri != null) {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/NoServerTestResourcesClientTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/NoServerTestResourcesClientTest.groovy
@@ -23,10 +23,39 @@ class NoServerTestResourcesClientTest extends Specification implements ClientCle
         e.message == "Test resource service is not available at $DUMMY_URL"
     }
 
-    private ApplicationContext createApplication() {
+    @RestoreSystemProperties
+    def "system property can disable test resources client"() {
+        given:
+        System.setProperty(systemPropertyNameOf(TestResourcesClient.ENABLED), "false")
+
+        when:
+        def app = createApplication()
+
+        then:
+        noExceptionThrown()
+        app.getProperty("datasources.default.url", String).empty
+
+        cleanup:
+        app?.close()
+    }
+
+    @RestoreSystemProperties
+    def "application configuration can disable test resources client"() {
+        when:
+        def app = createApplication(['test-resources.enabled': false])
+
+        then:
+        noExceptionThrown()
+        app.getProperty("datasources.default.url", String).empty
+
+        cleanup:
+        app?.close()
+    }
+
+    private ApplicationContext createApplication(Map<String, Object> properties = [:]) {
         System.setProperty(systemPropertyNameOf(TestResourcesClient.SERVER_URI), DUMMY_URL)
         def app = ApplicationContext.builder()
-                .properties(['server': 'false'])
+                .properties(['server': 'false'] + properties)
                 .start()
         assert !app.findBean(TestServer).present
         return app

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -95,10 +95,15 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
         private void computeKeys() {
             if (!keysComputed) {
                 if (resourceLoader instanceof PropertyResolver propertyResolver) {
+                    Map<String, Object> testResourcesConfig = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
+                    if (!isEnabled(testResourcesConfig)) {
+                        keys = Collections.emptyList();
+                        keysComputed = true;
+                        return;
+                    }
                     Map<String, Collection<String>> entries = producer.getPropertyEntries()
                         .stream()
                         .collect(Collectors.toMap(k -> k, propertyResolver::getPropertyEntries));
-                    Map<String, Object> testResourcesConfig = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
                     keys = producer.produceKeys(resourceLoader, entries, testResourcesConfig)
                         .stream()
                         // We use "containsProperties" here because "containsProperty"
@@ -110,6 +115,11 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
                 }
                 keysComputed = true;
             }
+        }
+
+        private boolean isEnabled(Map<String, Object> testResourcesConfig) {
+            Object enabled = testResourcesConfig.get("enabled");
+            return enabled == null || Boolean.parseBoolean(enabled.toString());
         }
 
     }


### PR DESCRIPTION
Baseline/no-CodeGraph arm for alvarosanchez/hermes-backup#20. Implements micronaut-projects/micronaut-test-resources#185.\n\nVerification (agent-reported/local):\n- ./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.NoServerTestResourcesClientTest\n- ./gradlew :micronaut-test-resources-core:test :micronaut-test-resources-client:check publishGuide\n- git diff --check\n\nThis PR is a draft disposable pilot artifact.