### PR TITLE
Allow disabling runtime test resources via configuration

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -19,4 +19,6 @@ Please refer to the https://micronaut-projects.github.io/micronaut-gradle-plugin
 In the case of Maven, you can enable test resources support simply by setting the property `micronaut.test.resources.enabled` (either in your
 POM or via the command-line).
 
+When a test resources client is on the application runtime classpath, you can disable runtime resolution without changing test behavior by setting `micronaut.test.resources.enabled=false` as a system property for the application run, or `test-resources.enabled=false` in application configuration.
+
 Please refer to the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/examples/test-resources.html[Maven plugin's Test Resources documentation] for more information about configuring the test resources plugin.

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesExpressionResolver.java
@@ -41,6 +41,9 @@ public class LazyTestResourcesExpressionResolver implements PropertyExpressionRe
                                    String expression,
                                    Class<T> requiredType) {
         if (expression.startsWith(PLACEHOLDER_PREFIX)) {
+            if (!TestResourcesConfiguration.isEnabled(propertyResolver)) {
+                return Optional.empty();
+            }
             String eagerExpression = expression.substring(PLACEHOLDER_PREFIX.length());
             var resolved = delegate.resolve(propertyResolver, conversionService, eagerExpression,
                 requiredType);

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -99,14 +99,19 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
                         .stream()
                         .collect(Collectors.toMap(k -> k, propertyResolver::getPropertyEntries));
                     Map<String, Object> testResourcesConfig = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
-                    keys = producer.produceKeys(resourceLoader, entries, testResourcesConfig)
-                        .stream()
-                        // We use "containsProperties" here because "containsProperty"
-                        // has a caching side effect which we don't want!
-                        .filter(key -> !propertyResolver.containsProperties(key))
-                        .collect(Collectors.toList());
+                    if (TestResourcesConfiguration.isEnabled(propertyResolver)) {
+                        keys = producer.produceKeys(resourceLoader, entries, testResourcesConfig)
+                            .stream()
+                            // We use "containsProperties" here because "containsProperty"
+                            // has a caching side effect which we don't want!
+                            .filter(key -> !propertyResolver.containsProperties(key))
+                            .collect(Collectors.toList());
+                    }
                 } else {
-                    keys = producer.produceKeys(resourceLoader, Collections.emptyMap(), Collections.emptyMap());
+                    Map<String, Object> testResourcesConfig = Collections.emptyMap();
+                    if (TestResourcesConfiguration.isEnabled(testResourcesConfig)) {
+                        keys = producer.produceKeys(resourceLoader, Collections.emptyMap(), testResourcesConfig);
+                    }
                 }
                 keysComputed = true;
             }

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/TestResourcesConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.core;
+
+import io.micronaut.core.value.PropertyResolver;
+
+import java.util.Map;
+import java.util.Optional;
+
+final class TestResourcesConfiguration {
+    private static final String MICRONAUT_TEST_RESOURCES_PROPERTY = "micronaut.test.resources";
+    private static final String ENABLED = "enabled";
+
+    private TestResourcesConfiguration() {
+    }
+
+    static boolean isEnabled(PropertyResolver propertyResolver) {
+        return propertyResolver.getProperty(MICRONAUT_TEST_RESOURCES_PROPERTY + "." + ENABLED, Boolean.class)
+            .or(() -> propertyResolver.getProperty(TestResourcesResolver.TEST_RESOURCES_PROPERTY + "." + ENABLED, Boolean.class))
+            .or(() -> systemPropertyEnabled())
+            .orElse(true);
+    }
+
+    static boolean isEnabled(Map<String, Object> testResourcesConfig) {
+        Object enabled = testResourcesConfig.get(ENABLED);
+        if (enabled == null) {
+            return systemPropertyEnabled().orElse(true);
+        }
+        if (enabled instanceof Boolean enabledValue) {
+            return enabledValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(enabled));
+    }
+
+    private static Optional<Boolean> systemPropertyEnabled() {
+        String enabled = System.getProperty(MICRONAUT_TEST_RESOURCES_PROPERTY + "." + ENABLED);
+        if (enabled == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Boolean.parseBoolean(enabled));
+    }
+}

--- a/test-resources-core/src/test/groovy/io/micronaut/testresources/core/LazyTestResourcesDisabledTest.groovy
+++ b/test-resources-core/src/test/groovy/io/micronaut/testresources/core/LazyTestResourcesDisabledTest.groovy
@@ -1,0 +1,190 @@
+package io.micronaut.testresources.core
+
+import io.micronaut.context.env.PropertyExpressionResolver
+import io.micronaut.core.convert.ArgumentConversionContext
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.core.value.PropertyResolver
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
+
+import java.util.stream.Stream
+
+class LazyTestResourcesDisabledTest extends Specification {
+
+    def "lazy expression resolver delegates by default"() {
+        given:
+        def delegate = new CountingExpressionResolver(Optional.of("resolved"))
+        def resolver = new LazyTestResourcesExpressionResolver(delegate)
+        def propertyResolver = new TestResourceLoader([:])
+
+        expect:
+        resolver.resolve(propertyResolver, ConversionService.SHARED, "auto.test.resources.datasources.default.url", String) == Optional.of("resolved")
+        delegate.calls == 1
+    }
+
+    @Unroll
+    @RestoreSystemProperties
+    def "lazy expression resolver does not delegate when disabled by #propertyName"() {
+        given:
+        if (systemProperty) {
+            System.setProperty(propertyName, "false")
+        }
+        def delegate = new CountingExpressionResolver(Optional.of("resolved"))
+        def resolver = new LazyTestResourcesExpressionResolver(delegate)
+        def propertyResolver = new TestResourceLoader(systemProperty ? [:] : [(propertyName): value])
+
+        expect:
+        resolver.resolve(propertyResolver, ConversionService.SHARED, "auto.test.resources.datasources.default.url", String).empty
+        delegate.calls == 0
+
+        where:
+        propertyName                         | value   | systemProperty
+        "test-resources.enabled"            | false   | false
+        "test-resources.enabled"            | "false"| false
+        "micronaut.test.resources.enabled"  | false   | false
+        "micronaut.test.resources.enabled"  | "false"| false
+        "micronaut.test.resources.enabled"  | null    | true
+    }
+
+    def "lazy property source loader produces keys by default"() {
+        given:
+        def producer = new CountingProducer(["datasources.default.url"])
+        def loader = new LazyTestResourcesPropertySourceLoader(producer)
+        def resourceLoader = new TestResourceLoader([:])
+
+        expect:
+        loader.load("test-resources", resourceLoader).orElseThrow().iterator().toList() == ["datasources.default.url"]
+        producer.calls == 1
+    }
+
+    @Unroll
+    @RestoreSystemProperties
+    def "lazy property source loader does not produce keys when disabled by #propertyName"() {
+        given:
+        if (systemProperty) {
+            System.setProperty(propertyName, "false")
+        }
+        def producer = new CountingProducer(["datasources.default.url"])
+        def loader = new LazyTestResourcesPropertySourceLoader(producer)
+        def resourceLoader = new TestResourceLoader(systemProperty ? [:] : [(propertyName): value])
+
+        expect:
+        loader.load("test-resources", resourceLoader).orElseThrow().iterator().toList() == []
+        producer.calls == 0
+
+        where:
+        propertyName                         | value   | systemProperty
+        "test-resources.enabled"            | false   | false
+        "test-resources.enabled"            | "false"| false
+        "micronaut.test.resources.enabled"  | false   | false
+        "micronaut.test.resources.enabled"  | "false"| false
+        "micronaut.test.resources.enabled"  | null    | true
+    }
+
+    private static final class CountingExpressionResolver implements PropertyExpressionResolver {
+        private final Optional<String> result
+        int calls
+
+        private CountingExpressionResolver(Optional<String> result) {
+            this.result = result
+        }
+
+        @Override
+        <T> Optional<T> resolve(PropertyResolver propertyResolver, ConversionService conversionService, String expression, Class<T> requiredType) {
+            calls++
+            result.flatMap(value -> conversionService.convert(value, requiredType))
+        }
+    }
+
+    private static final class CountingProducer implements PropertyExpressionProducer {
+        private final List<String> keys
+        int calls
+
+        private CountingProducer(List<String> keys) {
+            this.keys = keys
+        }
+
+        @Override
+        List<String> getPropertyEntries() {
+            []
+        }
+
+        @Override
+        List<String> produceKeys(ResourceLoader resourceLoader, Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+            calls++
+            keys
+        }
+    }
+
+    private static final class TestResourceLoader implements ResourceLoader, PropertyResolver {
+        private final Map<String, Object> properties
+
+        private TestResourceLoader(Map<String, Object> properties) {
+            this.properties = properties
+        }
+
+        @Override
+        boolean containsProperty(String name) {
+            properties.containsKey(name)
+        }
+
+        @Override
+        boolean containsProperties(String name) {
+            properties.keySet().any { it == name || it.startsWith("${name}.") }
+        }
+
+        @Override
+        <T> Optional<T> getProperty(String name, ArgumentConversionContext<T> conversionContext) {
+            def value = properties.get(name)
+            if (value == null) {
+                return Optional.empty()
+            }
+            ConversionService.SHARED.convert(value, conversionContext)
+        }
+
+        @Override
+        Collection<List<String>> getPropertyPathMatches(String pathPattern) {
+            []
+        }
+
+        @Override
+        Collection<String> getPropertyEntries(String name) {
+            properties.keySet()
+                .findAll { it.startsWith("${name}.") }
+                .collect { it.substring(name.length() + 1) }
+        }
+
+        @Override
+        Map<String, Object> getProperties(String name) {
+            properties.findAll { key, ignored -> key.startsWith("${name}.") }
+                .collectEntries { key, value -> [(key.substring(name.length() + 1)): value] }
+        }
+
+        @Override
+        Optional<InputStream> getResourceAsStream(String path) {
+            Optional.empty()
+        }
+
+        @Override
+        Optional<URL> getResource(String path) {
+            Optional.empty()
+        }
+
+        @Override
+        Stream<URL> getResources(String path) {
+            Stream.empty()
+        }
+
+        @Override
+        boolean supportsPrefix(String path) {
+            false
+        }
+
+        @Override
+        ResourceLoader forBase(String basePath) {
+            this
+        }
+    }
+}


### PR DESCRIPTION
CodeGraph arm for alvarosanchez/hermes-backup#20. Implements micronaut-projects/micronaut-test-resources#185.\n\nCodeGraph build used: colbymchenry/codegraph PR #973 at df8e0fe113eee020963ef3742f5f1b05d1f162c5 (version command: 1.1.0).\n\nVerification (agent-reported/local):\n- ./gradlew :micronaut-test-resources-core:test --tests io.micronaut.testresources.core.LazyTestResourcesDisabledTest\n- ./gradlew :micronaut-test-resources-core:check publishGuide\n- git diff --check\n\nThis PR is a draft disposable pilot artifact.