### PR TITLE
Allow control panel static assets through the access filter

### DIFF
--- a/test-resources-server/src/main/java/io/micronaut/testresources/server/AccessFilter.java
+++ b/test-resources-server/src/main/java/io/micronaut/testresources/server/AccessFilter.java
@@ -45,7 +45,12 @@ public class AccessFilter implements HttpServerFilter {
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
         if (request.getRemoteAddress().getAddress().isLoopbackAddress()) {
-            if (request.getPath().startsWith("/control-panel")) {
+            String path = request.getPath();
+            // The control panel page lives under /control-panel, while its static
+            // assets (CSS/JS) are served by micronaut-control-panel-ui under
+            // /micronaut-control-panel. Both must bypass the access-token check,
+            // since a browser cannot supply the Access-Token header.
+            if (path.startsWith("/control-panel") || path.startsWith("/micronaut-control-panel")) {
                 return chain.proceed(request);
             }
             String serverToken = accessConfiguration.getAccessToken();

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesServiceConfigFilesSpec.groovy
@@ -63,6 +63,31 @@ class TestResourcesServiceConfigFilesSpec extends Specification {
         process.isAlive()
     }
 
+    def "control panel page and its static assets bypass the access token"() {
+        given:
+        def portFile = tempDir.resolve("port-file")
+
+        when:
+        def process = startServer(
+            portFile,
+            [:],
+            ["-Dserver.access-token=${ACCESS_TOKEN}".toString()]
+        )
+        def port = waitForPortFile(portFile)
+
+        then: "a token-protected endpoint still rejects requests without the token"
+        request(port, [:], "/list").statusCode() == 401
+
+        and: "the control panel page is reachable without the token (a browser cannot send it)"
+        request(port, [:], "/control-panel").statusCode() != 401
+
+        and: "the control panel UI static assets, served under /micronaut-control-panel, are too"
+        request(port, [:], "/micronaut-control-panel/css/dashboard.css").statusCode() != 401
+
+        and:
+        process.isAlive()
+    }
+
     private final List<Process> runningProcesses = []
 
     private Process startServer(Path portFile, Map<String, String> environment, List<String> jvmArgs = []) {
@@ -92,9 +117,9 @@ class TestResourcesServiceConfigFilesSpec extends Specification {
         return Integer.parseInt(Files.readString(portFile).trim())
     }
 
-    private HttpResponse<String> request(int port, Map<String, String> headers = [:]) {
+    private HttpResponse<String> request(int port, Map<String, String> headers = [:], String path = "/list") {
         def requestBuilder = HttpRequest.newBuilder()
-            .uri(URI.create("http://127.0.0.1:${port}/list"))
+            .uri(URI.create("http://127.0.0.1:${port}${path}"))
             .timeout(Duration.ofSeconds(10))
             .GET()
         headers.each { name, value -> requestBuilder.header(name, value) }


### PR DESCRIPTION
Fixes #1128.

The Test Resources Control Panel loads as an unstyled, broken page in the browser: the `/control-panel` HTML returns 200, but every static asset it references returns 401 Unauthorized.

The assets are served by `micronaut-control-panel-ui` under the `/micronaut-control-panel` prefix, e.g.:

```
<link rel="stylesheet" href="/micronaut-control-panel/css/dashboard.css">
<script src="/micronaut-control-panel/js/dashboard.js"></script>
```

`AccessFilter` only whitelisted the `/control-panel` prefix, so these asset requests fell through to the access-token check. A browser cannot send the `Access-Token` header, so whenever `server.access.token` is set — the default when the server is launched by the Gradle/Maven plugins — every asset is rejected with 401.

This change also whitelists the `/micronaut-control-panel` prefix so loopback browser requests for the control panel UI assets bypass the token check, exactly as the page itself already does.

A regression test in `TestResourcesServiceConfigFilesSpec` boots the server with an access token and verifies that a token-protected endpoint (`/list`) still returns 401 without the token, while `/control-panel` and `/micronaut-control-panel/css/dashboard.css` are no longer rejected. The test fails without the production change and passes with it.
