### PR TITLE
Support disabled test resources server settings

### DIFF
--- a/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
+++ b/test-resources-build-tools/src/main/java/io/micronaut/testresources/buildtools/ServerUtils.java
@@ -69,6 +69,7 @@ public class ServerUtils {
     private static final int MAX_READS = 10;
 
     private static final String SERVER_URI = "server.uri";
+    private static final String ENABLED = "enabled";
     private static final String SERVER_ACCESS_TOKEN_MICRONAUT_PROPERTY = "server.access-token";
     private static final String SERVER_ACCESS_TOKEN = "server.access.token";
     private static final String ACCESS_TOKEN_HEADER = "Access-Token";
@@ -106,12 +107,35 @@ public class ServerUtils {
         throws IOException {
         Files.createDirectories(destinationDirectory);
         Path propertiesFile = destinationDirectory.resolve(PROPERTIES_FILE_NAME);
-        try (PrintWriter prn = new PrintWriter(Files.newOutputStream(propertiesFile))) {
+        try (PrintWriter prn = new PrintWriter(Files.newBufferedWriter(propertiesFile, StandardCharsets.UTF_8))) {
+            prn.println(ENABLED + "=true");
             prn.println(SERVER_URI + "=http\\://localhost\\:" + settings.getPort());
             settings.getAccessToken()
                 .ifPresent(token -> prn.println(SERVER_ACCESS_TOKEN + "=" + token));
             settings.getClientTimeout()
                 .ifPresent(timeout -> prn.println(SERVER_CLIENT_READ_TIMEOUT + "=" + timeout));
+            inferProjectDirectory(destinationDirectory)
+                .ifPresent(projectDirectory -> prn.println(CLIENT_PROJECT_PATH_URI + "=" + projectDirectory.toUri()));
+        }
+    }
+
+    /**
+     * Writes disabled server settings in an output directory.
+     * <p>
+     * Build tools use this when test resources are disabled for an application run
+     * but still need to leave a conventional settings file for the client-side
+     * property source loader. The client interprets {@code enabled=false} as a
+     * no-op client and does not require a server URI.
+     *
+     * @param destinationDirectory the destination directory
+     * @throws IOException if an error occurs
+     */
+    public static void writeDisabledServerSettings(Path destinationDirectory)
+        throws IOException {
+        Files.createDirectories(destinationDirectory);
+        Path propertiesFile = destinationDirectory.resolve(PROPERTIES_FILE_NAME);
+        try (PrintWriter prn = new PrintWriter(Files.newBufferedWriter(propertiesFile, StandardCharsets.UTF_8))) {
+            prn.println(ENABLED + "=false");
             inferProjectDirectory(destinationDirectory)
                 .ifPresent(projectDirectory -> prn.println(CLIENT_PROJECT_PATH_URI + "=" + projectDirectory.toUri()));
         }
@@ -129,8 +153,15 @@ public class ServerUtils {
             Properties props = new Properties();
             try (InputStream in = Files.newInputStream(propertiesFile)) {
                 props.load(in);
+                if (!Boolean.parseBoolean(props.getProperty(ENABLED, "true"))) {
+                    return Optional.empty();
+                }
+                String serverUri = props.getProperty(SERVER_URI);
+                if (serverUri == null) {
+                    return Optional.empty();
+                }
                 return Optional.of(new ServerSettings(
-                    new URI(props.getProperty(SERVER_URI)).getPort(),
+                    new URI(serverUri).getPort(),
                     props.getProperty(SERVER_ACCESS_TOKEN),
                     Optional.ofNullable(props.getProperty(SERVER_CLIENT_READ_TIMEOUT))
                         .map(Integer::parseInt)

--- a/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
+++ b/test-resources-build-tools/src/test/groovy/io/micronaut/testresources/buildtools/ServerUtilsTest.groovy
@@ -68,6 +68,24 @@ class ServerUtilsTest extends Specification {
         props.getProperty("micronaut.test.resources.project-path-uri") == projectDir.toUri().toString()
     }
 
+    def "writes disabled server settings"() {
+        given:
+        def projectDir = tmpDir.resolve("sample-project")
+        Files.createDirectories(projectDir.resolve("build/test-resources-server-config"))
+        Files.createFile(projectDir.resolve("settings.gradle"))
+        def settingsDir = projectDir.resolve("build/test-resources-server-config")
+
+        when:
+        ServerUtils.writeDisabledServerSettings(settingsDir)
+        def props = new Properties()
+        Files.newInputStream(settingsDir.resolve(ServerUtils.PROPERTIES_FILE_NAME)).withCloseable(props.&load)
+
+        then:
+        props.getProperty("enabled") == "false"
+        props.getProperty("micronaut.test.resources.project-path-uri") == projectDir.toUri().toString()
+        ServerUtils.readServerSettings(settingsDir).empty
+    }
+
     def "requires new server"() {
         def portFile = tmpDir.resolve("port-file")
         def settingsDir = tmpDir.resolve("settings")


### PR DESCRIPTION
Disposable staging CodeGraph MCP pilot artifact for alvarosanchez/hermes-backup#20.

This PR was produced by the corrected CodeGraph rerun on **staging Paperclip** (`https://staging.cliponaut.micronaut.fun`) using the `hermes-agent@cliponaut.local` Paperclip account path, after configuring Hermes with CodeGraph's MCP server (`codegraph serve --mcp`).

Pilot evidence from staging issue `DEV-1441`:
- CodeGraph installed from colbymchenry/codegraph PR #973 at `df8e0fe113eee020963ef3742f5f1b05d1f162c5`.
- `codegraph init .` ran in the assigned worktree; it indexed 312 files.
- Hermes MCP server `codegraph` was enabled and exposed native tool `codegraph_explore`.
- Run log contains native `codegraph_explore` tool usage before edits.

Verification reported by the staging agent and re-run by operator:
- `./gradlew :micronaut-test-resources-build-tools:test --tests io.micronaut.testresources.buildtools.ServerUtilsTest --no-daemon`
- `git diff --check`
- `./gradlew :micronaut-test-resources-build-tools:check --no-daemon`

Not intended for merge without maintainer review; this is an evaluation artifact.