### PR TITLE
Allow disabling test resources from application config

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -9,3 +9,6 @@ Test resources are only available during _development_ (for example when running
 A key aspect of test resources to understand is that they are created in reaction to a _missing property_ in configuration.
 For example, if the `datasources.default.url` property is missing, then a test resource will be responsible for resolving its value.
 If that property is set, then the test resource will not be used.
+
+You can disable Micronaut Test Resources for a particular application by setting `test-resources.enabled=false` in the application configuration.
+This is useful for development runs where the build tool would otherwise make the test resources client available, but the application should use only explicitly configured services.

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/TestResourcesClientPropertiesTest.groovy
@@ -36,9 +36,28 @@ class TestResourcesClientPropertiesTest extends Specification implements ClientC
         System.clearProperty("micronaut.test.resources.server.uri")
     }
 
+    @RestoreSystemProperties
+    def "application configuration can disable test resources"() {
+        System.setProperty("micronaut.test.resources.server.uri", "http://localhost:1")
+
+        when:
+        def app = createApplication('test-resources.enabled': false)
+
+        then:
+        app.getProperty("dummy1", String).empty
+        app.getProperty("dummy2", String).empty
+
+        cleanup:
+        System.clearProperty("micronaut.test.resources.server.uri")
+    }
+
     private ApplicationContext createApplication() {
+        createApplication([:])
+    }
+
+    private ApplicationContext createApplication(Map<String, Object> properties) {
         def app = ApplicationContext.builder()
-                .properties(['server': 'false'])
+                .properties(['server': 'false'] + properties)
                 .start()
         assert !app.findBean(TestServer).present
         return app

--- a/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
+++ b/test-resources-core/src/main/java/io/micronaut/testresources/core/LazyTestResourcesPropertySourceLoader.java
@@ -95,10 +95,15 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
         private void computeKeys() {
             if (!keysComputed) {
                 if (resourceLoader instanceof PropertyResolver propertyResolver) {
+                    Map<String, Object> testResourcesConfig = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
+                    if (!isEnabled(testResourcesConfig)) {
+                        keys = Collections.emptyList();
+                        keysComputed = true;
+                        return;
+                    }
                     Map<String, Collection<String>> entries = producer.getPropertyEntries()
                         .stream()
                         .collect(Collectors.toMap(k -> k, propertyResolver::getPropertyEntries));
-                    Map<String, Object> testResourcesConfig = propertyResolver.getProperties(TestResourcesResolver.TEST_RESOURCES_PROPERTY);
                     keys = producer.produceKeys(resourceLoader, entries, testResourcesConfig)
                         .stream()
                         // We use "containsProperties" here because "containsProperty"
@@ -110,6 +115,17 @@ public class LazyTestResourcesPropertySourceLoader implements PropertySourceLoad
                 }
                 keysComputed = true;
             }
+        }
+
+        private boolean isEnabled(Map<String, Object> testResourcesConfig) {
+            Object enabled = testResourcesConfig.get("enabled");
+            if (enabled == null) {
+                return true;
+            }
+            if (enabled instanceof Boolean b) {
+                return b;
+            }
+            return Boolean.parseBoolean(String.valueOf(enabled));
         }
 
     }


### PR DESCRIPTION
Disposable staging baseline/no-CodeGraph pilot artifact for alvarosanchez/hermes-backup#20.

This PR was produced by the baseline control run on **staging Paperclip** (`https://staging.cliponaut.micronaut.fun`) using normal Hermes/Paperclip repository tools only. CodeGraph MCP was disabled for this control arm.

Pilot evidence from staging issue `DEV-1442`:
- No CodeGraph MCP server configured during the baseline run (`hermes -p paperclip mcp list` returned no MCP servers before the issue was assigned).
- Local agent branch/commit: `DEV-baseline-staging-test-resources-185` at `ee9b3fff` (`Allow disabling test resources from application config`).
- Change: `test-resources.enabled=false` in application config now prevents lazy test-resource property key production before the client is created, so a Gradle/Maven development run can opt the application out of test-resource resolution.

Verification reported by the staging agent:
- `./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.TestResourcesClientPropertiesTest`
- `./gradlew :micronaut-test-resources-core:test --tests io.micronaut.testresources.core.ToggableTestResourcesResolverTest :micronaut-test-resources-client:check`
- `./gradlew :micronaut-test-resources-core:check`
- `./gradlew publishGuide`

Operator re-ran a bounded verification subset before PR creation:
- `./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.TestResourcesClientPropertiesTest --no-daemon`
- `./gradlew :micronaut-test-resources-core:test --tests io.micronaut.testresources.core.ToggableTestResourcesResolverTest :micronaut-test-resources-client:check --no-daemon`
- `git diff --check`

Not intended for merge without maintainer review; this is an evaluation artifact.

Fixes #185