### PR TITLE
docs: clarify Localstack property-triggered container provisioning

### DIFF
--- a/src/main/docs/guide/modules-localstack.adoc
+++ b/src/main/docs/guide/modules-localstack.adoc
@@ -2,7 +2,9 @@ Micronaut Test Resources supports a subset of https://localstack.cloud/[Localsta
 
 The default image (`{default-image-localstack}`) can be overwritten by setting the `test-resources.containers.localstack.image-name` property.
 
-The following services are supported:
+The Localstack container is provisioned through property resolution: Test Resources detects when your application looks up one of the properties below and no value has been configured, for example, a bean resolving `aws.services.s3.endpoint-override`, and treats that missing lookup as the signal to start the container and supply the value on demand. This means the container will only spin up when a bean or configuration actively attempts to resolve an overridden AWS service endpoint.
+
+The following services are supported, each triggered by requesting its corresponding property:
 
 - S3, by providing the `aws.services.s3.endpoint-override` property
 - DynamoDB, by providing the `aws.services.dynamodb.endpoint-override` property


### PR DESCRIPTION
## What
Adds a note to the Localstack module documentation explaining how the container gets provisioned.

## Why
The documentation listed which properties trigger which AWS services, but never explained the underlying mechanism. Users assumed classpath-based inference had failed when a Localstack service did not start automatically, when in fact the module is intentionally property-triggered rather than classpath-triggered. See #1095 for the original report and context.

## How I verified this
Read the actual provider implementation before writing the docs change, not just going by the issue description:
- `AbstractAwsTestResourceProvider` and `AbstractTestContainersProvider.resolve()` confirm the container is only created when `shouldAnswer()` matches a requested property name with no existing value, not from classpath presence.
- Compared against `KafkaTestResourceProvider` to confirm this lazy, property-triggered mechanism is the shared base behavior, so the doc wording avoids incorrectly implying Localstack is unique in this regard.
- Built the full guide locally with `./gradlew publishGuide` (JDK 25+), confirmed `modules-localstack.adoc` renders cleanly with no warnings, and checked the rendered HTML output directly.

Fixes #1095