### PR TITLE
Recreate stopped cached Testcontainers

### DIFF
--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
@@ -112,6 +112,10 @@ public final class TestContainers {
         return withKey(Key.of(owner, name, Scope.from(query), query), key -> {
             try {
                 T container = withMapLock("getOrCreate", () -> (T) CONTAINERS_BY_KEY.get(key));
+                if (container != null && container.getContainerId() != null && !isRunning(container)) {
+                    removeCachedContainer(key, container);
+                    container = null;
+                }
                 var dockerImageName = imageNameSupplier.get();
                 if (container == null) {
                     notifyStartOperation(PULLING, dockerImageName);
@@ -148,6 +152,30 @@ public final class TestContainers {
                 throw new TestResourcesResolutionException(message);
             }
         });
+    }
+
+    private static boolean isRunning(GenericContainer<?> container) {
+        try {
+            return container.isRunning();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Unable to inspect cached container {}; recreating it", container.getContainerId(), e);
+            return false;
+        }
+    }
+
+    private static void removeCachedContainer(Key key, GenericContainer<?> container) {
+        withMapLock("removeCachedContainer", () -> {
+            if (CONTAINERS_BY_KEY.get(key) == container) {
+                CONTAINERS_BY_KEY.remove(key);
+                CONTAINERS_BY_PROPERTY.values().forEach(containers -> containers.remove(container));
+            }
+            return null;
+        });
+        try {
+            container.close();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Unable to close stale cached container {}", container.getContainerId(), e);
+        }
     }
 
     private static void notifyStartOperation(Map<DockerImageName, AtomicInteger> operation, DockerImageName dockerImageName) {

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
@@ -2,7 +2,10 @@ package io.micronaut.testresources.testcontainers
 
 import io.micronaut.testresources.core.Scope
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class TestContainersTest extends Specification {
 
@@ -59,6 +62,30 @@ class TestContainersTest extends Specification {
                 (Scope.of(null)): [container1],
                 (Scope.of("child")) : [container2]
         ]
+    }
+
+    def "recreates a cached container which is no longer running"() {
+        given:
+        def created = new AtomicInteger()
+        def first = Stub(GenericContainer) {
+            getContainerId() >> "stale"
+            isRunning() >> false
+        }
+        def second = Stub(GenericContainer) {
+            getContainerId() >> "fresh"
+            isRunning() >> true
+        }
+        def containers = [first, second]
+
+        when:
+        2.times {
+            TestContainers.getOrCreate("foo", TestContainersTest, "stale", [:],
+                    { DockerImageName.parse("alpine:3.20") }) { containers[created.getAndIncrement()] }
+        }
+
+        then:
+        created.get() == 2
+        TestContainers.listAll().values().flatten() == [second]
     }
 
     void create(String name, String scope, GenericContainer container) {


### PR DESCRIPTION
Do not reuse a cached Testcontainer after its process has stopped. Remove the stale cache entry and recreate the resource while preserving the existing scoped container lifecycle.

Tests:
`JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.0.3.jdk/Contents/Home ./gradlew :micronaut-test-resources-testcontainers:test --tests io.micronaut.testresources.testcontainers.TestContainersTest --rerun-tasks --stacktrace`