### PR TITLE
Retry transient Test Resources client failures

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
@@ -20,13 +20,16 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.JsonMapper;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,6 +58,8 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
     private static final Argument<Boolean> BOOLEAN = Argument.BOOLEAN;
     private static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
     private static final String INTERNAL_SERVER_ERROR_PREFIX = INTERNAL_SERVER_ERROR + ": ";    
+    private static final int MAX_TRANSIENT_ATTEMPTS = 3;
+    private static final long TRANSIENT_RETRY_DELAY_MILLIS = 250;
 
     private final JsonMapper jsonMapper;
     private final String baseUri;
@@ -137,7 +142,24 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
         }
         config.accept(request);
         try {
-            var response = client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+            var requestValue = request.build();
+            HttpResponse<String> response = null;
+            for (int attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt++) {
+                try {
+                    response = client.send(requestValue, HttpResponse.BodyHandlers.ofString());
+                    break;
+                } catch (IOException e) {
+                    if (!isTransient(e) || attempt == MAX_TRANSIENT_ATTEMPTS) {
+                        throw e;
+                    }
+                    try {
+                        Thread.sleep(TRANSIENT_RETRY_DELAY_MILLIS);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new TestResourcesException(interrupted);
+                    }
+                }
+            }
             var body = response.body();
             if (response.statusCode() == 200) {
                 if (STRING.equalsType(type)) {
@@ -159,6 +181,20 @@ public class DefaultTestResourcesClient implements TestResourcesClient {
             Thread.currentThread().interrupt();
             throw new TestResourcesException(e);
         }
+    }
+
+    private static boolean isTransient(IOException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof HttpTimeoutException
+                || current instanceof ConnectException
+                || current instanceof SocketException
+                || current instanceof EOFException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private <T> T handleError(SimpleJsonErrorModel model) {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.testresources.client
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import spock.lang.Specification
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+class DefaultTestResourcesClientRetryTest extends Specification {
+    private HttpServer server
+
+    def cleanup() {
+        server?.stop(0)
+    }
+
+    def "retries a transient connection failure while resolving a property"() {
+        given:
+        def attempts = new AtomicInteger()
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+        server.createContext("/resolve") { HttpExchange exchange ->
+            if (attempts.getAndIncrement() == 0) {
+                exchange.close()
+                return
+            }
+            def body = 'resolved'.bytes
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.length)
+            exchange.responseBody.withCloseable { it.write(body) }
+        }
+        server.start()
+        def client = new DefaultTestResourcesClient("http://localhost:${server.address.port}", null, 10)
+
+        expect:
+        client.resolve("name", [:], [:]).get() == "resolved"
+        attempts.get() == 2
+    }
+}


### PR DESCRIPTION
Retry transient HTTP connection failures while resolving Test Resources properties. The retry recognizes timeout, connection, socket, and EOF failures and preserves interruption behavior.

Tests:
`JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-21.0.3.jdk/Contents/Home ./gradlew :micronaut-test-resources-client:test --tests io.micronaut.testresources.client.DefaultTestResourcesClientRetryTest --rerun-tasks --stacktrace`