### PR TITLE
Pin LocalStack and Elasticsearch test images

### DIFF
--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -33,7 +33,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     public static final String ELASTICSEARCH_HOSTS = "elasticsearch.http-hosts";
     public static final String SIMPLE_NAME = "elasticsearch";
     public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
-    public static final String DEFAULT_TAG = "8.4.3";
+    public static final String DEFAULT_TAG = "8.15.5";
     public static final String DISPLAY_NAME = "Elasticsearch";
 
     @Override

--- a/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
+++ b/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
@@ -12,6 +12,7 @@ class ElasticsearchStartedTest extends AbstractElasticsearchSpec {
 
         then:
         info.clusterName() != null
+        runningTestContainers().first().image == "docker.elastic.co/elasticsearch/elasticsearch:8.15.5"
     }
 
 }

--- a/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackTestResourceProvider.java
+++ b/test-resources-localstack/test-resources-localstack-core/src/main/java/io/micronaut/testresources/localstack/LocalStackTestResourceProvider.java
@@ -38,7 +38,7 @@ import java.util.stream.StreamSupport;
  */
 public class LocalStackTestResourceProvider extends AbstractTestContainersProvider<LocalStackContainer> {
 
-    private static final String DEFAULT_IMAGE = "localstack/localstack";
+    private static final String DEFAULT_IMAGE = "localstack/localstack:3.8.1";
     private static final String NAME = "localstack";
 
     private static final String AWS_ACCESS_KEY_ID = "aws.access-key-id";

--- a/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/localstack/s3/LocalStackS3Test.groovy
+++ b/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/localstack/s3/LocalStackS3Test.groovy
@@ -39,6 +39,7 @@ class LocalStackS3Test extends AbstractLocalStackSpec {
 
         and:
         listContainers().size() == 1
+        listContainers().first().image == 'localstack/localstack:3.8.1'
     }
 
     private S3Client buildClient() {


### PR DESCRIPTION
The Test Resources CI matrix currently has two environment-sensitive container failures:

* untagged `localstack/localstack` resolves to 2026.8.1, which exits with a license activation error unless `LOCALSTACK_AUTH_TOKEN` is configured;
* Elasticsearch `8.4.3` repeatedly logs `CgroupInfo.getMountPoint() ... anyController is null` under Java 21 hosted cgroups and then times out.

Pin the defaults to `localstack/localstack:3.8.1` (OSS) and `docker.elastic.co/elasticsearch/elasticsearch:8.15.5` (Java 21-compatible), while retaining the existing image and tag configuration overrides. Add regression assertions for both defaults.

Verified locally with Docker 29.5.3 and Java 21:
* `./gradlew :micronaut-test-resources-localstack-s3:test --tests io.micronaut.testresources.localstack.s3.LocalStackS3Test --no-daemon --console=plain`
* `./gradlew :micronaut-test-resources-elasticsearch:test --tests io.micronaut.testresources.elasticsearch.ElasticsearchStartedTest --no-daemon --console=plain`

Both tests pass. OSS Index scan failures in CI are pre-existing dependency advisories and are unrelated to these image pins.