### PR TITLE
Use an Elasticsearch image compatible with Java 21 cgroups

### DIFF
--- a/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
+++ b/test-resources-elasticsearch/src/main/java/io/micronaut/testresources/elasticsearch/ElasticsearchTestResourceProvider.java
@@ -33,7 +33,7 @@ public class ElasticsearchTestResourceProvider extends AbstractTestContainersPro
     public static final String ELASTICSEARCH_HOSTS = "elasticsearch.http-hosts";
     public static final String SIMPLE_NAME = "elasticsearch";
     public static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
-    public static final String DEFAULT_TAG = "8.4.3";
+    public static final String DEFAULT_TAG = "8.15.5";
     public static final String DISPLAY_NAME = "Elasticsearch";
 
     @Override

--- a/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
+++ b/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
@@ -12,6 +12,7 @@ class ElasticsearchStartedTest extends AbstractElasticsearchSpec {
 
         then:
         info.clusterName() != null
+        runningTestContainers().first().image == "docker.elastic.co/elasticsearch/elasticsearch:8.15.5"
     }
 
 }


### PR DESCRIPTION
Test Resources CI on Java 21 fails while starting the default Elasticsearch `8.4.3` image. The bundled JVM repeatedly logs `Could not reconfigure JMX ... CgroupInfo.getMountPoint() ... anyController is null` on hosted runners, then the Testcontainers log wait strategy times out.

Pin the default image tag to `8.15.5`, which starts successfully under the same cgroup layout, while retaining the existing image/tag configuration overrides. Add a regression assertion for the default image.

Verified locally with Docker 29.5.3 and Java 21:
`./gradlew :micronaut-test-resources-elasticsearch:test --tests io.micronaut.testresources.elasticsearch.ElasticsearchStartedTest --no-daemon --console=plain`

Result: 1 test passed.