### PR TITLE
Harden Test Resources container reuse and client retries

### DIFF
--- a/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
+++ b/test-resources-client/src/main/java/io/micronaut/testresources/client/DefaultTestResourcesClient.java
@@ -24,14 +24,17 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
@@ -65,6 +68,8 @@ public final class DefaultTestResourcesClient implements TestResourcesClient {
     private static final Argument<List<String>> LIST_OF_STRING = Argument.LIST_OF_STRING;
     private static final Argument<String> STRING = Argument.STRING;
     private static final Argument<Boolean> BOOLEAN = Argument.BOOLEAN;
+    private static final int MAX_TRANSIENT_ATTEMPTS = 3;
+    private static final long TRANSIENT_RETRY_DELAY_MILLIS = 250;
 
     private final String baseUri;
     private final HttpClient client;
@@ -167,7 +172,24 @@ public final class DefaultTestResourcesClient implements TestResourcesClient {
         }
         config.accept(request);
         try {
-            var response = client.send(request.build(), HttpResponse.BodyHandlers.ofByteArray());
+            var requestValue = request.build();
+            HttpResponse<byte[]> response = null;
+            for (int attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt++) {
+                try {
+                    response = client.send(requestValue, HttpResponse.BodyHandlers.ofByteArray());
+                    break;
+                } catch (IOException e) {
+                    if (!isTransient(e) || attempt == MAX_TRANSIENT_ATTEMPTS) {
+                        throw e;
+                    }
+                    try {
+                        Thread.sleep(TRANSIENT_RETRY_DELAY_MILLIS);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new TestResourcesException(interrupted);
+                    }
+                }
+            }
             var body = response.body();
             if (response.statusCode() == 200) {
                 return decodeResponse(body, type);
@@ -225,6 +247,20 @@ public final class DefaultTestResourcesClient implements TestResourcesClient {
             return Map.of(MESSAGE_KEY, matcher.group(1));
         }
         return Map.of(MESSAGE_KEY, text);
+    }
+
+    private static boolean isTransient(IOException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof HttpTimeoutException
+                || current instanceof ConnectException
+                || current instanceof SocketException
+                || current instanceof EOFException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private <T> T handleError(@Nullable Object payload) {

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.testresources.client
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import spock.lang.Specification
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+class DefaultTestResourcesClientRetryTest extends Specification {
+    private HttpServer server
+
+    def cleanup() {
+        server?.stop(0)
+    }
+
+    def "retries a transient connection failure while resolving a property"() {
+        given:
+        def attempts = new AtomicInteger()
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+        server.createContext("/resolve") { HttpExchange exchange ->
+            if (attempts.getAndIncrement() == 0) {
+                exchange.close()
+                return
+            }
+            def body = 'resolved'.bytes
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.length)
+            exchange.responseBody.withCloseable { it.write(body) }
+        }
+        server.start()
+        def client = new DefaultTestResourcesClient("http://localhost:${server.address.port}", null, 10)
+
+        expect:
+        client.resolve("name", [:], [:]).get() == "resolved"
+        attempts.get() == 2
+    }
+}

--- a/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
+++ b/test-resources-client/src/test/groovy/io/micronaut/testresources/client/DefaultTestResourcesClientRetryTest.groovy
@@ -2,8 +2,10 @@ package io.micronaut.testresources.client
 
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
+import io.micronaut.testresources.codec.TestResourcesCodec
 import spock.lang.Specification
 
+import java.io.ByteArrayOutputStream
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -23,7 +25,9 @@ class DefaultTestResourcesClientRetryTest extends Specification {
                 exchange.close()
                 return
             }
-            def body = 'resolved'.bytes
+            def output = new ByteArrayOutputStream()
+            TestResourcesCodec.writeValue('resolved', output)
+            def body = output.toByteArray()
             exchange.responseHeaders.add("Content-Type", "application/json")
             exchange.sendResponseHeaders(200, body.length)
             exchange.responseBody.withCloseable { it.write(body) }

--- a/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
+++ b/test-resources-elasticsearch/src/test/groovy/io/micronaut/testresources/elasticsearch/ElasticsearchStartedTest.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.testresources.elasticsearch
 
+import io.micronaut.testresources.core.DefaultTestResourceImages
+
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 
 @MicronautTest
@@ -12,6 +14,7 @@ class ElasticsearchStartedTest extends AbstractElasticsearchSpec {
 
         then:
         info.clusterName() != null
+        runningTestContainers().first().image == DefaultTestResourceImages.DEFAULT_ELASTICSEARCH_IMAGE
     }
 
 }

--- a/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/localstack/s3/LocalStackS3Test.groovy
+++ b/test-resources-localstack/test-resources-localstack-s3/src/test/groovy/io/micronaut/testresources/localstack/s3/LocalStackS3Test.groovy
@@ -3,6 +3,7 @@ package io.micronaut.testresources.localstack.s3
 import io.micronaut.context.annotation.ConfigurationBuilder
 import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.core.DefaultTestResourceImages
 import io.micronaut.testresources.localstack.AbstractLocalStackSpec
 import jakarta.inject.Inject
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -39,6 +40,7 @@ class LocalStackS3Test extends AbstractLocalStackSpec {
 
         and:
         listContainers().size() == 1
+        listContainers().first().image == DefaultTestResourceImages.DEFAULT_LOCALSTACK_IMAGE
     }
 
     private S3Client buildClient() {

--- a/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
+++ b/test-resources-testcontainers/src/main/java/io/micronaut/testresources/testcontainers/TestContainers.java
@@ -118,6 +118,10 @@ public final class TestContainers {
         return withKey(Key.of(owner, name, scope, query), key -> {
             try {
                 T container = withMapLock("getOrCreate", () -> (T) CONTAINERS_BY_KEY.get(key));
+                if (container != null && container.getContainerId() != null && !isRunning(container)) {
+                    removeCachedContainer(key, container);
+                    container = null;
+                }
                 var dockerImageName = imageNameSupplier.get();
                 if (container == null) {
                     notifyStartOperation(PULLING, dockerImageName);
@@ -158,6 +162,30 @@ public final class TestContainers {
                 throw new TestResourcesResolutionException(message);
             }
         });
+    }
+
+    private static boolean isRunning(GenericContainer<?> container) {
+        try {
+            return container.isRunning();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Unable to inspect cached container {}; recreating it", container.getContainerId(), e);
+            return false;
+        }
+    }
+
+    private static void removeCachedContainer(Key key, GenericContainer<?> container) {
+        withMapLock("removeCachedContainer", () -> {
+            if (CONTAINERS_BY_KEY.get(key) == container) {
+                CONTAINERS_BY_KEY.remove(key);
+                CONTAINERS_BY_PROPERTY.values().forEach(containers -> containers.remove(container));
+            }
+            return null;
+        });
+        try {
+            container.close();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Unable to close stale cached container {}", container.getContainerId(), e);
+        }
     }
 
     private static void notifyStartOperation(Map<DockerImageName, AtomicInteger> operation, DockerImageName dockerImageName) {

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
@@ -65,7 +65,10 @@ class TestContainersTest extends Specification {
     }
 
     def "normalized container identity can reuse a container across requested properties"() {
-        def container = Stub(GenericContainer)
+        def container = Stub(GenericContainer) {
+            getContainerId() >> "running"
+            isRunning() >> true
+        }
         int created = 0
 
         when:
@@ -177,7 +180,7 @@ class TestContainersTest extends Specification {
 
         when:
         2.times {
-            TestContainers.getOrCreate("foo", TestContainersTest, "stale", [:],
+            TestContainers.getOrCreate("foo", TestContainersTest.name, "stale", Scope.ROOT, [:],
                     { DockerImageName.parse("alpine:3.20") }) { containers[created.getAndIncrement()] }
         }
 

--- a/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
+++ b/test-resources-testcontainers/src/test/groovy/io/micronaut/testresources/testcontainers/TestContainersTest.groovy
@@ -2,7 +2,10 @@ package io.micronaut.testresources.testcontainers
 
 import io.micronaut.testresources.core.Scope
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class TestContainersTest extends Specification {
 
@@ -157,6 +160,30 @@ class TestContainersTest extends Specification {
         then:
         created == 1
         TestContainers.hasDatabase(container, "shared_db")
+    }
+
+    def "recreates a cached container which is no longer running"() {
+        given:
+        def created = new AtomicInteger()
+        def first = Stub(GenericContainer) {
+            getContainerId() >> "stale"
+            isRunning() >> false
+        }
+        def second = Stub(GenericContainer) {
+            getContainerId() >> "fresh"
+            isRunning() >> true
+        }
+        def containers = [first, second]
+
+        when:
+        2.times {
+            TestContainers.getOrCreate("foo", TestContainersTest, "stale", [:],
+                    { DockerImageName.parse("alpine:3.20") }) { containers[created.getAndIncrement()] }
+        }
+
+        then:
+        created.get() == 2
+        TestContainers.listAll().values().flatten() == [second]
     }
 
     void create(String name, String scope, GenericContainer container) {


### PR DESCRIPTION
This single 4.2.x PR combines the stale-container lifecycle fix and transient client retry fix. The 4.2.x line already contains the current OSS image defaults (LocalStack 4.14.0 and Elasticsearch 9.5.2), so the old 3.0.x image-pin implementation is represented by focused image assertions without regressing the newer defaults.

Crema/native rationale: native Pyronaut guides exercise Test Resources through Docker and expose readiness races that JVM-only guide runs do not. A stopped cached container previously reused dead mapped ports; transient timeout/reset/EOF responses during property resolution failed before guide assertions.

Observed failures:

- `connection reset`
- `EOF`
- client read timeouts
- LocalStack `2026.8.1`: `License activation failed ... No credentials were found`
- Elasticsearch `8.4.3`: `CgroupInfo.getMountPoint() ... anyController is null` under Java 21 cgroups

The 4.2.x catalog already carries the current Micronaut 5.1.11 platform and transitive security upgrades; no unnecessary dependency override is added. The 3.0.x OSS Index findings therefore do not apply to this 4.2.x target.

Tests:

- `:micronaut-test-resources-client:test --tests io.micronaut.testresources.client.DefaultTestResourcesClientRetryTest` — 1/1
- `:micronaut-test-resources-testcontainers:test --tests io.micronaut.testresources.testcontainers.TestContainersTest` — 9/9
- `:micronaut-test-resources-localstack-s3:test --tests io.micronaut.testresources.localstack.s3.LocalStackS3Test` — 1/1 (Docker)
- Elasticsearch is not included in the 4.2.x settings because that module is currently disabled pending the Micronaut 5 milestone.
