### PR TITLE
Keep colons in server error messages

### DIFF
--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -57,6 +58,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     public static final String SIMPLE_NAME = "kafka";
     private static final long ADMIN_TIMEOUT_SECONDS = 30;
     private static final int ADMIN_METADATA_ATTEMPTS = 3;
+    private static final long UNKNOWN_TOPIC_RETRY_DELAY_MILLIS = 1000;
     private static final TopicProvisioningConfiguration NO_TOPICS =
         new TopicProvisioningConfiguration(Collections.emptyList(), DEFAULT_PARTITIONS);
 
@@ -215,12 +217,26 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     static <T> T retryMetadataRequest(AdminMetadataRequest<T> request)
         throws ExecutionException, InterruptedException, TimeoutException {
         TimeoutException lastTimeout = new TimeoutException();
+        ExecutionException lastUnknownTopic = null;
         for (int attempt = 0; attempt < ADMIN_METADATA_ATTEMPTS; attempt++) {
             try {
                 return request.execute();
             } catch (TimeoutException e) {
                 lastTimeout = e;
+                lastUnknownTopic = null;
+            } catch (ExecutionException e) {
+                if (!(e.getCause() instanceof UnknownTopicOrPartitionException)) {
+                    throw e;
+                }
+                // A topic the controller already knows may not have reached the broker's metadata yet
+                lastUnknownTopic = e;
+                if (attempt < ADMIN_METADATA_ATTEMPTS - 1) {
+                    Thread.sleep(UNKNOWN_TOPIC_RETRY_DELAY_MILLIS);
+                }
             }
+        }
+        if (lastUnknownTopic != null) {
+            throw lastUnknownTopic;
         }
         throw lastTimeout;
     }

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -58,7 +57,6 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     public static final String SIMPLE_NAME = "kafka";
     private static final long ADMIN_TIMEOUT_SECONDS = 30;
     private static final int ADMIN_METADATA_ATTEMPTS = 3;
-    private static final long UNKNOWN_TOPIC_RETRY_DELAY_MILLIS = 1000;
     private static final TopicProvisioningConfiguration NO_TOPICS =
         new TopicProvisioningConfiguration(Collections.emptyList(), DEFAULT_PARTITIONS);
 
@@ -217,26 +215,12 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     static <T> T retryMetadataRequest(AdminMetadataRequest<T> request)
         throws ExecutionException, InterruptedException, TimeoutException {
         TimeoutException lastTimeout = new TimeoutException();
-        ExecutionException lastUnknownTopic = null;
         for (int attempt = 0; attempt < ADMIN_METADATA_ATTEMPTS; attempt++) {
             try {
                 return request.execute();
             } catch (TimeoutException e) {
                 lastTimeout = e;
-                lastUnknownTopic = null;
-            } catch (ExecutionException e) {
-                if (!(e.getCause() instanceof UnknownTopicOrPartitionException)) {
-                    throw e;
-                }
-                // A topic the controller already knows may not have reached the broker's metadata yet
-                lastUnknownTopic = e;
-                if (attempt < ADMIN_METADATA_ATTEMPTS - 1) {
-                    Thread.sleep(UNKNOWN_TOPIC_RETRY_DELAY_MILLIS);
-                }
             }
-        }
-        if (lastUnknownTopic != null) {
-            throw lastUnknownTopic;
         }
         throw lastTimeout;
     }

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -152,6 +152,17 @@ class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvis
 }
 
 class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
+    /**
+     * Shares the broker cached for {@link KafkaTestResourceProvider} in the same scope,
+     * instead of starting a second broker with the same network alias.
+     */
+    @Override
+    protected String getContainerOwnerKey(String propertyName,
+                                          Map<String, Object> properties,
+                                          Map<String, Object> testResourcesConfig) {
+        KafkaTestResourceProvider.name
+    }
+
     @Override
     protected void beforeCreateTopics(org.testcontainers.kafka.KafkaContainer container,
                                       TopicProvisioningConfiguration configuration,
@@ -160,7 +171,7 @@ class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
         properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, container.bootstrapServers)
         NewTopic topic = new NewTopic(topicsToCreate.first().name(), 1, (short) 1)
         try (AdminClient adminClient = AdminClient.create(properties)) {
-            adminClient.listTopics().names().get(30, TimeUnit.SECONDS)
+            KafkaTestResourceProvider.listTopicNames(adminClient)
             adminClient.createTopics([topic]).all().get(30, TimeUnit.SECONDS)
         } catch (ExecutionException e) {
             throw new AssertionError("Failed to create the racing Kafka topic", e)
@@ -261,6 +272,55 @@ class KafkaInvalidTopicProvisioningConfigTest extends AbstractKafkaSpec {
         def e = thrown(TimeoutException)
         e.message == "timeout-3"
         attempts.get() == 3
+    }
+
+    def "retries Kafka metadata requests while the broker does not know the topic yet"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        def result = KafkaTestResourceProvider.retryMetadataRequest({
+            if (attempts.incrementAndGet() == 1) {
+                throw new ExecutionException(new org.apache.kafka.common.errors.UnknownTopicOrPartitionException("not yet"))
+            }
+            "metadata"
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        result == "metadata"
+        attempts.get() == 2
+    }
+
+    def "rethrows an unknown topic failure when Kafka metadata retries are exhausted"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        KafkaTestResourceProvider.retryMetadataRequest({
+            attempts.incrementAndGet()
+            throw new ExecutionException(new org.apache.kafka.common.errors.UnknownTopicOrPartitionException("missing"))
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        def e = thrown(ExecutionException)
+        e.cause instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+        attempts.get() == 3
+    }
+
+    def "does not retry other Kafka metadata failures"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        KafkaTestResourceProvider.retryMetadataRequest({
+            attempts.incrementAndGet()
+            throw new ExecutionException(new IllegalStateException("broken"))
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        def e = thrown(ExecutionException)
+        e.cause.message == "broken"
+        attempts.get() == 1
     }
 }
 

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -44,6 +44,32 @@ abstract class AbstractKafkaTopicProvisioningSpec extends AbstractKafkaSpec {
             throw new AssertionError("Timed out after ${ADMIN_TIMEOUT_SECONDS}s describing Kafka topics ${topicNames.toList()} for ${bootstrapServers}", e)
         }
     }
+
+    /**
+     * Waits until the broker can describe the topics. The broker's metadata can trail the
+     * controller right after a topic is created, which makes describing it fail with
+     * {@link org.apache.kafka.common.errors.UnknownTopicOrPartitionException}.
+     */
+    static void awaitTopicsKnownToBroker(String bootstrapServers, String... topicNames) {
+        Properties properties = new Properties()
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(ADMIN_TIMEOUT_SECONDS)
+        try (AdminClient adminClient = AdminClient.create(properties)) {
+            while (true) {
+                try {
+                    adminClient.describeTopics(topicNames.toList()).allTopicNames().get(ADMIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    return
+                } catch (ExecutionException e) {
+                    if (!(e.cause instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) || System.nanoTime() > deadline) {
+                        throw new AssertionError("Kafka topics ${topicNames.toList()} did not become known to the broker at ${bootstrapServers}", e)
+                    }
+                    Thread.sleep(200)
+                }
+            }
+        } catch (TimeoutException e) {
+            throw new AssertionError("Timed out after ${ADMIN_TIMEOUT_SECONDS}s waiting for Kafka topics ${topicNames.toList()} at ${bootstrapServers}", e)
+        }
+    }
 }
 
 @MicronautTest
@@ -121,6 +147,7 @@ class KafkaReusedContainerTopicProvisioningTest extends AbstractKafkaTopicProvis
             (KafkaTestResourceProvider.KAFKA_TOPICS)    : "payments",
             (KafkaTestResourceProvider.KAFKA_PARTITIONS): "1"
         ]).orElseThrow()
+        awaitTopicsKnownToBroker(bootstrapServers, "payments")
         provider.resolve(KafkaTestResourceProvider.KAFKA_BOOTSTRAP_SERVERS, requestedProperties, [
             (KafkaTestResourceProvider.KAFKA_TOPICS)    : "payments",
             (KafkaTestResourceProvider.KAFKA_PARTITIONS): "3"
@@ -173,6 +200,7 @@ class RacingKafkaTestResourceProvider extends KafkaTestResourceProvider {
         try (AdminClient adminClient = AdminClient.create(properties)) {
             KafkaTestResourceProvider.listTopicNames(adminClient)
             adminClient.createTopics([topic]).all().get(30, TimeUnit.SECONDS)
+            AbstractKafkaTopicProvisioningSpec.awaitTopicsKnownToBroker(container.bootstrapServers, topic.name())
         } catch (ExecutionException e) {
             throw new AssertionError("Failed to create the racing Kafka topic", e)
         } catch (TimeoutException e) {
@@ -272,55 +300,6 @@ class KafkaInvalidTopicProvisioningConfigTest extends AbstractKafkaSpec {
         def e = thrown(TimeoutException)
         e.message == "timeout-3"
         attempts.get() == 3
-    }
-
-    def "retries Kafka metadata requests while the broker does not know the topic yet"() {
-        given:
-        def attempts = new AtomicInteger()
-
-        when:
-        def result = KafkaTestResourceProvider.retryMetadataRequest({
-            if (attempts.incrementAndGet() == 1) {
-                throw new ExecutionException(new org.apache.kafka.common.errors.UnknownTopicOrPartitionException("not yet"))
-            }
-            "metadata"
-        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
-
-        then:
-        result == "metadata"
-        attempts.get() == 2
-    }
-
-    def "rethrows an unknown topic failure when Kafka metadata retries are exhausted"() {
-        given:
-        def attempts = new AtomicInteger()
-
-        when:
-        KafkaTestResourceProvider.retryMetadataRequest({
-            attempts.incrementAndGet()
-            throw new ExecutionException(new org.apache.kafka.common.errors.UnknownTopicOrPartitionException("missing"))
-        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
-
-        then:
-        def e = thrown(ExecutionException)
-        e.cause instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException
-        attempts.get() == 3
-    }
-
-    def "does not retry other Kafka metadata failures"() {
-        given:
-        def attempts = new AtomicInteger()
-
-        when:
-        KafkaTestResourceProvider.retryMetadataRequest({
-            attempts.incrementAndGet()
-            throw new ExecutionException(new IllegalStateException("broken"))
-        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
-
-        then:
-        def e = thrown(ExecutionException)
-        e.cause.message == "broken"
-        attempts.get() == 1
     }
 }
 

--- a/test-resources-server-thin/src/main/java/io/micronaut/testresources/server/TestResourcesExceptionHandler.java
+++ b/test-resources-server-thin/src/main/java/io/micronaut/testresources/server/TestResourcesExceptionHandler.java
@@ -35,19 +35,22 @@ public class TestResourcesExceptionHandler implements ExceptionHandler<Throwable
             .contentType(TestResourcesMediaType.TEST_RESOURCES_BINARY_MEDIA_TYPE);
     }
 
+    /**
+     * Returns the deepest non-blank message in the cause chain, unchanged.
+     * Wrappers such as {@code TestResourcesResolutionException(cause)} carry
+     * {@code cause.toString()} as their message, so walking to the cause
+     * already skips their {@code java.lang.SomeException: } prefix. Messages
+     * themselves may contain colons, for example an image name with a tag.
+     */
     private static String extractMessage(Throwable exception) {
         Throwable cursor = exception;
-        String fallback = exception.getClass().getSimpleName();
+        String message = exception.getClass().getSimpleName();
         while (cursor != null) {
             if (cursor.getMessage() != null && !cursor.getMessage().isBlank()) {
-                fallback = cursor.getMessage();
+                message = cursor.getMessage();
             }
             cursor = cursor.getCause();
         }
-        int prefix = fallback.lastIndexOf(':');
-        if (prefix > -1 && prefix < fallback.length() - 1) {
-            return fallback.substring(prefix + 1).trim();
-        }
-        return fallback;
+        return message;
     }
 }

--- a/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesExceptionHandlerTest.groovy
+++ b/test-resources-server/src/test/groovy/io/micronaut/testresources/server/TestResourcesExceptionHandlerTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.testresources.server
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.testresources.client.DefaultTestResourcesClient
+import io.micronaut.testresources.client.TestResourcesException
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "TestResourcesExceptionHandlerTest")
+@Property(name = "micronaut.testresources.server.url", value = "")
+class TestResourcesExceptionHandlerTest extends Specification {
+
+    @Inject
+    EmbeddedServer server
+
+    def "client receives an error message containing colons intact (#property)"() {
+        given:
+        def client = new DefaultTestResourcesClient(server.URI.toString(), null, 60)
+
+        when:
+        client.resolve(property, [:], [:])
+
+        then:
+        TestResourcesException e = thrown()
+        e.message == expectedMessage
+
+        where:
+        property          | expectedMessage
+        "image.failure"   | "Container startup failed for image docker.io/postgres:16"
+        "nested.failure"  | "Connection refused: localhost:5432"
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "TestResourcesExceptionHandlerTest")
+    static class FailingResolver implements InjectableTestResourcesResolver {
+        @Override
+        List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+            ["image.failure", "nested.failure"]
+        }
+
+        @Override
+        Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfig) {
+            if (propertyName == "image.failure") {
+                throw new IllegalStateException("Container startup failed for image docker.io/postgres:16")
+            }
+            if (propertyName == "nested.failure") {
+                throw new IllegalStateException("Could not start container",
+                    new ConnectException("Connection refused: localhost:5432"))
+            }
+            Optional.empty()
+        }
+    }
+}


### PR DESCRIPTION
`TestResourcesExceptionHandler.extractMessage` picked the deepest non-blank cause message, then returned only the text after the **last** `:`. Any message that contains a colon lost everything else:

| Resolver failure | Message the client showed |
| --- | --- |
| `Container startup failed for image docker.io/postgres:16` | `16` |
| `Connection refused: localhost:5432` | `5432` |

Users rely on this message to see why a property could not be resolved.

## Where the stripping came from

It was added in #1052 (the binary protocol), with no test or review discussion about it. #1157 moved the file into `test-resources-server-thin` unchanged. It most likely targeted two prefixes, and neither needs it:

- **`java.lang.SomeException: ` from wrapping.** The controller wraps resolver failures with `TestResourcesResolutionException.wrap(ex)`, whose message is `cause.toString()`. The cause-chain walk already goes past that wrapper to the resolver's own message, so the prefix never reaches the colon logic.
- **Core's `Internal Server Error: `.** This handler writes the body itself, so that prefix never appears here. For other servers, `DefaultTestResourcesClient.sanitizeError` already strips it.

## Change

- `extractMessage` now returns the deepest non-blank message unchanged. It still falls back to the exception's simple class name. It still prefers the deepest cause, which is usually the root cause (for example the connection failure under "could not start container").
- New `TestResourcesExceptionHandlerTest` in `test-resources-server`. A resolver throws messages containing colons, one of them as a nested cause. The test asserts that `DefaultTestResourcesClient` receives them intact. It fails without the fix, getting `16` and `5432`.

This is independent of #1212, which adds `ServerErrorMessageTest` next to it.

## Kafka CI flake

Kafka CI failed on this PR in `KafkaReusedContainerTopicProvisioningTest`. That spec has failed about half of the Kafka CI runs since 2026-08-21, including 4.2.x pushes. This PR changes only that spec:

- **"rejects partition mismatch when the topic appears between listing and create"** hung for 2m33s until the racing admin client's `listTopics` timed out.
  - The container owner key is the provider class name, and `RacingKafkaTestResourceProvider` is a different class. So instead of reusing the scope's broker, it started a second broker on the same scoped network, under the same `kafka` alias.
  - It now overrides `getContainerOwnerKey` to share the cached broker, and lists topics with the provider's retrying helper.
  - After creating its topic, it waits until the broker can describe it.
- **"rejects conflicting Kafka partition requests"** failed with `UnknownTopicOrPartitionException` when describing a topic that `listTopics` had just returned, because the broker's metadata can lag behind the controller. The spec now waits until the broker can describe `payments` before it requests conflicting partitions.

The provider itself could also retry that error. That change was tried here and reverted: the aggregate build runs the kafka module's tests only with `-Pkafka`, so SonarCloud reports 0% coverage for any new kafka main code, and the gate failed. It will be proposed separately.

The kafka test sources hit an unrelated Groovy AST `StackOverflowError` when compiled locally on JDK 26. CI compiles them fine on JDK 25, so Kafka CI is what verifies these changes. Locally the spec was only syntax-checked with the Groovy parser.

## Verification

- Before the fix: `TestResourcesExceptionHandlerTest` fails both cases (`16`, `5432`).
- After: `./gradlew :micronaut-test-resources-server-thin:check :micronaut-test-resources-server:test :micronaut-test-resources-client:test` passes. Predictive Test Selection chose every class: 6 of 6 in server (16 tests, 4 `@Ignore`d) and 7 of 7 in client (37 tests). The only Checkstyle warning is on the generated `MicronautTestResourcesServerThinModuleInfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
