### PR TITLE
Retry Kafka topic description while the broker does not know the topic yet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,17 @@ def kafkaTestsEnabled = providers.gradleProperty("kafka").isPresent()
 project(":micronaut-test-resources-kafka") {
     // Kafka starts several heavyweight Testcontainers and is opt-in for the
     // aggregate build. The dedicated Kafka CI workflow enables it with -Pkafka.
-    tasks.withType(org.gradle.api.tasks.testing.Test).configureEach {
-        enabled = kafkaTestsEnabled
+    // Without it, the broker-free specs still run so coverage sees the module.
+    if (!kafkaTestsEnabled) {
+        tasks.withType(org.gradle.api.tasks.testing.Test).configureEach {
+            if (name == "test") {
+                filter {
+                    includeTestsMatching "io.micronaut.testresources.kafka.KafkaAdminRetryTest"
+                }
+            } else {
+                enabled = false
+            }
+        }
     }
 }
 

--- a/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
+++ b/test-resources-kafka/src/main/java/io/micronaut/testresources/kafka/KafkaTestResourceProvider.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -57,6 +58,7 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     public static final String SIMPLE_NAME = "kafka";
     private static final long ADMIN_TIMEOUT_SECONDS = 30;
     private static final int ADMIN_METADATA_ATTEMPTS = 3;
+    private static final long UNKNOWN_TOPIC_RETRY_DELAY_MILLIS = 1000;
     private static final TopicProvisioningConfiguration NO_TOPICS =
         new TopicProvisioningConfiguration(Collections.emptyList(), DEFAULT_PARTITIONS);
 
@@ -215,12 +217,26 @@ public class KafkaTestResourceProvider extends AbstractTestContainersProvider<Ka
     static <T> T retryMetadataRequest(AdminMetadataRequest<T> request)
         throws ExecutionException, InterruptedException, TimeoutException {
         TimeoutException lastTimeout = new TimeoutException();
+        ExecutionException lastUnknownTopic = null;
         for (int attempt = 0; attempt < ADMIN_METADATA_ATTEMPTS; attempt++) {
             try {
                 return request.execute();
             } catch (TimeoutException e) {
                 lastTimeout = e;
+                lastUnknownTopic = null;
+            } catch (ExecutionException e) {
+                if (!(e.getCause() instanceof UnknownTopicOrPartitionException)) {
+                    throw e;
+                }
+                // A topic the controller already knows may not have reached the broker's metadata yet
+                lastUnknownTopic = e;
+                if (attempt < ADMIN_METADATA_ATTEMPTS - 1) {
+                    Thread.sleep(UNKNOWN_TOPIC_RETRY_DELAY_MILLIS);
+                }
             }
+        }
+        if (lastUnknownTopic != null) {
+            throw lastUnknownTopic;
         }
         throw lastTimeout;
     }

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaAdminRetryTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaAdminRetryTest.groovy
@@ -1,0 +1,161 @@
+package io.micronaut.testresources.kafka
+
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.DescribeTopicsResult
+import org.apache.kafka.clients.admin.ListTopicsResult
+import org.apache.kafka.clients.admin.TopicDescription
+import org.apache.kafka.common.KafkaFuture
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Kafka admin retry specs that need no broker. The aggregate build runs this spec
+ * even without -Pkafka, so keep it free of containers.
+ */
+class KafkaAdminRetryTest extends Specification {
+
+    def "retries Kafka metadata requests once after a timeout"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        def result = KafkaTestResourceProvider.retryMetadataRequest({
+            if (attempts.incrementAndGet() == 1) {
+                throw new TimeoutException("first")
+            }
+            "metadata"
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        result == "metadata"
+        attempts.get() == 2
+    }
+
+    def "rethrows the last timeout when Kafka metadata retries are exhausted"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        KafkaTestResourceProvider.retryMetadataRequest({
+            throw new TimeoutException("timeout-${attempts.incrementAndGet()}")
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        def e = thrown(TimeoutException)
+        e.message == "timeout-3"
+        attempts.get() == 3
+    }
+
+    def "retries Kafka metadata requests while the broker does not know the topic yet"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        def result = KafkaTestResourceProvider.retryMetadataRequest({
+            if (attempts.incrementAndGet() == 1) {
+                throw new ExecutionException(new UnknownTopicOrPartitionException("not yet"))
+            }
+            "metadata"
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        result == "metadata"
+        attempts.get() == 2
+    }
+
+    def "rethrows an unknown topic failure when Kafka metadata retries are exhausted"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        KafkaTestResourceProvider.retryMetadataRequest({
+            attempts.incrementAndGet()
+            throw new ExecutionException(new UnknownTopicOrPartitionException("missing"))
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        def e = thrown(ExecutionException)
+        e.cause instanceof UnknownTopicOrPartitionException
+        attempts.get() == 3
+    }
+
+    def "does not retry other Kafka metadata failures"() {
+        given:
+        def attempts = new AtomicInteger()
+
+        when:
+        KafkaTestResourceProvider.retryMetadataRequest({
+            attempts.incrementAndGet()
+            throw new ExecutionException(new IllegalStateException("broken"))
+        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
+
+        then:
+        def e = thrown(ExecutionException)
+        e.cause.message == "broken"
+        attempts.get() == 1
+    }
+
+    def "retries timed out topic listing before failing"() {
+        given:
+        def adminClient = Mock(AdminClient)
+        def listTopicsResult = Mock(ListTopicsResult)
+        listTopicsResult.names() >> new TimeoutOnlyKafkaFuture<Set<String>>()
+
+        when:
+        KafkaTestResourceProvider.listTopicNames(adminClient)
+
+        then:
+        thrown(TimeoutException)
+        3 * adminClient.listTopics() >> listTopicsResult
+    }
+
+    def "retries timed out topic listing before returning names"() {
+        given:
+        def adminClient = Mock(AdminClient)
+        def listTopicsResult = Mock(ListTopicsResult)
+        def topicNames = ["orders"] as Set
+        adminClient.listTopics() >> listTopicsResult
+        listTopicsResult.names() >>> [
+            new TimeoutOnlyKafkaFuture<Set<String>>(),
+            KafkaFuture.completedFuture(topicNames)
+        ]
+
+        expect:
+        KafkaTestResourceProvider.listTopicNames(adminClient) == topicNames
+    }
+
+    def "retries timed out topic description before failing"() {
+        given:
+        def adminClient = Mock(AdminClient)
+        def describeTopicsResult = Mock(DescribeTopicsResult)
+        def topicNames = ["orders"]
+        describeTopicsResult.allTopicNames() >> new TimeoutOnlyKafkaFuture<Map<String, TopicDescription>>()
+
+        when:
+        KafkaTestResourceProvider.describeTopics(adminClient, topicNames)
+
+        then:
+        thrown(TimeoutException)
+        3 * adminClient.describeTopics(topicNames) >> describeTopicsResult
+    }
+
+    def "retries timed out topic description before returning descriptions"() {
+        given:
+        def adminClient = Mock(AdminClient)
+        def describeTopicsResult = Mock(DescribeTopicsResult)
+        def topicNames = ["orders"]
+        def descriptions = [(topicNames.first()): Mock(TopicDescription)]
+        adminClient.describeTopics(topicNames) >> describeTopicsResult
+        describeTopicsResult.allTopicNames() >>> [
+            new TimeoutOnlyKafkaFuture<Map<String, TopicDescription>>(),
+            KafkaFuture.completedFuture(descriptions)
+        ]
+
+        expect:
+        KafkaTestResourceProvider.describeTopics(adminClient, topicNames) == descriptions
+    }
+}

--- a/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
+++ b/test-resources-kafka/src/test/groovy/io/micronaut/testresources/kafka/KafkaTopicProvisioningTest.groovy
@@ -6,17 +6,13 @@ import io.micronaut.testresources.core.TestResourcesResolutionException
 import jakarta.inject.Inject
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
-import org.apache.kafka.clients.admin.DescribeTopicsResult
-import org.apache.kafka.clients.admin.ListTopicsResult
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.admin.TopicDescription
-import org.apache.kafka.common.KafkaFuture
 
 import java.util.Properties
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
 
 abstract class AbstractKafkaTopicProvisioningSpec extends AbstractKafkaSpec {
     private static final long ADMIN_TIMEOUT_SECONDS = 30
@@ -229,100 +225,5 @@ class KafkaInvalidTopicProvisioningConfigTest extends AbstractKafkaSpec {
         then:
         def e = thrown(IllegalArgumentException)
         e.message.contains("must be an integer")
-    }
-
-    def "retries Kafka metadata requests once after a timeout"() {
-        given:
-        def attempts = new AtomicInteger()
-
-        when:
-        def result = KafkaTestResourceProvider.retryMetadataRequest({
-            if (attempts.incrementAndGet() == 1) {
-                throw new TimeoutException("first")
-            }
-            "metadata"
-        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
-
-        then:
-        result == "metadata"
-        attempts.get() == 2
-    }
-
-    def "rethrows the last timeout when Kafka metadata retries are exhausted"() {
-        given:
-        def attempts = new AtomicInteger()
-
-        when:
-        KafkaTestResourceProvider.retryMetadataRequest({
-            throw new TimeoutException("timeout-${attempts.incrementAndGet()}")
-        } as KafkaTestResourceProvider.AdminMetadataRequest<String>)
-
-        then:
-        def e = thrown(TimeoutException)
-        e.message == "timeout-3"
-        attempts.get() == 3
-    }
-}
-
-class KafkaAdminRetryTest extends AbstractKafkaSpec {
-
-    def "retries timed out topic listing before failing"() {
-        given:
-        def adminClient = Mock(AdminClient)
-        def listTopicsResult = Mock(ListTopicsResult)
-        listTopicsResult.names() >> new TimeoutOnlyKafkaFuture<Set<String>>()
-
-        when:
-        KafkaTestResourceProvider.listTopicNames(adminClient)
-
-        then:
-        thrown(TimeoutException)
-        3 * adminClient.listTopics() >> listTopicsResult
-    }
-
-    def "retries timed out topic listing before returning names"() {
-        given:
-        def adminClient = Mock(AdminClient)
-        def listTopicsResult = Mock(ListTopicsResult)
-        def topicNames = ["orders"] as Set
-        adminClient.listTopics() >> listTopicsResult
-        listTopicsResult.names() >>> [
-            new TimeoutOnlyKafkaFuture<Set<String>>(),
-            KafkaFuture.completedFuture(topicNames)
-        ]
-
-        expect:
-        KafkaTestResourceProvider.listTopicNames(adminClient) == topicNames
-    }
-
-    def "retries timed out topic description before failing"() {
-        given:
-        def adminClient = Mock(AdminClient)
-        def describeTopicsResult = Mock(DescribeTopicsResult)
-        def topicNames = ["orders"]
-        describeTopicsResult.allTopicNames() >> new TimeoutOnlyKafkaFuture<Map<String, TopicDescription>>()
-
-        when:
-        KafkaTestResourceProvider.describeTopics(adminClient, topicNames)
-
-        then:
-        thrown(TimeoutException)
-        3 * adminClient.describeTopics(topicNames) >> describeTopicsResult
-    }
-
-    def "retries timed out topic description before returning descriptions"() {
-        given:
-        def adminClient = Mock(AdminClient)
-        def describeTopicsResult = Mock(DescribeTopicsResult)
-        def topicNames = ["orders"]
-        def descriptions = [(topicNames.first()): Mock(TopicDescription)]
-        adminClient.describeTopics(topicNames) >> describeTopicsResult
-        describeTopicsResult.allTopicNames() >>> [
-            new TimeoutOnlyKafkaFuture<Map<String, TopicDescription>>(),
-            KafkaFuture.completedFuture(descriptions)
-        ]
-
-        expect:
-        KafkaTestResourceProvider.describeTopics(adminClient, topicNames) == descriptions
     }
 }


### PR DESCRIPTION
Kafka CI runs [34346446216](https://github.com/micronaut-projects/micronaut-test-resources/actions/runs/34346446216) and [32527275388](https://github.com/micronaut-projects/micronaut-test-resources/actions/runs/32527275388) failed `KafkaReusedContainerTopicProvisioningTest` "rejects conflicting Kafka partition requests when reusing a cached broker in the same scope" with `Failed to provision Kafka topics [...]`, caused by `UnknownTopicOrPartitionException` (`provisionTopics` -> `verifyExistingTopicPartitions` -> `describeTopics` -> `retryMetadataRequest`).

Right after a topic is created, by the provider or by someone racing it, the single KRaft broker's metadata can trail the controller. `retryMetadataRequest` only retried `TimeoutException`.

### Change
- `retryMetadataRequest` also retries an `ExecutionException` caused by `UnknownTopicOrPartitionException`. It waits 1s between attempts (3 attempts, as before) and rethrows that exception once the attempts are used up. Other `ExecutionException`s are still rethrown immediately.
- New specs cover three cases: retry then success, rethrow once attempts are exhausted, and no retry for other failures.

### Coverage in Java CI
This change was dropped from #1213 because Java CI disables the kafka module's tests without `-Pkafka`. JaCoCo therefore reported 0% for kafka main code, and any new line failed the Sonar "Coverage on New Code" gate.

- The admin retry specs need no broker. They move from `KafkaTopicProvisioningTest.groovy` into their own `KafkaAdminRetryTest` (a plain `Specification`, no scope or container).
- The root `build.gradle` no longer disables the kafka `test` task without `-Pkafka`. It now filters that task to `KafkaAdminRetryTest` (9 specs, about 9s, no Docker) and still disables any other `Test` task. `-Pkafka` (Kafka CI) runs everything as before.

Verified locally on JDK 25: `:micronaut-test-resources-kafka:check` without `-Pkafka` ran only `KafkaAdminRetryTest`, 9/9 passed, no containers started. Coverage will be checked on this PR's Sonar run.

The `RacingKafkaTestResourceProvider` owner-key fix stays in #1213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
