### PR TITLE
Use the Quay-hosted MinIO image as the default

### DIFF
--- a/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
+++ b/test-resources-core/src/main/resources/io/micronaut/testresources/core/default-images/Dockerfile
@@ -75,7 +75,7 @@ FROM mariadb:12.3.2 AS mariadb
 
 # provider: minio
 # property: test-resources.containers.minio.image-name
-FROM minio/minio:RELEASE.2025-09-07T16-13-09Z AS minio
+FROM quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z AS minio
 
 # provider: mongodb
 # property: test-resources.containers.mongodb.image-name

--- a/test-resources-minio/src/main/java/io/micronaut/testresources/minio/MinioTestResourceProvider.java
+++ b/test-resources-minio/src/main/java/io/micronaut/testresources/minio/MinioTestResourceProvider.java
@@ -36,6 +36,11 @@ public class MinioTestResourceProvider extends AbstractTestContainersProvider<Mi
     public static final String DEFAULT_IMAGE = DefaultTestResourceImages.DEFAULT_MINIO_IMAGE;
     public static final String DISPLAY_NAME = "MinIO";
     public static final String SIMPLE_NAME = "minio";
+    /**
+     * The image name Testcontainers' {@link MinIOContainer} expects. The default image is served
+     * from Quay, since the Docker Hub repository is no longer pullable anonymously.
+     */
+    private static final String TESTCONTAINERS_COMPATIBLE_IMAGE = "minio/minio";
     private static final List<String> SUPPORTED_KEYS = List.of(
         MINIO_URL,
         MINIO_ACCESS_KEY,
@@ -64,7 +69,7 @@ public class MinioTestResourceProvider extends AbstractTestContainersProvider<Mi
 
     @Override
     protected MinIOContainer createContainer(DockerImageName imageName, Map<String, Object> requestedProperties, Map<String, Object> testResourcesConfig) {
-        return new MinIOContainer(imageName);
+        return new MinIOContainer(imageName.asCompatibleSubstituteFor(TESTCONTAINERS_COMPATIBLE_IMAGE));
     }
 
     @Override


### PR DESCRIPTION
## Problem

`:micronaut-test-resources-minio:test` fails on every run — first attempt and rerun alike:

```
com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"pull access denied for minio/minio,
  repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}
io.micronaut.testresources.core.TestResourcesResolutionException: Status 404: ...  (MinioStartedTest)
```

The `minio/minio` Docker Hub repository is no longer pullable anonymously — `https://hub.docker.com/v2/repositories/minio/minio/` returns 404, and `docker pull minio/minio` fails locally with the same message. This is unrelated to any Micronaut change.

## Fix

MinIO publishes the same images on Quay, so the default now points at `quay.io/minio/minio`, keeping the pinned `RELEASE.2025-09-07T16-13-09Z` tag — it resolves to the identical digest (`sha256:14cea493…`).

Because Testcontainers' `MinIOContainer` asserts the image it is handed is `minio/minio`, `MinioTestResourceProvider.createContainer` now marks the resolved image as a compatible substitute for it. The `test-resources.containers.minio.image-name` override keeps working, and anyone pointing it at another registry or a private mirror gets the same substitution instead of an assertion failure.

The default image constant is generated from the Renovate-visible `default-images/Dockerfile`, so Renovate keeps tracking the tag — now against Quay.

## Verification

- `docker pull minio/minio` → 404; `docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` → OK.
- `./gradlew :micronaut-test-resources-minio:test --rerun-tasks` — 3/3 pass, including `MinioStartedTest`, which asserts the started container's image starts with `MinioTestResourceProvider.DEFAULT_IMAGE`.
- `./gradlew :micronaut-test-resources-core:test` — 9/9 pass, including the tests that check the generated constants, the pinned-tag rule and the published default-image documentation against the manifest.

## Does `4.2.x` need the same fix?

**Yes.** `4.2.x` carries the identical `FROM minio/minio:RELEASE.2025-09-07T16-13-09Z` default and is equally broken — its Java CI passed earlier today only because the runner had a cached image. There is no merge-up automation in this repository, so this commit should be cherry-picked onto `4.2.x` separately.

## Context

Unblocks the core 5.2 bump micronaut-projects/micronaut-test-resources#1214 (`claude/core-5.2-bump-4.3.x`), part of the core 5.2 rollout tracked in micronaut-projects/micronaut-core#13110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)